### PR TITLE
Add Codex hook adapter with auto-enabled feature flag

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -15,7 +15,7 @@ _Last updated: 2026-04-21._
 | Windsurf | ✅ | ✅ | ✅ | `.windsurf/hooks.json` |
 | OpenClaw | ✅ | — | ✅ | JS plugin at `~/.openclaw/hooks/` |
 | Hermes | ✅ | — | ✅ | JS plugin at `~/.hermes/hooks/` |
-| Codex (OpenAI) | 🟡 partial | ✅ | — | `~/.codex/hooks.json` (experimental, Bash-only) |
+| Codex (OpenAI) | ✅ partial | ✅ | ✅ | `~/.codex/hooks.json` (experimental — Bash-only, `apply_patch` blind spot) |
 | Gemini CLI | 🟡 roadmap | — | — | `settings.json` hooks block (stable) |
 | OpenCode | 🟡 roadmap | — | — | JS plugin `tool.execute.before` |
 | Kiro | 🟡 roadmap | — | — | `preToolUse` hooks (exit-2 blocks) |
@@ -70,21 +70,21 @@ _Last updated: 2026-04-21._
 - **Session ingest:** offline analysis of `~/.hermes/sessions/*.jsonl` via `warden ingest --input <file> --agent hermes`.
 - **Code:** `warden/hooks.py` `_merge_hermes()`, `_normalize_hermes()`.
 
