### PR TITLE
CLI UX consolidation: merge info/status, swap dashboard/serve, auto-install Claude skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Warden uses a **YAML-based policy engine**. All detection rules, enforcement set
 | `warden/policy_engine.py` | Loads YAML rules, compiles regex patterns, evaluates events |
 | `warden/default_policy.yaml` | All default rules, settings (block_categories, manifest_patterns) |
 | `warden/policy_schema.json` | JSON Schema for validating policy files |
-| `warden/cli.py` | CLI entry point — check, status, sessions, info, policy, hooks |
+| `warden/cli.py` | CLI entry point — check, status, sessions, dashboard, policy, hooks |
 | `warden/hooks.py` | IDE hook installation and event normalization (Claude, Cursor, Windsurf, OpenClaw, Hermes) |
 | `warden/store.py` | SQLite + JSONL session storage |
 | `warden/feed.py` | Correlates findings with threat advisories |
@@ -159,10 +159,10 @@ Warden uses a **YAML-based policy engine**. All detection rules, enforcement set
 #### CLI commands:
 
 ```bash
-immunity info                                    # workspace, mode, rules, hooks at a glance
-immunity dashboard                               # global overview of all registered workspaces
+immunity status                                  # workspace, mode, cloak, latest session at a glance
+immunity status --all                            # global overview of all registered workspaces
+immunity dashboard                               # local web dashboard (opens a browser)
 immunity check "rm -rf /"                        # pre-check a command
-immunity status                                  # most recent session findings
 immunity sessions --findings-only                # flagged sessions sorted by risk
 immunity sessions --findings-only --global       # across all registered workspaces
 immunity policy show                             # active rules after merging
@@ -174,7 +174,7 @@ immunity install-hooks --agent openclaw --mode enforce
 immunity install-hooks --agent hermes --mode enforce
 ```
 
-**Workspace registry:** Workspaces are auto-registered in `~/.prismor/workspaces.json` whenever hooks are installed or events are dispatched. The `dashboard` and `--global` commands read from this registry — no filesystem scanning.
+**Workspace registry:** Workspaces are auto-registered in `~/.prismor/workspaces.json` whenever hooks are installed or events are dispatched. The `status --all` and `--global` commands read from this registry — no filesystem scanning.
 
 ### Cloaking (secret prevention layer)
 

--- a/PYPI.md
+++ b/PYPI.md
@@ -71,7 +71,7 @@ immunity sweep
 **Launch the self-hosted dashboard** (reads from local SQLite, no cloud):
 
 ```bash
-immunity serve   # http://127.0.0.1:7070
+immunity dashboard   # opens http://127.0.0.1:7070 in your browser
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ Disabled by default. See [docs/semantic-guard.md](docs/semantic-guard.md) for fu
 ## Self-Hosted Dashboard
 
 ```bash
-immunity serve           # http://127.0.0.1:7070
-immunity serve --port 8080
+immunity dashboard            # opens http://127.0.0.1:7070 in your browser
+immunity dashboard --port 8080
+immunity dashboard --no-open  # headless server only (was: immunity serve)
 ```
 
 Sessions, findings, threat categories, agent breakdowns, and a live event feed — all from local workspace DBs. No cloud.

--- a/SKILL.md
+++ b/SKILL.md
@@ -69,6 +69,10 @@ pip install immunity-agent
 immunity setup            # interactive 5-step TUI
 ```
 
+For Claude Code, `immunity setup` also drops this skill into
+`<workspace>/.claude/skills/immunity-agent/` so it travels with the project —
+that's where this file came from if you're reading it locally.
+
 Non-interactive / CI / piped:
 
 ```bash
@@ -201,8 +205,8 @@ pick the smallest tool that answers the question:
 | "Full security posture, fix what you can" | `immunity audit --fix` |
 | "Run this command in a safe sandbox" | `immunity sandbox <cmd>` |
 | "Recurring blocked patterns I should accept?" | `immunity learn` |
-| "Show all registered workspaces" | `immunity dashboard` (terminal overview across every workspace where hooks are installed) |
-| "Open the dashboard" | `immunity serve` → http://127.0.0.1:7070 |
+| "Show all registered workspaces" | `immunity status --all` (terminal overview across every workspace where hooks are installed) |
+| "Open the dashboard" | `immunity dashboard` → http://127.0.0.1:7070 (opens a browser; `--no-open` for headless) |
 | "Am I on the latest version?" | `immunity update --check` (install with `immunity update`) |
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,7 +41,7 @@ immunity
 │   ├─ setup                  Interactive onboarding wizard (5-step TUI)
 │   ├─ install-hooks          Wire Warden hooks into an agent/IDE
 │   ├─ uninstall-hooks        Remove hooks
-│   └─ status / info          Health check / workspace summary
+│   └─ status [--all]         Health check (this workspace / all workspaces)
 │
 ├─ Runtime protection (policy engine)
 │   ├─ check                  Pre-check a command or path against policy
@@ -54,8 +54,8 @@ immunity
 │   ├─ deps                   Check project deps vs. threat feed
 │   ├─ analyze / ingest       Run the engine over a JSONL session
 │   ├─ sessions / session     List / show stored sessions
-│   ├─ dashboard              Terminal overview of all workspaces
-│   └─ serve                  Local web dashboard (127.0.0.1:7070)
+│   ├─ status --all           Terminal overview of all workspaces
+│   └─ dashboard              Local web dashboard (127.0.0.1:7070, opens browser)
 │
 ├─ Secret prevention
 │   ├─ cloak <action>         install · add · list · remove · status · pattern
@@ -82,8 +82,8 @@ immunity
 | `immunity setup [DIR]` | `--non-interactive`, `--mode`, `--agents`, `--cloak/--no-cloak` | Interactive wizard (or scripted with flags / `PRISMOR_MODE`, `PRISMOR_CLOAK` env vars). Picks mode, toggles rules, selects agents, enables cloaking. |
 | `immunity install-hooks` | `--agent <name\|all>` (required), `--mode <observe\|enforce>`, `--scope <project\|user>` | Writes hook config for the chosen agent so Warden sees tool calls. Without hooks, nothing is monitored. |
 | `immunity uninstall-hooks` | `--agent <name\|all>`, `--scope` | Removes Prismor hooks for an agent. Clean rollback. |
-| `immunity status` | `--workspace` | Health check: hooks, mode, cloak state, latest session, and the single next action. Run this first every session. |
-| `immunity info` | `--workspace` | Workspace summary (deprecated alias of `status`). |
+| `immunity status` | `--workspace`, `--all`, `--days N` | Health check: hooks, mode, cloak state, latest session, and the single next action. Run this first every session. `--all` shows every registered workspace. |
+| `immunity info` | `--workspace` | _Deprecated_ alias of `status`. |
 
 Agent → config matrix and per-agent details: [AGENT_INTEGRATIONS.md](../AGENT_INTEGRATIONS.md).
 Modes (`observe` vs `enforce`): [Warden](warden.md).
@@ -117,8 +117,9 @@ Full policy model, rule schema, and the default rule list: [Warden](warden.md).
 | `immunity ingest --input <file>` | `--session-id`, `--agent` | Analyze a session and store it in the local DB. |
 | `immunity sessions` | `--findings-only`, `--global`, `--limit`, `--json` | List stored sessions, optionally only flagged ones, optionally across all workspaces. |
 | `immunity session <id>` | `--json` | Drill into one session's tool-call trace + findings. |
-| `immunity dashboard` | — | Terminal overview of every registered workspace. See [Dashboard](dashboard.md). |
-| `immunity serve` | `--port`, `--host` | Local web dashboard at `http://127.0.0.1:7070`. See [Dashboard](dashboard.md). |
+| `immunity status --all` | `--days N` | Terminal overview of every registered workspace. See [Dashboard](dashboard.md). |
+| `immunity dashboard` | `--port`, `--host`, `--no-open` | Local web dashboard at `http://127.0.0.1:7070` (opens a browser tab). See [Dashboard](dashboard.md). |
+| `immunity serve` | `--port`, `--host`, `--no-open` | _Deprecated_ alias of `dashboard --no-open` (headless server only). |
 
 ---
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,35 +26,38 @@ across every project you've protected.
 
 ```
    workspace A ─┐
-   workspace B ─┼─► registered workspaces ─► dashboard / serve ─► you
+   workspace B ─┼─► registered workspaces ─► status --all / dashboard ─► you
    workspace C ─┘        (warden.db each)
 ```
 
 ---
 
