### PR TITLE
feat: add Codex (OpenAI) as a supported agent

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -2,7 +2,7 @@
 
 How Prismor Warden integrates with each major AI coding agent — what ships today, what's planned, and what mechanism each agent exposes for runtime security monitoring.
 
-_Last updated: 2026-06-05._
+_Last updated: 2026-06-17._
 
 ---
 
@@ -15,7 +15,7 @@ _Last updated: 2026-06-05._
 | Windsurf | ✅ | ✅ | ✅ | `.windsurf/hooks.json` |
 | OpenClaw | ✅ | — | ✅ | JS plugin at `~/.openclaw/hooks/` |
 | Hermes | ✅ | — | ✅ | JS plugin at `~/.hermes/hooks/` |
-| Codex (OpenAI) | 🟡 partial | ✅ | — | `~/.codex/hooks.json` (experimental, Bash-only) |
+| Codex (OpenAI) | ✅* | ✅ | ✅ | `~/.codex/hooks.json` + `.codex/config.toml` |
 | Gemini CLI | 🟡 roadmap | — | — | `settings.json` hooks block (stable) |
 | OpenCode | 🟡 roadmap | — | — | JS plugin `tool.execute.before` |
 | Kiro | 🟡 roadmap | — | — | `preToolUse` hooks (exit-2 blocks) |
@@ -27,6 +27,8 @@ _Last updated: 2026-06-05._
 | Kilocode | soft only | ✅ | — | `session.chat.before` injects guardrail prompt, can't veto |
 
 ✅ shipped · 🟡 planned (adapter not implemented) · — not applicable
+
+\* Codex requires `codex-cli` ≥ `0.141.0-alpha.1`. Earlier versions (including the `0.140.0` stable release) have an upstream bug where `codex exec` never dispatches any hook at all — see the Codex section below.
 
 ---
 
@@ -89,21 +91,21 @@ Immunity Agent integrates with Hermes at two complementary layers:
 - **Payload note:** `toolArgs` arrives as a JSON-encoded string; `_normalize_copilot()` parses it before evaluation.
 - **Code:** `warden/hooks.py` `_merge_copilot()`, `_strip_copilot()`, `_normalize_copilot()`.
 
