### PR TITLE
feat(dashboard): auto-increment port if default is already in use

### DIFF
--- a/warden/server.py
+++ b/warden/server.py
@@ -182,7 +182,17 @@ def run_server(host: str = "127.0.0.1", port: int = 7070, open_browser: bool = F
     ``HTTPServer(...)`` constructor, so the request lands even before
     ``serve_forever()`` starts accepting.
     """
-    server = HTTPServer((host, port), WardenRequestHandler)
+    import errno as _errno
+    while True:
+        try:
+            server = HTTPServer((host, port), WardenRequestHandler)
+            break
+        except OSError as exc:
+            if exc.errno == _errno.EADDRINUSE:
+                print(f"[warden] port {port} in use, trying {port + 1}…", flush=True)
+                port += 1
+            else:
+                raise
     url = f"http://{host}:{port}"
     print(f"[warden] dashboard → {url}  (Ctrl-C to stop)", flush=True)
     if open_browser:


### PR DESCRIPTION
## Summary
- If `7070` (or any explicitly passed `--port`) is occupied when `immunity dashboard` starts, the server now retries on successive ports until it finds a free one
- Prints a notice for each skipped port: `[warden] port 7070 in use, trying 7071…`
- Browser is opened (and the URL printed) on the actual bound port

## Test plan
- [ ] Start any process on port 7070, then run `immunity dashboard` — confirm it binds on 7071 and opens the browser there
- [ ] Verify `--port` flag still works and falls through correctly when that port is also occupied
- [ ] Confirm unrelated `OSError`s (e.g. permission denied on port 80) still propagate as exceptions