-## Terminal: `immunity status` and `immunity dashboard`
+## Terminal: `immunity status` and `immunity status --all`
 
 ```bash
 immunity status        # THIS workspace: hooks, mode, cloak, latest session, next step
-immunity dashboard     # ALL workspaces: risk, findings, mode, last activity
+immunity status --all  # ALL workspaces: risk, findings, mode, last activity
 ```
 
 - **`status`** is the per-workspace health check — run it first every session. It
   ends with the single next action that matters (install hooks, switch to
   enforce, review findings, or "clean").
-- **`dashboard`** is the cross-project bird's-eye view: one line per registered
+- **`status --all`** is the cross-project bird's-eye view: one line per registered
   workspace with its latest risk score, finding count, mode, and how long ago it
-  was active.
+  was active. Add `--days N` to change the activity window (default 7).
 
 ---
 
-## Web: `immunity serve`
+## Web: `immunity dashboard`
 
 ```bash
-immunity serve                       # http://127.0.0.1:7070
-immunity serve --port 8080           # custom port
-immunity serve --host 127.0.0.1      # bind host (keep it local)
+immunity dashboard                   # opens http://127.0.0.1:7070 in your browser
+immunity dashboard --port 8080       # custom port
+immunity dashboard --host 127.0.0.1  # bind host (keep it local)
+immunity dashboard --no-open         # headless: start the server, don't open a browser
 ```
+
+> `immunity serve` is the deprecated alias of `immunity dashboard --no-open`.
 
 Serves a self-contained HTML dashboard plus a small JSON API over the registered
 workspace databases. The only external resource is a Chart.js CDN link loaded by
@@ -70,7 +73,7 @@ the browser; the data never leaves your machine.
 | `GET /api/events` | Paginated events (`?page&limit&verdict&agent`) |
 | `GET /api/supply-chain` | Supply-chain enforcement stats |
 