+### Codex (OpenAI)
+
+- **Config:** `~/.codex/hooks.json` (user) or `<repo>/.codex/hooks.json` (project). MCP/skill scan also reads `~/.codex/config.toml` and `<repo>/.codex/config.toml` — both `hooks.json` and inline `[[hooks.PreToolUse]]`-style TOML hook declarations work identically.
+- **Events hooked:** `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`.
+- **Matchers installed:** `Bash|apply_patch|mcp__.*`. Verified against a real `codex exec` session: `Bash` is the actual tool name Codex reports to `PreToolUse`/`PostToolUse`.
+- **Blocking:** exit 2 from hook → block; stderr → rejection reason. Verified end to end — a policy-blocked command (`rm package-lock.json`, matched by the `lockfile-deletion` rule) was actually denied by Codex's tool router before execution, with the file left untouched.
+- **Sweep target:** `~/.codex/`.
+- **Minimum version: `codex-cli` ≥ `0.141.0-alpha.1`.** Earlier versions, including the `0.140.0` stable release, have an upstream bug ([openai/codex#26383](https://github.com/openai/codex/issues/26383), [#26452](https://github.com/openai/codex/issues/26452)) where `codex exec` never dispatches *any* hook — not because of config shape, matcher syntax, or hook trust, but because `--dangerously-bypass-hook-trust` silently failed to propagate to the exec thread, so hooks (which require persisted trust) were dropped before dispatch even without `exec` printing an error. Fixed in [openai/codex#26434](https://github.com/openai/codex/pull/26434), merged 2026-06-16, first shipped in `rust-v0.141.0-alpha.1`. As of this writing that fix has not yet reached a stable release tag — pin to an alpha ≥ that build if you need working Codex hooks today, and watch for the next `0.141.x` (or later) stable release.
+- **Code:** `warden/hooks.py` `_merge_codex()`, `_strip_codex()`, `_normalize_codex()`.
+
 ---
 
 ## Roadmap — hook adapters planned
 
 Each agent below exposes a blocking pre-tool hook. An adapter requires (1) config-merge in `warden/hooks.py`, (2) `_normalize_*` function, (3) registration in `_SUPPORTED_AGENTS` and `warden/store.py`, (4) sweep target in `warden/sweep.py` if applicable.
-
-### Codex (OpenAI) — partial
-
-- **Why partial:** hooks are experimental, opt-in via `[features] codex_hooks = true` in `~/.codex/config.toml`. `PreToolUse`/`PostToolUse` currently fire only for Bash/shell — `apply_patch` file writes are **not** hooked ([openai/codex#16732](https://github.com/openai/codex/issues/16732)).
-- **Config:** `~/.codex/hooks.json` (user) or `<repo>/.codex/hooks.json` (project). All matching layers run additively.
-- **Events:** `SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, `Stop`.
-- **Payload:** JSON on stdin — shared `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `model`, plus event-specific fields (`tool_input.command`, etc.). Default timeout 600s.
-- **Blocking:** exit 2 → block, stderr → reason. `PreToolUse` and `PermissionRequest` support `systemMessage` output.
-- **Sweep target:** `~/.codex/` (already covered).
-- **Adapter work:** payload shape mirrors Claude Code — `_normalize_claude` can be reused with minor field renames. Document the `apply_patch` blind spot to users.
 
 ### Gemini CLI (Google)
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ immunity uninstall-hooks --agent all --scope project      # every supported agen
 | Windsurf | `<workspace>/.windsurf/hooks.json` | `~/.codeium/windsurf/hooks.json` |
 | OpenClaw | `<workspace>/.openclaw/plugins.json` | `~/.openclaw/config.json` |
 | Hermes | `<workspace>/.hermes/plugins.json` | `~/.hermes/config.json` |
+| Codex | `<workspace>/.codex/hooks.json` | `~/.codex/hooks.json` |
 | Copilot | `<workspace>/.github/copilot/hooks.json` | `~/.copilot/hooks.json` |
 
 If you only run one scope, the other one's hooks (if installed) keep firing. Run both if you want Warden fully out of the picture for an agent.
@@ -271,7 +272,7 @@ Sessions, findings, threat categories, agent breakdowns, and a live event feed �
 
 ```mermaid
 flowchart TD
-    IDE["Your IDE / Agent\n(Claude Code · Cursor · Windsurf)"]
+    IDE["Your IDE / Agent\n(Claude Code · Cursor · Windsurf · Codex)"]
 
     IDE -->|"PreToolUse / PostToolUse hooks"| Warden
 

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from warden.hooks import (
     _is_pre_action,
     _strip_claude,
+    _strip_codex,
     _strip_cursor,
     _strip_windsurf,
     install_hooks,
@@ -105,6 +106,36 @@ class TestStripCursor(unittest.TestCase):
         self.assertFalse(removed)
 
 
+class TestStripCodex(unittest.TestCase):
+    """Test _strip_codex removes Prismor entries."""
+
+    def test_removes_prismor_hooks(self):
+        marker = "/repo/warden/cli.py"
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash|apply_patch|mcp__.*",
+                        "hooks": [
+                            {"type": "command", "command": f'python3 "{marker}" hook-dispatch --agent codex'},
+                            {"type": "command", "command": "other-tool --check"},
+                        ],
+                    }
+                ]
+            }
+        }
+        result, removed = _strip_codex(config, marker)
+        self.assertTrue(removed)
+        self.assertEqual(len(result["hooks"]["PreToolUse"]), 1)
+        self.assertEqual(len(result["hooks"]["PreToolUse"][0]["hooks"]), 1)
+        self.assertEqual(result["hooks"]["PreToolUse"][0]["hooks"][0]["command"], "other-tool --check")
+
+    def test_no_change(self):
+        config = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "unrelated"}]}]}}
+        result, removed = _strip_codex(config, "/repo/warden/cli.py")
+        self.assertFalse(removed)
+
+
 class TestStripWindsurf(unittest.TestCase):
     """Test _strip_windsurf removes Prismor entries."""
 
@@ -155,6 +186,8 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
             config_path = self.workspace / ".claude" / "settings.json"
         elif agent == "cursor":
             config_path = self.workspace / ".cursor" / "hooks.json"
+        elif agent == "codex":
+            config_path = self.workspace / ".codex" / "hooks.json"
         else:
             config_path = self.workspace / ".windsurf" / "hooks.json"
         self.assertTrue(config_path.exists())
@@ -187,6 +220,9 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
 
     def test_windsurf_roundtrip(self):
         self._roundtrip("windsurf")
+
+    def test_codex_roundtrip(self):
+        self._roundtrip("codex")
 
     def test_uninstall_nonexistent_config(self):
         results = uninstall_hooks(
@@ -349,6 +385,58 @@ class TestNormalizePayloadCursor(unittest.TestCase):
         self.assertEqual(event["command"], "git status")
 
 
+class TestNormalizePayloadCodex(unittest.TestCase):
+    """Test Codex payload normalization."""
+
+    def test_user_prompt(self):
+        payload = {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "codex-1",
+            "prompt": "Review this change",
+        }
+        result = normalize_payload(agent="codex", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "prompt")
+        self.assertEqual(event["prompt"], "Review this change")
+        self.assertEqual(event["agent"], "codex")
+
+    def test_bash_tool(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "session_id": "codex-2",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+        }
+        result = normalize_payload(agent="codex", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "git status")
+
+    def test_apply_patch_maps_to_file_write(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "session_id": "codex-3",
+            "tool_name": "apply_patch",
+            "tool_input": {"command": "*** Begin Patch\n*** End Patch\n"},
+        }
+        result = normalize_payload(agent="codex", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "file_write")
+        self.assertIn("*** Begin Patch", event["content"])
+
+    def test_permission_request_is_shell_when_bash(self):
+        payload = {
+            "hook_event_name": "PermissionRequest",
+            "session_id": "codex-4",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /"},
+        }
+        result = normalize_payload(agent="codex", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "rm -rf /")
+
+
 class TestNormalizePayloadWindsurf(unittest.TestCase):
     """Test Windsurf payload normalization."""
 
@@ -416,6 +504,9 @@ class TestIsPreActionExtended(unittest.TestCase):
 
     def test_cursor_before_submit_prompt(self):
         self.assertTrue(_is_pre_action("beforeSubmitPrompt"))
+
+    def test_codex_permission_request(self):
+        self.assertTrue(_is_pre_action("PermissionRequest"))
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner_codex.py
+++ b/tests/test_scanner_codex.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from warden.scanner import discover_configs, parse_config
+
+
+class TestScannerCodex(unittest.TestCase):
+    def test_parse_codex_toml_mcp_servers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = Path(tmpdir) / "config.toml"
+            cfg.write_text(
+                """
+[mcp_servers.demo]
+command = "node"
+args = ["server.js"]
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            entries = parse_config(cfg)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["name"], "demo")
+            self.assertEqual(entries[0]["agent"], "unknown")
+            self.assertEqual(entries[0]["config"]["command"], "node")
+
+    def test_discover_project_codex_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            codex_dir = workspace / ".codex"
+            codex_dir.mkdir()
+            (codex_dir / "config.toml").write_text("[mcp_servers.demo]\ncommand='node'\n", encoding="utf-8")
+            (codex_dir / "hooks.json").write_text('{"hooks":{}}' + "\n", encoding="utf-8")
+
+            discovered = discover_configs(agent="codex", workspace=workspace)
+            paths = {str(item["path"]) for item in discovered}
+            self.assertIn(str(codex_dir / "config.toml"), paths)
+            self.assertIn(str(codex_dir / "hooks.json"), paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warden/audit.py
+++ b/warden/audit.py
@@ -108,6 +108,7 @@ def _check_hooks(workspace: Path, repo_root: Path) -> List[AuditFinding]:
         "windsurf": workspace / ".windsurf" / "hooks.json",
         "openclaw": workspace / ".openclaw" / "plugins.json",
         "hermes": workspace / ".hermes" / "plugins.json",
+        "codex": workspace / ".codex" / "hooks.json",
     }
 
     installed_agents: List[str] = []

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1860,7 +1860,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── deps ──────────────────────────────────────────────────────────
@@ -1934,20 +1934,20 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
     uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -2167,7 +2167,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--agents",
         default=None,
         metavar="AGENT[,AGENT…]",
-        help="Comma-separated agents to hook (non-interactive only): claude,cursor,windsurf,…",
+        help="Comma-separated agents to hook (non-interactive only): claude,cursor,windsurf,codex,…",
     )
     setup_parser.add_argument(
         "--cloak",
@@ -2286,7 +2286,7 @@ def _print_info(workspace: Path) -> None:
     # Hooks — check which agents have hooks installed
     agents_with_hooks = []
     mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -2335,6 +2335,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".openclaw" / "plugins.json"
     if agent == "hermes":
         return workspace / ".hermes" / "plugins.json"
+    if agent == "codex":
+        return workspace / ".codex" / "hooks.json"
     if agent == "copilot":
         return workspace / ".github" / "copilot" / "hooks.json"
     return workspace / ".windsurf" / "hooks.json"
@@ -2444,7 +2446,7 @@ def _print_dashboard(days: int = 7) -> None:
         risk_color = _RED if latest_risk >= 50 else _YELLOW if latest_risk >= 20 else _GREEN
 
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:
@@ -2567,7 +2569,7 @@ def _print_status_overview(workspace: Path) -> None:
     # Hooks + mode
     agents_with_hooks: List[str] = []
     mode: Optional[str] = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from warden.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"]
 
 
 def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[Dict[str, Any], bool]:
@@ -24,6 +24,8 @@ def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[D
         return _strip_openclaw(config, marker)
     if agent == "hermes":
         return _strip_hermes(config, marker)
+    if agent == "codex":
+        return _strip_codex(config, marker)
     if agent == "copilot":
         return _strip_copilot(config, marker)
     return _strip_windsurf(config, marker)
@@ -48,6 +50,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_openclaw(config, command, repo_root)
         elif current_agent == "hermes":
             config = _merge_hermes(config, command, repo_root)
+        elif current_agent == "codex":
+            config = _merge_codex(config, command)
         elif current_agent == "copilot":
             config = _merge_copilot(config, command)
         else:
@@ -122,6 +126,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_openclaw(payload, session_id)
     elif agent == "hermes":
         event = _normalize_hermes(payload, session_id)
+    elif agent == "codex":
+        event = _normalize_codex(payload, session_id, workspace)
     elif agent == "copilot":
         event = _normalize_copilot(payload, session_id)
     else:
@@ -215,6 +221,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".openclaw" / "plugins.json"
         if agent == "hermes":
             return workspace / ".hermes" / "plugins.json"
+        if agent == "codex":
+            return workspace / ".codex" / "hooks.json"
         if agent == "copilot":
             return workspace / ".github" / "copilot" / "hooks.json"
         return workspace / ".windsurf" / "hooks.json"
@@ -227,6 +235,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".openclaw" / "config.json"
     if agent == "hermes":
         return home / ".hermes" / "config.json"
+    if agent == "codex":
+        return home / ".codex" / "hooks.json"
     if agent == "copilot":
         return home / ".copilot" / "hooks.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
@@ -629,6 +639,23 @@ def _merge_copilot(config: Dict[str, Any], command: str) -> Dict[str, Any]:
     return {**config, "version": config.get("version", 1), "hooks": hooks}
 
 
+def _merge_codex(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    hooks = dict(config.get("hooks", {}))
+    hooks["UserPromptSubmit"] = _merge_claude_entries(
+        hooks.get("UserPromptSubmit", []),
+        {"matcher": "*", "hooks": [{"type": "command", "command": command}]},
+    )
+    for event_name in ["PreToolUse", "PermissionRequest", "PostToolUse"]:
+        hooks[event_name] = _merge_claude_entries(
+            hooks.get(event_name, []),
+            {
+                "matcher": "Bash|apply_patch|mcp__.*",
+                "hooks": [{"type": "command", "command": command}],
+            },
+        )
+    return {**config, "hooks": hooks}
+
+
 def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
     hooks = dict(config.get("hooks", {}))
     removed = False
@@ -640,6 +667,25 @@ def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any],
         if len(filtered) < len(entries):
             removed = True
         hooks[event_name] = filtered
+    return {**config, "hooks": hooks}, removed
+
+
+def _strip_codex(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        cleaned = []
+        for entry in entries:
+            inner_hooks = entry.get("hooks", [])
+            filtered = [h for h in inner_hooks if marker not in h.get("command", "")]
+            if len(filtered) < len(inner_hooks):
+                removed = True
+            if filtered:
+                cleaned.append({**entry, "hooks": filtered})
+        hooks[event_name] = cleaned
     return {**config, "hooks": hooks}, removed
 
 
@@ -672,6 +718,51 @@ def _normalize_copilot(payload: Dict[str, Any], session_id: str) -> Dict[str, An
         return {**base, "type": "file_write", "path": tool_args.get("path") or tool_args.get("filePath", ""), "content": tool_args.get("content", "")}
     if tool_name in {"WebFetch", "web_fetch", "WebSearch"}:
         return {**base, "type": "network", "url": tool_args.get("url", "")}
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _normalize_codex(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
+    hook_event = payload.get("hook_event_name", "unknown")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+    base = {
+        "ts": payload.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "agent": "codex",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+    }
+    if hook_event == "UserPromptSubmit":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    if tool_name == "Bash":
+        return {
+            **base,
+            "type": "shell",
+            "command": tool_input.get("command", ""),
+            "stdout": payload.get("stdout", ""),
+            "stderr": payload.get("stderr", ""),
+        }
+    if tool_name == "Read":
+        return {**base, "type": "file_read", "path": tool_input.get("file_path") or tool_input.get("path", "")}
+    if tool_name in {"Edit", "MultiEdit", "Write", "apply_patch"}:
+        return {
+            **base,
+            "type": "file_write",
+            "path": tool_input.get("file_path") or tool_input.get("path", ""),
+            "content": _join_edits(tool_input.get("edits", [])) or tool_input.get("content", "") or tool_input.get("command", ""),
+        }
+    if tool_name in {"WebFetch", "WebSearch"}:
+        return {**base, "type": "network", "url": tool_input.get("url", ""), "response": payload.get("response", "")}
+    mcp_event = _classify_mcp_event(
+        base=base,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        response=payload.get("tool_response", payload.get("response")),
+        is_post=(hook_event == "PostToolUse"),
+        workspace=workspace,
+    )
+    if mcp_event is not None:
+        return mcp_event
     return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 
@@ -1036,5 +1127,5 @@ def _is_pre_action(agent_event: str) -> bool:
     return (
         lower.startswith("pre")
         or lower.startswith("before")
-        or agent_event in {"PreToolUse", "UserPromptSubmit"}
+        or agent_event in {"PreToolUse", "UserPromptSubmit", "PermissionRequest"}
     )

--- a/warden/scanner.py
+++ b/warden/scanner.py
@@ -1,7 +1,7 @@
 """Skill / MCP server scanner for Prismor Warden.
 
 Discovers MCP server and skill configurations across supported agents
-(Claude Code, Cursor, Windsurf, OpenClaw, Hermes), synthesizes skill_manifest
+(Claude Code, Cursor, Windsurf, OpenClaw, Hermes, Codex), synthesizes skill_manifest
 events from each entry, and evaluates them through the PolicyEngine.
 
 Usage (from CLI):
@@ -15,6 +15,7 @@ import ast
 import json
 import re
 import shlex
+import tomllib
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -246,6 +247,17 @@ def _hermes_configs(workspace: Path) -> List[Path]:
     return [p for p in _dedupe(candidates) if p.exists()]
 
 
+def _codex_configs(workspace: Path) -> List[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".codex" / "config.toml",
+        home / ".codex" / "hooks.json",
+        workspace / ".codex" / "config.toml",
+        workspace / ".codex" / "hooks.json",
+    ]
+    return [p for p in _dedupe(candidates) if p.exists()]
+
+
 def _dedupe(paths: List[Path]) -> List[Path]:
     """De-duplicate paths (preserves order). Resolves each path first so
     symlinks and workspace-that-equals-HOME don't produce duplicates."""
@@ -268,6 +280,7 @@ _AGENT_DISCOVERERS = {
     "windsurf": _windsurf_configs,
     "openclaw": _openclaw_configs,
     "hermes": _hermes_configs,
+    "codex": _codex_configs,
 }
 
 
@@ -330,8 +343,11 @@ def parse_config(config_path: Path) -> List[Dict[str, Any]]:
     """Parse a single config file and return extracted skill/server entries."""
     try:
         text = config_path.read_text(encoding="utf-8")
-        data = json.loads(text)
-    except (json.JSONDecodeError, OSError):
+        if config_path.suffix == ".toml":
+            data = tomllib.loads(text)
+        else:
+            data = json.loads(text)
+    except (json.JSONDecodeError, tomllib.TOMLDecodeError, OSError):
         return []
 
     agent = "unknown"

--- a/warden/setup_wizard.py
+++ b/warden/setup_wizard.py
@@ -231,6 +231,7 @@ def _detect_agents(target: Path) -> dict:
         "windsurf": (target / ".windsurf").exists() or (home / ".codeium").exists(),
         "openclaw": shutil.which("openclaw") is not None or (target / ".openclaw").exists(),
         "hermes":   shutil.which("hermes") is not None or (target / ".hermes").exists(),
+        "codex":    shutil.which("codex") is not None or (target / ".codex").exists() or (home / ".codex").exists(),
     }
 
 
@@ -340,6 +341,7 @@ def _step_agents(target: Path) -> list:
         {"name": "windsurf", "label": "Windsurf",    "on": detected.get("windsurf", False)},
         {"name": "openclaw", "label": "OpenClaw",    "on": detected.get("openclaw", False)},
         {"name": "hermes",   "label": "Hermes",      "on": detected.get("hermes", False)},
+        {"name": "codex",    "label": "Codex",       "on": detected.get("codex", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True


### PR DESCRIPTION
## Summary

- Wires Codex through every code path the other agents already use: `install-hooks`/`uninstall-hooks`/`hook-dispatch`/`scan` CLI args, hook merge/strip/normalize in `warden/hooks.py`, MCP/skill config discovery (`hooks.json` + `config.toml`, including inline TOML hook declarations) in `warden/scanner.py`, hook-status detection in `warden/audit.py`/`warden/cli.py`, and setup-wizard auto-detection.
- Updates `AGENT_INTEGRATIONS.md` and `README.md` to document Codex as supported, including the matcher used (`Bash|apply_patch|mcp__.*`) and the minimum required `codex-cli` version.

## Why a minimum version is called out

While validating this, `codex exec` appeared to silently never fire any hook at all, regardless of `hooks.json` vs inline TOML, matcher syntax, or `--dangerously-bypass-hook-trust`. Traced it to a real upstream Codex bug, not a Prismor issue: `--dangerously-bypass-hook-trust` printed its warning but didn't propagate the bypass to the exec thread, so hooks (which require persisted trust) were silently dropped before dispatch. Already fixed upstream in [openai/codex#26434](https://github.com/openai/codex/pull/26434) (merged 2026-06-16), first shipping in `rust-v0.141.0-alpha.1` — but not yet promoted to a stable release tag as of this PR. Docs call out the minimum version so users don't file a false bug report against Prismor.

## Test plan

- [x] `python3 -m pytest tests/` — 541 passed
- [x] Verified end to end against a real `codex exec` session on a `0.141.0-alpha.4` build: `UserPromptSubmit`/`PreToolUse`/`PostToolUse` all fire with the installed matcher and dispatch correctly to `warden.immunity_cli hook-dispatch`
- [x] Verified enforcement: a policy-blocked command (`rm package-lock.json`, matched by the `lockfile-deletion` rule) was actually denied by Codex's tool router before execution — file left untouched, Codex's own log shows `PreToolUse Blocked`