+### Codex (OpenAI) — partial
+
+- **Why partial:** `PreToolUse` / `PostToolUse` fire only for Bash/shell today — `apply_patch` file writes are not hooked ([openai/codex#16732](https://github.com/openai/codex/issues/16732)). Hooks themselves are opt-in behind `[features] codex_hooks = true` in `~/.codex/config.toml`; `warden install-hooks --agent codex` sets this automatically.
+- **Config:** `~/.codex/hooks.json` (user) or `<repo>/.codex/hooks.json` (project). All matching layers run additively.
+- **Events hooked:** `PreToolUse`, `PostToolUse`, `UserPromptSubmit` (matcher `*`).
+- **Payload:** JSON on stdin — shared `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `model`, plus event-specific fields (`tool_input.command`, etc.).
+- **Blocking:** exit 2 → block, stderr → reason — same contract as Claude Code, so Warden's dispatcher is reused unchanged.
+- **Sweep target:** `~/.codex/`.
+- **Code:** `warden/hooks.py` `_merge_codex()`, `_normalize_codex()`, `_ensure_codex_feature_flag()`.
+
 ---
 
 ## Roadmap — hook adapters planned
 
-Each agent below exposes a blocking pre-tool hook. An adapter requires (1) config-merge in `warden/hooks.py`, (2) `_normalize_*` function, (3) registration in `_SUPPORTED_AGENTS` and `warden/store.py`, (4) sweep target in `warden/sweep.py` if applicable.
-
-### Codex (OpenAI) — partial
-
-- **Why partial:** hooks are experimental, opt-in via `[features] codex_hooks = true` in `~/.codex/config.toml`. `PreToolUse`/`PostToolUse` currently fire only for Bash/shell — `apply_patch` file writes are **not** hooked ([openai/codex#16732](https://github.com/openai/codex/issues/16732)).
-- **Config:** `~/.codex/hooks.json` (user) or `<repo>/.codex/hooks.json` (project). All matching layers run additively.
-- **Events:** `SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, `Stop`.
-- **Payload:** JSON on stdin — shared `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `model`, plus event-specific fields (`tool_input.command`, etc.). Default timeout 600s.
-- **Blocking:** exit 2 → block, stderr → reason. `PreToolUse` and `PermissionRequest` support `systemMessage` output.
-- **Sweep target:** `~/.codex/` (already covered).
-- **Adapter work:** payload shape mirrors Claude Code — `_normalize_claude` can be reused with minor field renames. Document the `apply_patch` blind spot to users.
+Each agent below exposes a blocking pre-tool hook. An adapter requires (1) config-merge in `warden/hooks.py`, (2) `_normalize_*` function, (3) registration in `_SUPPORTED_AGENTS`, (4) sweep target in `warden/sweep.py` if applicable.
 
 ### Gemini CLI (Google)
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -698,7 +698,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── audit ──────────────────────────────────────────────────────────
@@ -742,20 +742,20 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
     uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -872,7 +872,7 @@ def _print_info(workspace: Path) -> None:
     # Hooks — check which agents have hooks installed
     agents_with_hooks = []
     mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -921,6 +921,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".openclaw" / "plugins.json"
     if agent == "hermes":
         return workspace / ".hermes" / "plugins.json"
+    if agent == "codex":
+        return workspace / ".codex" / "hooks.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -967,7 +969,7 @@ def _print_dashboard() -> None:
 
         # Mode detection
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 from warden.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex"]
 
 
 def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, mode: str) -> List[Dict[str, str]]:
@@ -27,6 +27,9 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_openclaw(config, command, repo_root)
         elif current_agent == "hermes":
             config = _merge_hermes(config, command, repo_root)
+        elif current_agent == "codex":
+            config = _merge_codex(config, command)
+            _ensure_codex_feature_flag()
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -53,6 +56,8 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
                 config, removed = _strip_openclaw(config, marker)
             elif current_agent == "hermes":
                 config, removed = _strip_hermes(config, marker)
+            elif current_agent == "codex":
+                config, removed = _strip_codex(config, marker)
             else:
                 config, removed = _strip_windsurf(config, marker)
             if removed:
@@ -91,6 +96,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_openclaw(payload, session_id)
     elif agent == "hermes":
         event = _normalize_hermes(payload, session_id)
+    elif agent == "codex":
+        event = _normalize_codex(payload, session_id)
     else:
         event = _normalize_cursor(payload, session_id)
     return {"sessionId": session_id, "event": event}
@@ -124,6 +131,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".openclaw" / "plugins.json"
         if agent == "hermes":
             return workspace / ".hermes" / "plugins.json"
+        if agent == "codex":
+            return workspace / ".codex" / "hooks.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -134,6 +143,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".openclaw" / "config.json"
     if agent == "hermes":
         return home / ".hermes" / "config.json"
+    if agent == "codex":
+        return home / ".codex" / "hooks.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -704,3 +715,80 @@ def _is_pre_action(agent_event: str) -> bool:
         or lower.startswith("before")
         or agent_event in {"PreToolUse", "UserPromptSubmit"}
     )
+
+
+def _merge_codex(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    hooks = dict(config.get("hooks", {}))
+    entry = {"matcher": "*", "hooks": [{"type": "command", "command": command}]}
+    hooks["PreToolUse"] = _merge_claude_entries(hooks.get("PreToolUse", []), entry)
+    hooks["PostToolUse"] = _merge_claude_entries(hooks.get("PostToolUse", []), entry)
+    hooks["UserPromptSubmit"] = _merge_claude_entries(
+        hooks.get("UserPromptSubmit", []),
+        {"matcher": "*", "hooks": [{"type": "command", "command": command}]},
+    )
+    return {**config, "hooks": hooks}
+
+
+def _strip_codex(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    return _strip_claude(config, marker)
+
+
+def _normalize_codex(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    hook_event = payload.get("hook_event_name", "unknown")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {}) or {}
+    base = {
+        "ts": payload.get("timestamp"),
+        "session_id": session_id,
+        "agent": "codex",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "model": payload.get("model"), "raw": payload},
+    }
+    if hook_event == "UserPromptSubmit":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    command = tool_input.get("command") or tool_input.get("bash") or ""
+    if command or tool_name in {"Bash", "shell", "exec"}:
+        return {**base, "type": "shell", "command": command}
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _ensure_codex_feature_flag() -> None:
+    """Idempotently set [features] codex_hooks = true in ~/.codex/config.toml.
+
+    Codex hooks are opt-in behind this flag. Without it, the hooks.json
+    entries this module writes are silently ignored by the Codex CLI.
+    """
+    import re
+
+    config_path = Path.home() / ".codex" / "config.toml"
+    header = "[features]"
+    flag_line = "codex_hooks = true"
+
+    if not config_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(f"{header}\n{flag_line}\n", encoding="utf-8")
+        return
+
+    text = config_path.read_text(encoding="utf-8")
+    try:
+        import tomllib
+
+        data = tomllib.loads(text)
+        if data.get("features", {}).get("codex_hooks") is True:
+            return
+    except ImportError:
+        if flag_line in text:
+            return
+
+    if re.search(r"^\s*\[features\]\s*$", text, re.MULTILINE):
+        text = re.sub(
+            r"^(\s*\[features\]\s*\n)",
+            r"\1" + flag_line + "\n",
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    else:
+        text = text.rstrip() + f"\n\n{header}\n{flag_line}\n"
+
+    config_path.write_text(text, encoding="utf-8")

--- a/warden/scanner.py
+++ b/warden/scanner.py
@@ -74,12 +74,23 @@ def _hermes_configs() -> List[Path]:
     return [p for p in candidates if p.exists()]
 
 
+def _codex_configs() -> List[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".codex" / "config.toml",
+        home / ".codex" / "mcp.json",
+        Path.cwd() / ".codex" / "config.toml",
+    ]
+    return [p for p in candidates if p.exists()]
+
+
 _AGENT_DISCOVERERS = {
     "claude": _claude_configs,
     "cursor": _cursor_configs,
     "windsurf": _windsurf_configs,
     "openclaw": _openclaw_configs,
     "hermes": _hermes_configs,
+    "codex": _codex_configs,
 }
 
 


### PR DESCRIPTION
## Summary

Codex uses the same stdin-JSON + exit-2 contract as Claude, so the adapter reuses the existing dispatcher. The main wrinkle is that Codex hooks are opt-in behind `[features] codex_hooks = true` in `~/.codex/config.toml` — without it, Warden's `hooks.json` is silently ignored. `warden install-hooks --agent codex` now sets that flag automatically.

- **hooks:** `_merge_codex` writes `PreToolUse`, `PostToolUse`, `UserPromptSubmit` (matcher `*`) into `.codex/hooks.json`.
- **feature flag:** `_ensure_codex_feature_flag()` idempotently adds `codex_hooks = true` under `[features]` in `~/.codex/config.toml`. Handles four cases: file missing, file exists without `[features]`, `[features]` exists without flag, flag already set.
- **uninstall:** `_strip_codex` reuses `_strip_claude` since the shape is identical. Does not clear the feature flag (other future Codex features may rely on it).
- **normalizer:** `_normalize_codex` maps `tool_input.command` → shell event; `UserPromptSubmit` → prompt event. `apply_patch` writes are not hooked by Codex yet (openai/codex#16732) — documented.
- **scanner:** `_codex_configs` discovers `~/.codex/config.toml` and `~/.codex/mcp.json` so `warden scan` picks up MCP entries.
- **CLI:** `codex` added to all `--agent` choice lists and both agent-enumeration loops.
- **Docs:** `AGENT_INTEGRATIONS.md` moves Codex from "roadmap" into the supported tier with a ✅ partial badge.

## Blocking semantics

Same as Claude: exit 2 with stderr → block, stderr is the rejection reason. No dispatcher changes needed.

## Smoke tests

\`\`\`
# Feature flag helper
config.toml after first run:
[features]
codex_hooks = true

config.toml after adding to existing features section:
[features]
codex_hooks = true
some_other_flag = false

# Hooks adapter
install path: /tmp/.../.codex/hooks.json
events: ['PreToolUse', 'PostToolUse', 'UserPromptSubmit']
shell type: shell command: ls -la agent: codex
uninstall removed: True residual hooks: 0
\`\`\`

## Test plan

- [ ] `warden install-hooks --agent codex --mode enforce` in a fresh workspace — verify `~/.codex/config.toml` gets `[features] codex_hooks = true` and `.codex/hooks.json` gets prismor entries.
- [ ] Run Codex with a destructive Bash command in enforce mode — confirm exit 2 blocks it.
- [ ] Uninstall — verify hooks removed but existing config preserved.
- [ ] Confirm `apply_patch`-style file edits still flow through (they won't fire PreToolUse — known Codex limitation).

## Not in this PR

- `PermissionRequest`, `SessionStart`, `Stop` events — can be added later if useful.
- GitHub Copilot CLI adapter — separate PR (wrapper script pattern because Copilot uses JSON-on-stdout response instead of exit-2).
- Kiro adapter — schema for shell-command hooks still being confirmed.