-If you run `serve` before installing hooks anywhere, it warns that no workspaces
+If you run `dashboard` before installing hooks anywhere, it warns that no workspaces
 are registered yet — install hooks in a project first to collect data.
 
 ---

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -112,8 +112,9 @@ All `warden` commands available after setup.
 
 ```bash
 # Workspace overview
-immunity info
-immunity dashboard                               # all workspaces at a glance
+immunity status
+immunity status --all                            # all workspaces at a glance
+immunity dashboard                               # web dashboard (opens a browser)
 
 # Test a command against your policy
 immunity check "rm -rf /"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,28 @@ packages = ["warden", "supplychain"]
 "templates/CLAUDE.md.template" = "warden/data/templates/CLAUDE.md.template"
 "warden/cloaking/hermes-plugin/plugin.yaml" = "warden/data/cloaking/hermes-plugin/plugin.yaml"
 "warden/cloaking/hermes-plugin/__init__.py" = "warden/data/cloaking/hermes-plugin/__init__.py"
+# Bundle the immunity-agent Claude skill (SKILL.md + its docs/, minus the heavy
+# unreferenced demo.gif) so `immunity setup` can install it into a workspace's
+# .claude/skills/ directory. Files are listed explicitly — a `docs/` directory
+# mapping would drag in demo.gif (force-include ignores wheel `exclude`).
+"SKILL.md" = "warden/data/SKILL.md"
+"docs/architecture.md" = "warden/data/docs/architecture.md"
+"docs/canary.md" = "warden/data/docs/canary.md"
+"docs/cli-reference.md" = "warden/data/docs/cli-reference.md"
+"docs/dashboard.md" = "warden/data/docs/dashboard.md"
+"docs/docker.md" = "warden/data/docs/docker.md"
+"docs/hermes.md" = "warden/data/docs/hermes.md"
+"docs/iam.md" = "warden/data/docs/iam.md"
+"docs/learning.md" = "warden/data/docs/learning.md"
+"docs/live-telemetry.md" = "warden/data/docs/live-telemetry.md"
+"docs/network-isolation.md" = "warden/data/docs/network-isolation.md"
+"docs/policy-layers-and-exemptions.md" = "warden/data/docs/policy-layers-and-exemptions.md"
+"docs/scoped-agent.md" = "warden/data/docs/scoped-agent.md"
+"docs/semantic-guard.md" = "warden/data/docs/semantic-guard.md"
+"docs/skill-scanner.md" = "warden/data/docs/skill-scanner.md"
+"docs/supply-chain.md" = "warden/data/docs/supply-chain.md"
+"docs/sweep-and-cloak.md" = "warden/data/docs/sweep-and-cloak.md"
+"docs/warden.md" = "warden/data/docs/warden.md"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -538,6 +538,29 @@ def do_install(target, mode, rules, agents, tokenize=False):
         return True, "created"
     spinner_run("Updating CLAUDE.md", update_claude)
 
+    # 4b. Install the immunity-agent Claude skill (Claude Code only).
+    if "claude" in agents:
+        def install_skill():
+            skill_md = PRISMOR_DIR / "SKILL.md"
+            docs_src = PRISMOR_DIR / "docs"
+            if not skill_md.exists():
+                return True, "skipped (skill not found)"
+            dest = target / ".claude" / "skills" / "immunity-agent"
+            if (dest / "SKILL.md").exists():
+                return True, "already present"
+            try:
+                dest.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(skill_md, dest / "SKILL.md")
+                if docs_src.is_dir():
+                    docs_dest = dest / "docs"
+                    docs_dest.mkdir(exist_ok=True)
+                    for md in docs_src.glob("*.md"):
+                        shutil.copy2(md, docs_dest / md.name)
+                return True, "installed"
+            except OSError as e:
+                return False, str(e)[:40]
+        spinner_run("Installing immunity-agent skill", install_skill)
+
     # 5. Verify feed
     def verify():
         vsh = PRISMOR_DIR / "scripts" / "verify_feed.sh"
@@ -589,14 +612,17 @@ def do_install(target, mode, rules, agents, tokenize=False):
     print()
     def info(k, v):
         print(f"  {w(k + ':', GRN)}  {w(v, DIM)}")
-    info("Skills",  "https://github.com/PrismorSec/security-playbook")
-    info("Feed",    str(PRISMOR_DIR / "advisories/immunity-feed.json").replace(home, "~"))
-    info("Warden",  f"hooks installed (mode: {mode})")
-    info("Config",  str(target / "CLAUDE.md").replace(home, "~"))
-    info("Command", "immunity (restart shell if not found)")
+    info("Hooks",      f"installed (mode: {mode})")
+    if "claude" in agents:
+        info("Skill",  str(target / ".claude" / "skills" / "immunity-agent").replace(home, "~"))
+    info("Guardrails", "https://github.com/PrismorSec/security-playbook")
+    info("Feed",       str(PRISMOR_DIR / "advisories/immunity-feed.json").replace(home, "~"))
+    info("Config",     str(target / "CLAUDE.md").replace(home, "~"))
+    info("Command",    "immunity (restart shell if not found)")
     print()
     print(w("  Quick commands:", GRN))
-    print(f"    immunity status                      {w('most recent session', DIM)}")
+    print(f"    immunity status                      {w('this workspace health check', DIM)}")
+    print(f"    immunity status --all                {w('overview across all workspaces', DIM)}")
     print(f"    immunity sessions --findings-only     {w('all flagged sessions by risk', DIM)}")
     print(f"    immunity check \"rm -rf /\"             {w('pre-check a command', DIM)}")
     print()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,37 @@ class TestCliExitCodes(unittest.TestCase):
         self.assertIn("--agent", r.stdout)
 
 
+class TestCliCommandConsolidation(unittest.TestCase):
+    """info→status, dashboard/serve, and status --all consolidation."""
+
+    def test_info_is_alias_of_status(self):
+        # `info` warns it's deprecated and renders the `status` overview.
+        r = run_cli("info")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("deprecated alias", r.stderr)
+        self.assertIn("status", r.stdout)
+        # The old separate "workspace info" renderer is gone.
+        self.assertNotIn("workspace info", r.stdout)
+
+    def test_status_all_flag_exists(self):
+        r = run_cli("status", "--help")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("--all", r.stdout)
+        self.assertIn("--days", r.stdout)
+
+    def test_dashboard_serves_web_dashboard(self):
+        # `dashboard` is now the web server, so it exposes --port/--host/--no-open.
+        r = run_cli("dashboard", "--help")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("--port", r.stdout)
+        self.assertIn("--no-open", r.stdout)
+
+    def test_serve_is_deprecated_alias(self):
+        r = run_cli("serve", "--help")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("--no-open", r.stdout)
+
+
 class TestCliAnalyze(unittest.TestCase):
     """Test the analyze command against the sample session."""
 
@@ -168,6 +199,37 @@ class TestImmunityUmbrella(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
         for action in ("install", "uninstall", "add", "list", "remove", "status"):
             self.assertIn(action, r.stdout)
+
+
+class TestSkillInstall(unittest.TestCase):
+    """`immunity setup` bundles + installs the immunity-agent Claude skill."""
+
+    def test_install_skill_copies_manifest_and_docs(self):
+        import tempfile
+        from warden.setup_wizard import _install_skill
+        with tempfile.TemporaryDirectory() as ws:
+            ok, detail = _install_skill(Path(ws))
+            self.assertTrue(ok, detail)
+            skill = Path(ws) / ".claude" / "skills" / "immunity-agent"
+            self.assertTrue((skill / "SKILL.md").exists())
+            # Docs the SKILL.md links to come along, the heavy gif does not.
+            self.assertTrue((skill / "docs" / "warden.md").exists())
+            self.assertFalse((skill / "docs" / "demo.gif").exists())
+
+    def test_install_skill_is_idempotent(self):
+        import tempfile
+        from warden.setup_wizard import _install_skill
+        with tempfile.TemporaryDirectory() as ws:
+            _install_skill(Path(ws))
+            ok, detail = _install_skill(Path(ws))
+            self.assertTrue(ok)
+            self.assertEqual(detail, "already present")
+
+    def test_skill_is_bundled_in_resolver(self):
+        # The resolver must find the manifest in a git checkout (and, by the
+        # same suffix, an installed wheel).
+        from warden.paths import skill_manifest_path
+        self.assertTrue(skill_manifest_path().exists())
 
     def test_top_level_shortcut_dispatches(self):
         # `immunity analyze` should reach the warden analyze command.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,50 @@ class TestImmunityUmbrella(unittest.TestCase):
         for shortcut in ("setup", "status", "audit", "info"):
             self.assertIn(shortcut, r.stdout)
 
+    def test_help_lists_every_command(self):
+        # Help is introspection-driven: every non-internal top-level command
+        # from the real parser must show up, so nothing can silently drop out.
+        import argparse
+        from warden.cli import build_parser
+        r = run_immunity("--help")
+        self.assertEqual(r.returncode, 0)
+        hidden = {"hook-dispatch"}  # internal, intentionally not listed
+        parser = build_parser()
+        commands = []
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                commands = list(action.choices.keys())
+                break
+        for cmd in commands:
+            if cmd in hidden:
+                continue
+            self.assertIn(cmd, r.stdout, f"command '{cmd}' missing from --help")
+
+    def test_help_shows_subactions_and_modes(self):
+        # Sub-actions of domains and a command's "internal" mode flags must be
+        # discoverable straight from `immunity --help`.
+        r = run_immunity("--help")
+        self.assertEqual(r.returncode, 0)
+        for token in ("install", "show", "plant", "--redact", "--all", "--no-open"):
+            self.assertIn(token, r.stdout, f"'{token}' missing from --help")
+
+    def test_warden_bare_is_quiet(self):
+        # `immunity warden` with no subcommand must NOT dump the argparse usage
+        # wall — just a short deprecation pointer to `immunity help`.
+        r = run_immunity("warden")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("deprecated", r.stderr.lower())
+        self.assertIn("immunity help", r.stderr)
+        self.assertNotIn("positional arguments", r.stdout + r.stderr)
+        self.assertNotIn("{info,dashboard", r.stdout + r.stderr)
+
+    def test_warden_subcommand_still_forwards(self):
+        # `immunity warden status` keeps working (warns, then runs status).
+        r = run_immunity("warden", "status")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("deprecated", r.stderr.lower())
+        self.assertIn("status", r.stdout)
+
     def test_bare_invocation_prints_help(self):
         r = run_immunity()
         self.assertEqual(r.returncode, 0)

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -7,7 +7,7 @@ Commands:
   deps          Check workspace dependencies against threat feed
   audit         Full security posture check across all Warden subsystems
   audit --fix   Auto-remediate fixable issues
-  status        Show findings from the most recent session
+  status        One-shot health check for this workspace (--all for every workspace)
   analyze       Analyze a JSONL session file
   ingest        Analyze and store a session
   sessions      List stored sessions
@@ -15,7 +15,7 @@ Commands:
   install-hooks Install IDE hooks for real-time monitoring
   uninstall-hooks Remove IDE hooks
   hook-dispatch Internal: called by IDE hooks (not for direct use)
-  serve         Start a local HTTP API server for the Prismor web dashboard
+  dashboard     Open the Prismor web dashboard (local server + browser)
   enroll TOKEN  Enroll this machine into a Prismor org (central observability + policy)
   enroll-status Show this machine's enrollment status
   logout        Un-enroll this machine (remove device identity + cached remote policy)
@@ -150,27 +150,31 @@ def main(argv: Optional[List[str]] = None) -> None:
         ws_value = os.environ.get("PRISMOR_WARDEN_WORKSPACE")
     workspace = Path(ws_value).resolve() if ws_value else infer_default_workspace(Path.cwd())
 
-    # ── dashboard: global overview ───────────────────────────────────────
-    if args.command == "dashboard":
-        _print_dashboard(days=getattr(args, "days", 7))
-        return
-
-    # ── serve: local HTTP API server for web dashboard ───────────────────
-    if args.command == "serve":
+    # ── dashboard / serve: local web dashboard (HTTP server) ─────────────
+    # `dashboard` starts the server and opens a browser tab. `serve` is the
+    # deprecated alias that defaults to headless (no browser).
+    if args.command in ("dashboard", "serve"):
         from warden.server import run_server
+        if args.command == "serve":
+            sys.stderr.write(
+                "Note: 'immunity serve' is a deprecated alias — use 'immunity dashboard --no-open'.\n"
+            )
         registered = list_registered_workspaces()
         if not registered:
             sys.stderr.write(
                 "[warden] Warning: no registered workspaces found.\n"
                 "         Run 'immunity install-hooks' in a project first to collect data.\n"
             )
-        run_server(host=args.host, port=args.port)
+        # dashboard opens a browser by default; serve stays headless. --no-open
+        # forces headless for dashboard too.
+        open_browser = args.command == "dashboard" and not getattr(args, "no_open", False)
+        run_server(host=args.host, port=args.port, open_browser=open_browser)
         return
 
-    # ── info: quick workspace summary ───────────────────────────────────
+    # ── info: deprecated alias of status ────────────────────────────────
     if args.command == "info":
         sys.stderr.write("Note: 'immunity info' is a deprecated alias — use 'immunity status'.\n")
-        _print_info(workspace)
+        _print_status_overview(workspace)
         return
 
     # ── enroll / device identity ────────────────────────────────────────
@@ -709,7 +713,10 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     # ── status: one-shot health check (mode, hooks, cloak, latest session) ──
     if args.command == "status":
-        _print_status_overview(workspace)
+        if getattr(args, "all", False):
+            _print_dashboard(days=getattr(args, "days", 7))
+        else:
+            _print_status_overview(workspace)
         return
 
     # ── analyze ────────────────────────────────────────────────────────
@@ -1797,32 +1804,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", version=f"immunity-agent {__version__}")
     subparsers = parser.add_subparsers(dest="command")
 
-    # ── info ───────────────────────────────────────────────────────────
-    subparsers.add_parser("info", help="Show workspace, mode, rules, and hook status")
+    # ── info (deprecated alias of status) ───────────────────────────────
+    subparsers.add_parser("info", help="(deprecated) alias of `status`")
 
-    # ── dashboard ─────────────────────────────────────────────────────
-    dashboard_parser = subparsers.add_parser("dashboard", help="Global overview of all registered workspaces")
-    dashboard_parser.add_argument(
-        "--days",
-        type=int,
-        default=7,
-        metavar="N",
-        help="Show activity for the last N days (default: 7)",
-    )
-
-    # ── serve ──────────────────────────────────────────────────────────
-    serve_parser = subparsers.add_parser(
-        "serve",
-        help="Start a local HTTP API server for the Prismor web dashboard",
-    )
-    serve_parser.add_argument(
-        "--port", type=int, default=7070,
-        help="Port to listen on (default: 7070)",
-    )
-    serve_parser.add_argument(
-        "--host", default="127.0.0.1",
-        help="Host to bind to (default: 127.0.0.1)",
-    )
+    # ── dashboard / serve: local web dashboard ──────────────────────────
+    # `dashboard` opens the browser-based web dashboard. `serve` is a
+    # deprecated alias that stays headless (no browser).
+    for _name, _help in (
+        ("dashboard", "Open the Prismor web dashboard (starts a local server + browser)"),
+        ("serve", "(deprecated) alias of `dashboard --no-open` — headless server only"),
+    ):
+        _dp = subparsers.add_parser(_name, help=_help)
+        _dp.add_argument(
+            "--port", type=int, default=7070,
+            help="Port to listen on (default: 7070)",
+        )
+        _dp.add_argument(
+            "--host", default="127.0.0.1",
+            help="Host to bind to (default: 127.0.0.1)",
+        )
+        _dp.add_argument(
+            "--no-open", action="store_true",
+            help="Don't open a browser tab (headless server only)",
+        )
 
     # ── check ──────────────────────────────────────────────────────────
     check_parser = subparsers.add_parser("check", help="Quick pre-check a command or file path")
@@ -1900,6 +1904,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="One-shot health check: workspace, mode, hooks, cloak, latest session",
     )
     status_parser.add_argument("--workspace", help="Workspace path")
+    status_parser.add_argument(
+        "--all", action="store_true",
+        help="Show all registered workspaces (global overview) instead of just this one",
+    )
+    status_parser.add_argument(
+        "--days", type=int, default=7, metavar="N",
+        help="With --all: show activity for the last N days (default: 7)",
+    )
 
     # ── analyze ────────────────────────────────────────────────────────
     analyze = subparsers.add_parser("analyze", help="Analyze a session (or current session if no --input)")
@@ -2240,91 +2252,6 @@ def _truncate_str(s: str, n: int) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
-def _print_info(workspace: Path) -> None:
-    """Show a quick summary of the workspace config."""
-    home = str(Path.home())
-    ws_display = str(workspace).replace(home, "~")
-
-    print()
-    print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  workspace info")
-    print(f"  {_color('─' * 50, _DIM)}")
-    print()
-
-    # Workspace
-    print(f"  {_color('Workspace:', _GREEN)}    {ws_display}")
-
-    # Policy
-    policy_path = workspace / ".prismor-warden" / "policy.yaml"
-    if policy_path.exists():
-        print(f"  {_color('Policy:', _GREEN)}       {str(policy_path).replace(home, '~')}")
-    else:
-        print(f"  {_color('Policy:', _GREEN)}       {_color('defaults only (no project overrides)', _DIM)}")
-
-    # Rules
-    engine = PolicyEngine(workspace=workspace)
-    # Count how many rules come from defaults vs how many are disabled
-    default_path = Path(__file__).resolve().parent / "default_policy.yaml"
-    total_default = 0
-    try:
-        from warden.policy_engine import _load_yaml
-        data = _load_yaml(default_path)
-        if data:
-            total_default = len(data.get("rules", []))
-    except Exception:
-        total_default = len(engine.rules)
-    n_active = len(engine.rules)
-    n_disabled = total_default - n_active
-    rules_str = f"{n_active} active"
-    if n_disabled > 0:
-        rules_str += f", {_color(f'{n_disabled} disabled', _YELLOW)}"
-    print(f"  {_color('Rules:', _GREEN)}        {rules_str}")
-
-    # Allowlists
-    if engine.allowlists:
-        print(f"  {_color('Allowlists:', _GREEN)}   {len(engine.allowlists)}")
-
-    # Hooks — check which agents have hooks installed
-    agents_with_hooks = []
-    mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
-        hook_path = _find_hook_config(agent_name, workspace)
-        if hook_path and hook_path.exists():
-            try:
-                content = hook_path.read_text()
-                if "warden" in content.lower() or "prismor" in content.lower():
-                    agents_with_hooks.append(agent_name)
-                    # Try to detect mode from hook config
-                    if mode is None:
-                        if "--mode enforce" in content:
-                            mode = "enforce"
-                        elif "--mode observe" in content:
-                            mode = "observe"
-            except Exception:
-                pass
-
-    if agents_with_hooks:
-        mode_color = _GREEN if mode == "enforce" else _YELLOW
-        mode_str = _color(mode or "unknown", mode_color)
-        print(f"  {_color('Hooks:', _GREEN)}       {', '.join(agents_with_hooks)}  ({mode_str})")
-    else:
-        print(f"  {_color('Hooks:', _GREEN)}       {_color('not installed', _YELLOW)}")
-
-    # Sessions
-    sessions = list_sessions(workspace, 5)
-    sessions_with_findings = [s for s in sessions if s.get("findingsCount", 0) > 0]
-    total_sessions = len(list_sessions(workspace, 999))
-    print(f"  {_color('Sessions:', _GREEN)}     {total_sessions} total, {len(sessions_with_findings)} with findings")
-
-    # Latest risk
-    if sessions:
-        latest = sessions[0]
-        risk = latest.get("riskScore", 0)
-        risk_color = _RED if risk >= 50 else _YELLOW if risk >= 20 else _GREEN
-        print(f"  {_color('Latest risk:', _GREEN)}  {_color(f'{risk}/100', risk_color)}  ({latest['sessionId'][:20]})")
-
-    print()
-
-
 def _find_hook_config(agent: str, workspace: Path) -> Path:
     """Find the hook config file for an agent."""
     if agent == "claude":
@@ -2383,7 +2310,7 @@ def _print_dashboard(days: int = 7) -> None:
 
     # ── Header ────────────────────────────────────────────────────────────
     print()
-    print(f"  {_color('Prismor Immunity-agent dashboard', _BOLD)}")
+    print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  all workspaces")
     print(f"  {'─' * 50}")
     print()
 

--- a/warden/iam.py
+++ b/warden/iam.py
@@ -99,7 +99,7 @@ def _mtime(path: Path) -> float:
 
 
 # path+mtime keyed memo. Per-event hook runs are separate processes so this is
-# a no-op there, but the long-lived `immunity serve` path calls load_iam_config
+# a no-op there, but the long-lived `immunity dashboard` server calls load_iam_config
 # on every request — this keeps it off the YAML parser in the hot path while
 # still reloading automatically when either config file changes on disk.
 _CONFIG_CACHE: Dict[Any, Dict[str, Any]] = {}

--- a/warden/immunity_cli.py
+++ b/warden/immunity_cli.py
@@ -37,7 +37,7 @@ def _c(text: str, code: str) -> str:
 # is purely curation for the help text and never drifts out of sync with routing.
 _TOP_LEVEL_SHORTCUTS = {
     # Common, frequently-typed:
-    "setup", "status", "audit", "info", "dashboard", "serve",
+    "setup", "status", "audit", "dashboard",
     "check", "scan", "deps", "semantic-check",
     "analyze", "ingest", "sessions", "session",
     "install-hooks", "uninstall-hooks", "hook-dispatch",
@@ -137,11 +137,12 @@ def _print_usage() -> None:
     print(f"    immunity setup              {d('Interactive onboarding wizard')}")
     print(f"    immunity update             {d('Check for and install the latest version')}")
     print(f"    immunity status             {d('One-shot health check: hooks, mode, cloak, latest session')}")
+    print(f"    immunity status --all       {d('Global overview across every registered workspace')}")
+    print(f"    immunity dashboard          {d('Open the web dashboard (local server + browser)')}")
     print(f"    immunity audit              {d('Full security posture audit')}")
     print(f"    immunity enroll <token>     {d('Enroll this machine into a Prismor org (central observability + policy)')}")
     print(f"    immunity enroll-status      {d('Show this device enrollment status')}")
     print(f"    immunity workspace          {d('Is THIS repo org-managed or personal? (scope org telemetry/policy per repo)')}")
-    print(f"    immunity info               {d('Workspace summary (deprecated alias of status)')}")
     print()
     print(f"  {b('Domains')}  {d('(each takes an action; see `immunity <domain> --help`)')}")
     print(f"    immunity cloak       <action>   {d('Secret cloaking at the tool boundary')}")
@@ -162,8 +163,6 @@ def _print_usage() -> None:
     print(f"    immunity analyze <file>     {d('Analyze a JSONL session file')}")
     print(f"    immunity install-hooks      {d('Install IDE hooks for real-time monitoring')}")
     print(f"    immunity uninstall-hooks    {d('Remove IDE hooks')}")
-    print(f"    immunity dashboard          {d('Global overview of all registered workspaces')}")
-    print(f"    immunity serve              {d('Start the local HTTP API server (web dashboard)')}")
     print()
     print(f"  {b('Supply-chain interception')}  {d('(also: pip3, pnpm, yarn, uv, cargo, go)')}")
     print(f"    immunity supplychain npm install <pkg>")
@@ -178,6 +177,8 @@ def _print_usage() -> None:
     print(f"  {b('Deprecated')}  {d('(kept working; will be removed in a future release)')}")
     print(f"    warden <command>            {d('the standalone warden CLI — use immunity instead')}")
     print(f"    immunity warden <command>   {d('drop the warden prefix: every warden command is a direct immunity command')}")
+    print(f"    immunity info               {d('use `immunity status`')}")
+    print(f"    immunity serve              {d('use `immunity dashboard --no-open`')}")
     print()
 
 

--- a/warden/immunity_cli.py
+++ b/warden/immunity_cli.py
@@ -29,29 +29,11 @@ def _c(text: str, code: str) -> str:
     return text
 
 
-# ── Routing tables ──────────────────────────────────────────────────────────
+# ── Routing ───────────────────────────────────────────────────────────────────
 #
-# The frequently-typed warden subcommands we surface explicitly in --help under
-# "Quick start" / "Runtime shortcuts". Routing no longer depends on this list —
-# `main()` forwards ANY real warden command (see `_warden_commands()`), so this
-# is purely curation for the help text and never drifts out of sync with routing.
-_TOP_LEVEL_SHORTCUTS = {
-    # Common, frequently-typed:
-    "setup", "status", "audit", "dashboard",
-    "check", "scan", "deps", "semantic-check",
-    "analyze", "ingest", "sessions", "session",
-    "install-hooks", "uninstall-hooks", "hook-dispatch",
-    "update",
-    # Enterprise control plane (device enrollment + org-managed policy):
-    "enroll", "enroll-status", "logout", "workspace", "exempt",
-}
-
-# Domains that map to a warden.cli subparser of the same name. Used only to
-# group them under "Domains" in --help; routing is introspection-driven below.
-_WARDEN_DOMAINS = {
-    "cloak", "policy", "sweep", "iam", "canary", "scope", "learn",
-}
-
+# Routing is fully introspection-driven: `main()` forwards ANY real warden
+# command (see `_warden_commands()`), and `_print_usage()` builds the help from
+# the live parser (see `_command_table()`), so neither can drift out of sync.
 _SUPPLY_DOMAIN = "supplychain"
 
 
@@ -96,15 +78,22 @@ def main(argv: Optional[List[str]] = None) -> None:
         return
 
     # `immunity warden <command> ...` — DEPRECATED alias. Every warden command is
-    # now a direct immunity command, so the `warden` namespace is redundant. We
-    # keep it working (warn, then forward the remaining args) so old scripts and
-    # muscle memory don't break.
+    # now a direct immunity command, so the `warden` namespace is redundant.
     if cmd == "warden":
-        target = rest[0] if rest else "<command>"
+        # Bare `immunity warden` with no subcommand: don't dump warden's noisy
+        # argparse usage — point at the unified help instead.
+        if not rest:
+            sys.stderr.write(
+                "'warden' is deprecated — every warden command is now a direct "
+                "immunity command.\n"
+                "Run 'immunity help' to see all commands.\n"
+            )
+            return
+        # With a subcommand: warn once, then forward so old scripts keep working.
         sys.stderr.write(
             "Warning: 'immunity warden ...' is deprecated — every warden command "
             "is now a direct immunity command.\n"
-            f"Use 'immunity {target}' instead.\n\n"
+            f"Use 'immunity {rest[0]}' instead.\n\n"
         )
         from warden.cli import main as warden_main
         warden_main(rest)
@@ -124,61 +113,111 @@ def main(argv: Optional[List[str]] = None) -> None:
     sys.exit(2)
 
 
+# Ordered grouping for `immunity help`. Every group lists the commands it
+# owns; any introspected command NOT named here lands in the "More" catch-all,
+# so a new warden.cli subcommand can never silently vanish from help.
+_HELP_GROUPS = [
+    ("Quick start",          ["setup", "status", "dashboard", "audit", "update"]),
+    ("Runtime protection",   ["check", "semantic-check", "scan", "deps", "sandbox", "policy"]),
+    ("Sessions & forensics", ["analyze", "ingest", "sessions", "session"]),
+    ("Hooks",                ["install-hooks", "uninstall-hooks"]),
+    ("Secret prevention",    ["cloak", "sweep", "canary"]),
+    ("Identity & scoping",   ["iam", "scope", "learn"]),
+    ("Enterprise / org",     ["enroll", "enroll-status", "workspace", "exempt", "logout"]),
+    ("Supply chain",         ["supplychain"]),
+]
+
+# Commands handled elsewhere in the help (deprecated section) or never shown.
+_HELP_HIDDEN = {"hook-dispatch", "info", "serve", "warden"}
+
+# supplychain is dispatched by this umbrella, not a warden.cli subcommand, so it
+# is injected manually with its own help + sub-actions.
+_SUPPLY_HELP = ("Supply-chain install gating + project hardening", "supplychain")
+_SUPPLY_ACTIONS = ["npm", "pip", "pnpm", "yarn", "uv", "cargo", "go", "harden"]
+
+
+def _command_table():
+    """Introspect build_parser() → {name: (help, sub_actions, mode_flags)}.
+
+    Generated from the live parser so help can never drift from the real CLI.
+    """
+    import argparse
+    table = {}
+    try:
+        from warden.cli import build_parser
+        parser = build_parser()
+    except Exception:
+        return table
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        helps = {ca.dest: (ca.help or "") for ca in action._get_subactions()}
+        for name, sub in action.choices.items():
+            nested, flags = [], []
+            for sa in sub._actions:
+                if isinstance(sa, argparse._SubParsersAction):
+                    nested = list(sa.choices.keys())
+                elif isinstance(sa, argparse._StoreTrueAction):
+                    flags += [o for o in sa.option_strings if o.startswith("--")]
+            table[name] = (helps.get(name, ""), nested, flags)
+        break
+    # supplychain isn't in warden.cli — add it so help is complete.
+    table["supplychain"] = (_SUPPLY_HELP[0], _SUPPLY_ACTIONS, [])
+    return table
+
+
 def _print_usage() -> None:
     def b(t: str) -> str: return _c(t, _BOLD)
     def d(t: str) -> str: return _c(t, _DIM)
+
+    table = _command_table()
+    pad = 16
+
+    def _emit(name: str) -> None:
+        if name not in table:
+            return
+        help_text, nested, flags = table[name]
+        print(f"    {name.ljust(pad)}{d(help_text)}")
+        if nested:
+            print(f"    {' ' * pad}{d('· ' + ' · '.join(nested))}")
+        elif flags:
+            print(f"    {' ' * pad}{d('modes:  ' + '  '.join(flags))}")
 
     print()
     print(f"  {b('immunity')} — runtime security for AI coding agents")
     print()
     print(f"  Usage: {b('immunity')} <command> [options...]")
-    print()
-    print(f"  {b('Quick start')}")
-    print(f"    immunity setup              {d('Interactive onboarding wizard')}")
-    print(f"    immunity update             {d('Check for and install the latest version')}")
-    print(f"    immunity status             {d('One-shot health check: hooks, mode, cloak, latest session')}")
-    print(f"    immunity status --all       {d('Global overview across every registered workspace')}")
-    print(f"    immunity dashboard          {d('Open the web dashboard (local server + browser)')}")
-    print(f"    immunity audit              {d('Full security posture audit')}")
-    print(f"    immunity enroll <token>     {d('Enroll this machine into a Prismor org (central observability + policy)')}")
-    print(f"    immunity enroll-status      {d('Show this device enrollment status')}")
-    print(f"    immunity workspace          {d('Is THIS repo org-managed or personal? (scope org telemetry/policy per repo)')}")
-    print()
-    print(f"  {b('Domains')}  {d('(each takes an action; see `immunity <domain> --help`)')}")
-    print(f"    immunity cloak       <action>   {d('Secret cloaking at the tool boundary')}")
-    print(f"    immunity policy      <action>   {d('Manage policy rules (init/validate/show/edit/test)')}")
-    print(f"    immunity sweep       [options]  {d('Scan AI tool configs for leaked secrets')}")
-    print(f"    immunity iam         <action>   {d('Agent identities and permission profiles')}")
-    print(f"    immunity canary      <action>   {d('Plant and manage canarytokens')}")
-    print(f"    immunity scope       <action>   {d('Session-scoped policy rules')}")
-    print(f"    immunity learn       [options]  {d('Mine session history for new rules')}")
-    print(f"    immunity supplychain <action>   {d('Supply chain (npm/pip/pnpm/uv/cargo/go + harden)')}")
-    print()
-    print(f"  {b('Runtime shortcuts')}")
-    print(f"    immunity check <cmd>        {d('Pre-check a command against policy')}")
-    print(f"    immunity scan               {d('Scan MCP servers and skills for security risks')}")
-    print(f"    immunity deps               {d('Check workspace dependencies vs. threat feed')}")
-    print(f"    immunity sessions           {d('List stored sessions')}")
-    print(f"    immunity session <id>       {d('Show a specific session')}")
-    print(f"    immunity analyze <file>     {d('Analyze a JSONL session file')}")
-    print(f"    immunity install-hooks      {d('Install IDE hooks for real-time monitoring')}")
-    print(f"    immunity uninstall-hooks    {d('Remove IDE hooks')}")
-    print()
-    print(f"  {b('Supply-chain interception')}  {d('(also: pip3, pnpm, yarn, uv, cargo, go)')}")
-    print(f"    immunity supplychain npm install <pkg>")
-    print(f"    immunity supplychain pip install <pkg>")
-    print(f"    immunity supplychain harden [--dry-run] [PATH]")
+    print(f"         {b('immunity')} <command> --help   {d('flags + sub-actions for one command')}")
+
+    grouped = set(_HELP_HIDDEN)
+    for title, names in _HELP_GROUPS:
+        present = [n for n in names if n in table]
+        if not present:
+            continue
+        print()
+        print(f"  {b(title)}")
+        for n in present:
+            _emit(n)
+            grouped.add(n)
+
+    # Catch-all: any real command not placed in a group above.
+    leftover = [n for n in table if n not in grouped]
+    if leftover:
+        print()
+        print(f"  {b('More')}")
+        for n in sorted(leftover):
+            _emit(n)
+
     print()
     print(f"  {b('Help & version')}")
-    print(f"    immunity --help             {d('This message')}")
-    print(f"    immunity <command> --help   {d('Help for a specific command')}")
-    print(f"    immunity --version          {d('Show version')}")
+    print(f"    {'--help'.ljust(pad)}{d('This message')}")
+    print(f"    {'<cmd> --help'.ljust(pad)}{d('Flags + sub-actions for one command')}")
+    print(f"    {'--version'.ljust(pad)}{d('Show version')}")
     print()
     print(f"  {b('Deprecated')}  {d('(kept working; will be removed in a future release)')}")
-    print(f"    warden <command>            {d('the standalone warden CLI — use immunity instead')}")
-    print(f"    immunity warden <command>   {d('drop the warden prefix: every warden command is a direct immunity command')}")
-    print(f"    immunity info               {d('use `immunity status`')}")
-    print(f"    immunity serve              {d('use `immunity dashboard --no-open`')}")
+    print(f"    {'warden <cmd>'.ljust(pad)}{d('the standalone warden CLI — use immunity directly')}")
+    print(f"    {'info'.ljust(pad)}{d('use `immunity status`')}")
+    print(f"    {'serve'.ljust(pad)}{d('use `immunity dashboard --no-open`')}")
     print()
 
 

--- a/warden/paths.py
+++ b/warden/paths.py
@@ -78,3 +78,16 @@ def public_key_path() -> Path:
 
 def template_path(name: str) -> Path:
     return _resolve("templates", name)
+
+
+def skill_manifest_path() -> Path:
+    """Locate the bundled immunity-agent Claude skill manifest (SKILL.md).
+
+    Git checkout: ``<root>/SKILL.md``. Installed wheel: ``warden/data/SKILL.md``.
+    """
+    return _resolve("SKILL.md")
+
+
+def skill_docs_dir() -> Path:
+    """Locate the skill's ``docs/`` directory (reference material it links to)."""
+    return _resolve("docs")

--- a/warden/server.py
+++ b/warden/server.py
@@ -174,10 +174,21 @@ class WardenRequestHandler(BaseHTTPRequestHandler):
         pass
 
 
-def run_server(host: str = "127.0.0.1", port: int = 7070) -> None:
-    """Start the warden HTTP API server (blocks until Ctrl-C)."""
+def run_server(host: str = "127.0.0.1", port: int = 7070, open_browser: bool = False) -> None:
+    """Start the warden HTTP API server (blocks until Ctrl-C).
+
+    When ``open_browser`` is set, opens the default browser to the dashboard
+    once the listening socket is bound. The socket is bound by the
+    ``HTTPServer(...)`` constructor, so the request lands even before
+    ``serve_forever()`` starts accepting.
+    """
     server = HTTPServer((host, port), WardenRequestHandler)
-    print(f"[warden] dashboard → http://{host}:{port}  (Ctrl-C to stop)", flush=True)
+    url = f"http://{host}:{port}"
+    print(f"[warden] dashboard → {url}  (Ctrl-C to stop)", flush=True)
+    if open_browser:
+        import threading
+        import webbrowser
+        threading.Timer(0.4, lambda: webbrowser.open(url)).start()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/warden/setup_wizard.py
+++ b/warden/setup_wizard.py
@@ -486,6 +486,38 @@ def _spinner_run(label: str, fn) -> None:
 
 # ── Install ───────────────────────────────────────────────────────────────────
 
+def _install_skill(target: Path):
+    """Copy the bundled immunity-agent Claude skill into the workspace.
+
+    Installs to ``<target>/.claude/skills/immunity-agent/`` (SKILL.md plus its
+    docs/). Idempotent: if a SKILL.md is already present it's left untouched so
+    user edits survive re-runs. Returns ``(ok, detail)`` for the spinner.
+    """
+    try:
+        from warden.paths import skill_manifest_path, skill_docs_dir
+        skill_md = skill_manifest_path()
+        docs_src = skill_docs_dir()
+    except Exception as e:
+        return False, str(e)[:40]
+    if not skill_md.exists():
+        return True, "skipped (skill not bundled)"
+
+    dest = target / ".claude" / "skills" / "immunity-agent"
+    if (dest / "SKILL.md").exists():
+        return True, "already present"
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(skill_md, dest / "SKILL.md")
+        if docs_src.exists() and docs_src.is_dir():
+            docs_dest = dest / "docs"
+            docs_dest.mkdir(exist_ok=True)
+            for md in docs_src.glob("*.md"):
+                shutil.copy2(md, docs_dest / md.name)
+        return True, "installed"
+    except OSError as e:
+        return False, str(e)[:40]
+
+
 def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], cloak: bool = False) -> None:
     sys.stdout.write(ALT_OFF)
     sys.stdout.write("\033[H\033[J" + HIDE)
@@ -599,6 +631,10 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
         return True, "created"
     _spinner_run("Updating CLAUDE.md", _update_claude)
 
+    # 4b. Install the immunity-agent Claude skill (Claude Code only).
+    if "claude" in agents:
+        _spinner_run("Installing immunity-agent skill", lambda: _install_skill(target))
+
     # 5. Feed signature verification (use warden.paths resolver, skip shell script)
     def _verify_feed():
         try:
@@ -642,13 +678,16 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
     def _info(k: str, v: str) -> None:
         print(f"  {_w(k + ':', GRN)}  {_w(v, DIM)}")
 
-    _info("Skills",  "https://github.com/PrismorSec/security-playbook")
-    _info("Warden",  f"hooks installed  (mode: {mode})")
-    _info("Config",  str(target / "CLAUDE.md").replace(home, "~"))
-    _info("Command", "immunity status  ·  immunity sessions  ·  immunity check \"<cmd>\"")
+    _info("Hooks",      f"installed  (mode: {mode})")
+    if "claude" in agents:
+        _info("Skill",  str(target / ".claude" / "skills" / "immunity-agent").replace(home, "~"))
+    _info("Guardrails", "https://github.com/PrismorSec/security-playbook")
+    _info("Config",     str(target / "CLAUDE.md").replace(home, "~"))
+    _info("Command",    "immunity status  ·  immunity sessions  ·  immunity check \"<cmd>\"")
     print()
     print(_w("  Quick commands:", GRN))
-    print(f"    immunity status                       {_w('most recent session', DIM)}")
+    print(f"    immunity status                       {_w('this workspace health check', DIM)}")
+    print(f"    immunity status --all                 {_w('overview across all workspaces', DIM)}")
     print(f"    immunity sessions --findings-only     {_w('all flagged sessions by risk', DIM)}")
     print(f"    immunity check \"rm -rf /\"              {_w('pre-check a command', DIM)}")
     print(f"    immunity sweep                        {_w('scan AI tool configs for leaked secrets', DIM)}")


### PR DESCRIPTION
## Why

Three rough edges surfaced from real terminal usage (see screenshots in the originating discussion):

1. **`info` vs `status`** — `info` claimed to be a deprecated alias of `status` but still ran a *separate* renderer (`_print_info`) that duplicated ~80% of the status view, including a verbatim copy of the hook/mode-detection loop.
2. **`dashboard` vs `serve`** — `serve`'s help said *"Prismor web dashboard"* and served the real HTML UI, while the command literally named `dashboard` was a static multi-workspace **text** summary. The names were backwards relative to intent.
3. **`setup` "Skills:"** — `immunity setup` advertised a `Skills:` line but only appended a security-playbook block to `CLAUDE.md`. It never installed the actual `immunity-agent` Claude skill (the one that teaches an agent to drive this very CLI), even though the repo ships one at `SKILL.md`.

## What changed

- **`info` → real alias of `status`**: warns, then calls `_print_status_overview()`. Deleted the duplicate `_print_info()`.
- **`dashboard` / `serve` swapped to match intent**:
  - `immunity dashboard` now starts the local server **and opens a browser tab** (`--no-open` for headless).
  - The old text overview moved to **`immunity status --all [--days N]`**.
  - `immunity serve` is kept working as a **deprecated alias** of `dashboard --no-open`.
- **`setup` installs the Claude skill**: copies the bundled `SKILL.md` + `docs/` into `<workspace>/.claude/skills/immunity-agent/` (Claude Code only, idempotent). The skill is force-included into the wheel under `warden/data/` — explicitly listed so the 6MB unreferenced `demo.gif` stays out (wheel: 330K → 385K). New resolver helpers `warden.paths.skill_manifest_path` / `skill_docs_dir`. Install banner relabeled `Hooks` / `Skill` / `Guardrails` (was the conflated "Skills").
- Docs + in-code help updated across `README`, `PYPI.md`, `AGENTS.md`, `docs/{cli-reference,dashboard,warden}.md`, and the umbrella usage.

## Testing

- **Local (macOS):** full suite `548 passed` (was 541 + 7 new CLI/skill tests).
- **st3ve (Linux, py3.12):** installed the freshly built wheel in an isolated venv outside the source tree to validate the **wheel-bundled** skill path. Confirmed:
  - resolver finds `…/site-packages/warden/data/SKILL.md` (17 docs, no gif);
  - `immunity setup --non-interactive` copies the skill into the workspace and is idempotent (`already present` on re-run);
  - `info`/`status --all`/`dashboard --no-open` behave as expected;
  - `515 passed` (gap vs local = pre-existing `requests`-dependent pipeline tests not installed in the fresh venv).

## Migration

`info` and `serve` keep working with a one-line deprecation note — no breakage for existing scripts or muscle memory.