### PR TITLE
feat: cloak hardening, policy editor UX, and dashboard rule controls

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -45,6 +45,44 @@ def _pkg_version() -> str:
 VERSION = f"v{_pkg_version()}"
 BACK = object()  # sentinel for "go back"
 
+# ── Hook catalogue ────────────────────────────────────────────────────────────
+
+HOOK_DEFS = [
+    {
+        "id":      "runtime",
+        "label":   "Runtime monitor",
+        "default": True,
+        "desc":    "Intercepts all tool calls — blocks/logs dangerous Bash, file ops, and prompt injections",
+    },
+    {
+        "id":      "cloak-core",
+        "label":   "Secret cloak",
+        "default": True,
+        "desc":    "Decloak @@SECRET:name@@ in Bash inputs; recloak real secrets from MCP tool output",
+    },
+    {
+        "id":      "cloak-guard",
+        "label":   "Secret guard",
+        "default": True,
+        "desc":    "Detects and denies tool calls where the model passes raw secret values directly",
+    },
+    {
+        "id":      "cloak-prompt",
+        "label":   "Prompt guard",
+        "default": True,
+        "desc":    "Soft-blocks if you paste a raw secret value directly into the chat prompt",
+    },
+    {
+        "id":      "cloak-sweep",
+        "label":   "Session sweep",
+        "default": False,
+        "desc":    "Scans session transcripts for secret residue at session end (verbose — off by default)",
+    },
+]
+
+def _default_hooks():
+    return {d["id"]: d["default"] for d in HOOK_DEFS}
+
 # ── ANSI ─────────────────────────────────────────────────────────────────────
 
 RST  = "\033[0m"
@@ -319,49 +357,48 @@ def step_agents(target):
             return chosen if chosen else ["claude"]
         elif key in ('q','Q','\x03'): cleanup(); sys.exit(0)
 
-# ── Step 3: Secret Cloaking ──────────────────────────────────────────────────
+# ── Step 3: Hook selection ───────────────────────────────────────────────────
 
-def step_tokenize(current=True):
-    """Yes/no toggle for the secret-cloaking prevention layer.
-
-    Installs PreToolUse/PostToolUse/UserPromptSubmit hooks that keep real
-    secret values out of the model's context, the JSONL transcript, and
-    upstream API requests. Requires ``jq`` on the user's PATH.
-    """
-    opts = [
-        ("yes", "Install cloaking hooks  (recommended — prevents secret leaks to the LLM provider)"),
-        ("no",  "Skip — only runtime policy hooks will be installed"),
-    ]
-    sel = 0 if current else 1
+def step_hooks(current=None):
+    """Multi-select checklist: every hook with a one-liner description."""
+    if current is None:
+        current = _default_hooks()
+    hooks = {d["id"]: current.get(d["id"], d["default"]) for d in HOOK_DEFS}
+    sel = 0
+    label_w = max(visible_len(d["label"]) for d in HOOK_DEFS) + 2
 
     while True:
-        lines = header_lines(3, 3, "SECRET CLOAKING")
-        lines.append(f"  {w('Prevents real secrets from reaching model context, JSONL transcripts,', DIM)}")
-        lines.append(f"  {w('or upstream API requests. See warden/cloaking/README.md.', DIM)}")
+        tw = term_width()
+        lines = header_lines(3, 3, "HOOKS")
+        lines.append(f"  {w('Select which hooks to install:', DIM)}")
         lines.append("")
-        for i, (name, desc) in enumerate(opts):
-            arrow = w("▸ ", CYAN) if i == sel else "  "
-            dot   = w("●", GRN) if i == sel else w("○", DIM)
-            tw = term_width()
-            max_desc = max(tw - 24, 30)
-            nm    = pad(w(name, BOLD) if i == sel else w(name, DIM), 8)
-            lines.append(f"  {arrow}{dot}  {nm}{w(desc[:max_desc], DIM)}")
+        for i, hd in enumerate(HOOK_DEFS):
+            arrow    = w("▸ ", CYAN) if i == sel else "  "
+            dot      = w("●", GRN) if hooks[hd["id"]] else w("○", DIM)
+            lbl      = pad(w(hd["label"], BOLD) if i == sel else hd["label"], label_w)
+            max_desc = max(tw - label_w - 10, 20)
+            desc     = w(hd["desc"][:max_desc], DIM)
+            lines.append(f"  {arrow}{dot}  {lbl}{desc}")
         lines.append("")
         lines.append(control_line([
-            ("↑↓", "select"), ("←", "back"), ("enter", "next"), ("q", "quit"),
+            ("↑↓", "move"), ("space", "toggle"),
+            ("←", "back"), ("enter", "next"), ("q", "quit"),
         ]))
         render(lines)
 
         key = read_key()
-        if key in (UP,):              sel = (sel - 1) % len(opts)
-        elif key in (DOWN,):          sel = (sel + 1) % len(opts)
+        if key in (UP,):              sel = (sel - 1) % len(HOOK_DEFS)
+        elif key in (DOWN,):          sel = (sel + 1) % len(HOOK_DEFS)
+        elif key == SPACE:            hooks[HOOK_DEFS[sel]["id"]] = not hooks[HOOK_DEFS[sel]["id"]]
         elif key in (LEFT, 'b', 'B'): return BACK
-        elif key in (ENTER, '\n'):    return opts[sel][0] == "yes"
+        elif key in (ENTER, '\n'):    return dict(hooks)
         elif key in ('q','Q','\x03'): cleanup(); sys.exit(0)
 
 # ── Confirm ──────────────────────────────────────────────────────────────────
 
-def step_confirm(target, mode, rules, agents, tokenize=False):
+def step_confirm(target, mode, rules, agents, hooks=None):
+    if hooks is None:
+        hooks = _default_hooks()
     home = str(Path.home())
     disp = str(target).replace(home, "~")
     n_on = sum(1 for r in rules if r["on"])
@@ -387,8 +424,9 @@ def step_confirm(target, mode, rules, agents, tokenize=False):
         lines.append(row(kv("Mode", mode, GRN if mode == "enforce" else YEL)))
         lines.append(row(kv("Rules", f"{n_on}/{len(rules)} enabled")))
         lines.append(row(kv("Agents", ags)))
-        lines.append(row(kv("Cloak", "yes  (secret prevention)" if tokenize else "no",
-                              GRN if tokenize else DIM)))
+        n_hooks = sum(1 for d in HOOK_DEFS if hooks.get(d["id"], d["default"]))
+        lines.append(row(kv("Hooks", f"{n_hooks}/{len(HOOK_DEFS)} enabled",
+                              GRN if n_hooks else DIM)))
         lines.append(row())
         lines.append(bdr("╰", "─", "╯"))
         lines.append("")
@@ -430,14 +468,17 @@ def spinner_run(label, fn):
     sys.stdout.write(f"\r  {icon}  {label}{suffix}            \n")
     sys.stdout.flush()
 
-def do_install(target, mode, rules, agents, tokenize=False):
+def do_install(target, mode, rules, agents, hooks=None):
     # Switch back to normal buffer for install output
     sys.stdout.write(ALT_OFF)
     sys.stdout.write("\033[H\033[J" + HIDE)
     sys.stdout.flush()
     print(w("  Installing Prismor Immunity Agent...\n", BOLD, CYAN))
 
+    if hooks is None:
+        hooks = _default_hooks()
     target = Path(target).resolve()
+    cli = PRISMOR_DIR / "immunity"
 
     # 0. Register workspace globally
     try:
@@ -469,31 +510,37 @@ def do_install(target, mode, rules, agents, tokenize=False):
             return True, f"{len(disabled)} disabled"
         spinner_run("Writing policy overrides", write_policy)
 
-    # 3. Install hooks
-    cli = PRISMOR_DIR / "immunity"
-    for agent in agents:
-        def install(a=agent):
-            if not cli.exists():
-                return False, "immunity entry point not found"
-            r = subprocess.run([sys.executable, str(cli), "install-hooks",
-                                "--agent", a, "--workspace", str(target),
-                                "--scope", "project", "--mode", mode],
-                               capture_output=True, timeout=30)
-            return r.returncode == 0, ""
-        spinner_run(f"Installing {agent} hooks", install)
+    # 3. Warden runtime hooks
+    if hooks.get("runtime", True):
+        for agent in agents:
+            def install(a=agent):
+                if not cli.exists():
+                    return False, "immunity entry point not found"
+                r = subprocess.run([sys.executable, str(cli), "install-hooks",
+                                    "--agent", a, "--workspace", str(target),
+                                    "--scope", "project", "--mode", mode],
+                                   capture_output=True, timeout=30)
+                return r.returncode == 0, ""
+            spinner_run(f"Installing {agent} hooks", install)
 
-    # 3b. Cloaking hooks (opt-in — Claude Code only for now)
-    if tokenize and "claude" in agents:
-        def install_tokenize():
+    # 3b. Cloaking hooks (Claude Code only)
+    if hooks.get("cloak-core", True) and "claude" in agents:
+        def install_cloak():
             if not cli.exists():
                 return False, "immunity entry point not found"
             if not shutil.which("jq"):
                 return False, "jq not found (brew install jq)"
-            r = subprocess.run([sys.executable, str(cli), "cloak", "install",
-                                "--workspace", str(target), "--scope", "project"],
-                               capture_output=True, timeout=30)
+            cmd = [sys.executable, str(cli), "cloak", "install",
+                   "--workspace", str(target), "--scope", "project"]
+            if not hooks.get("cloak-guard", True):
+                cmd.append("--no-secret-guard")
+            if not hooks.get("cloak-prompt", True):
+                cmd.append("--no-userprompt-guard")
+            if hooks.get("cloak-sweep", False):
+                cmd.append("--sweep-on-stop")
+            r = subprocess.run(cmd, capture_output=True, timeout=30)
             return r.returncode == 0, "enabled" if r.returncode == 0 else r.stderr.decode()[:40]
-        spinner_run("Installing cloaking hooks", install_tokenize)
+        spinner_run("Installing cloaking hooks", install_cloak)
 
     # 4. CLAUDE.md
     def update_claude():
@@ -592,7 +639,8 @@ def do_install(target, mode, rules, agents, tokenize=False):
     print()
     def info(k, v):
         print(f"  {w(k + ':', GRN)}  {w(v, DIM)}")
-    info("Hooks",      f"installed (mode: {mode})")
+    n_hooks = sum(1 for d in HOOK_DEFS if hooks.get(d["id"], d["default"]))
+    info("Hooks",      f"{n_hooks}/{len(HOOK_DEFS)} installed  (mode: {mode})")
     if "claude" in agents:
         info("Skill",  str(target / ".claude" / "skills" / "immunity-agent").replace(home, "~"))
     info("Docs",       "https://github.com/PrismorSec/immunity-agent")
@@ -612,15 +660,21 @@ def do_install(target, mode, rules, agents, tokenize=False):
 # ── Non-interactive ──────────────────────────────────────────────────────────
 
 def run_non_interactive(target):
-    mode = os.environ.get("PRISMOR_MODE", "observe")
+    mode  = os.environ.get("PRISMOR_MODE", "observe")
     cloak = os.environ.get("PRISMOR_CLOAK", "").lower() in {"1", "true", "yes", "on"}
     rules = load_rules()
     target = Path(target).resolve()
-    det = detect_agents(target)
+    det    = detect_agents(target)
     agents = [n for n, ok in det.items() if ok] or ["claude"]
-    tok_tag = ", cloak=yes" if cloak else ""
-    print(f"[prismor] Non-interactive (mode={mode}, agents={','.join(agents)}{tok_tag})")
-    do_install(target, mode, rules, agents, tokenize=cloak)
+    hooks  = _default_hooks()
+    if not cloak:
+        hooks["cloak-core"]   = False
+        hooks["cloak-guard"]  = False
+        hooks["cloak-prompt"] = False
+        hooks["cloak-sweep"]  = False
+    cloak_tag = ", cloak=yes" if cloak else ""
+    print(f"[prismor] Non-interactive (mode={mode}, agents={','.join(agents)}{cloak_tag})")
+    do_install(target, mode, rules, agents, hooks=hooks)
 
 # ── Wizard ───────────────────────────────────────────────────────────────────
 
@@ -635,7 +689,7 @@ def run_wizard(target):
     rules = load_rules()
     mode = "enforce"
     agents = None
-    tokenize = True  # default yes in wizard; user can toggle at step 3
+    hooks = _default_hooks()
     step = 1
 
     try:
@@ -651,13 +705,13 @@ def run_wizard(target):
                 agents = result
                 step = 3
             elif step == 3:
-                result = step_tokenize(tokenize)
+                result = step_hooks(hooks)
                 if result is BACK:
                     step = 2; continue
-                tokenize = result
+                hooks = result
                 step = 4
             elif step == 4:
-                result = step_confirm(target, mode, rules, agents, tokenize=tokenize)
+                result = step_confirm(target, mode, rules, agents, hooks=hooks)
                 if result is BACK:
                     step = 3; continue
                 break  # confirmed → install
@@ -665,10 +719,10 @@ def run_wizard(target):
         rules = load_rules()
         mode = "enforce"
         agents = ["claude"]
-        tokenize = False
+        hooks = _default_hooks()
 
     raw_off()
-    do_install(target, mode, rules, agents, tokenize=tokenize)
+    do_install(target, mode, rules, agents, hooks=hooks)
 
 # ── Entry ────────────────────────────────────────────────────────────────────
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1375,7 +1375,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 print(f"Installed Hermes Agent cloaking plugin at {h_result['pluginDir']}")
                 for label in h_result["hooksInstalled"]:
                     print(f"  + {label}")
-            print(f"Secrets directory: {result.get('secretsDir', h_result.get('secretsDir', str(Path.home() / '.prismor' / 'secrets')))}")
+            _sdir = (result if cloak_agent in ("claude", "all") else h_result).get("secretsDir", str(Path.home() / ".prismor" / "secrets"))
+            print(f"Secrets directory: {_sdir}")
             print()
             print("Next step: register your first secret with")
             print(f"  {_color('immunity cloak add <name>', _CYAN)}  (reads the value from stdin)")
@@ -2776,52 +2777,137 @@ def _policy_edit(workspace: Path) -> None:
     _atexit.register(_restore)
     tty.setcbreak(fd)
 
-    def _read_key():
-        ch = sys.stdin.read(1)
-        if ch == '\x1b':
-            ch2 = sys.stdin.read(1)
-            if ch2 == '[':
-                ch3 = sys.stdin.read(1)
-                return 'ESC[' + ch3
-            return ch
-        return ch
+    import select
 
-    sel = 0
+    def _read_key():
+        # Read at the raw fd level (unbuffered). Mixing select() with
+        # sys.stdin.read() breaks here: read() buffers the rest of an escape
+        # sequence in Python, so select() on the fd sees nothing and a lone ESC
+        # is wrongly reported. os.read goes straight to the OS buffer.
+        ch = os.read(fd, 1)
+        if ch == b'\x1b':
+            # Distinguish a bare ESC from an arrow/cursor sequence via a short
+            # poll. Handle both CSI ("\x1b[") and SS3 ("\x1bO") cursor keys.
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if not r:
+                return '\x1b'
+            ch2 = os.read(fd, 1)
+            if ch2 in (b'[', b'O'):
+                ch3 = os.read(fd, 1)
+                return 'ESC[' + ch3.decode('latin-1', 'ignore')
+            return '\x1b'
+        try:
+            return ch.decode('utf-8')
+        except UnicodeDecodeError:
+            return ''
+
+    import shutil
+
+    sel = 0          # index into the currently-visible (filtered) list
+    top = 0          # first visible row of the scroll viewport
+    query = ""       # active search filter
+    searching = False  # True while typing a search query
+
+    def _visible():
+        if not query:
+            return all_rules
+        q = query.lower()
+        return [r for r in all_rules if q in r["id"].lower() or q in r["title"].lower()]
+
     while True:
+        term = shutil.get_terminal_size((100, 30))
+        cols, rows = term.columns, term.lines
+        vis = _visible()
+        sel = 0 if not vis else max(0, min(sel, len(vis) - 1))
+
+        # Viewport height = terminal rows minus fixed chrome (header + footer).
+        view_h = max(3, rows - 10)
+        if sel < top:
+            top = sel
+        elif sel >= top + view_h:
+            top = sel - view_h + 1
+        top = max(0, min(top, max(0, len(vis) - view_h)))
+
         n_on = sum(1 for r in all_rules if r["on"])
         buf = "\033[H\033[J\033[?25l"  # home, clear, hide cursor
-        buf += f"\n  {_BOLD}PRISMOR IMMUNITY AGENT{_NC}  policy edit\n"
-        buf += f"  {_DIM}Workspace: {workspace}{_NC}\n"
-        buf += f"  {_DIM}{'─' * 64}{_NC}\n\n"
-        buf += f"  {n_on}/{len(all_rules)} rules enabled\n\n"
+        buf += f"\n  {_BOLD}PRISMOR IMMUNITY AGENT{_NC}  policy edit"
+        buf += f"   {_DIM}{n_on}/{len(all_rules)} enabled"
+        if query:
+            buf += f"  ·  filter {_CYAN}“{query}”{_NC}{_DIM} → {len(vis)}"
+        buf += f"{_NC}\n"
+        buf += f"  {_DIM}{'─' * min(max(cols - 4, 20), 80)}{_NC}\n"
 
-        for i, r in enumerate(all_rules):
-            arrow = f"{_CYAN}▸ {_NC}" if i == sel else "  "
+        # top scroll indicator
+        buf += (f"  {_DIM}↑ {top} more{_NC}\n" if top > 0 else "\n")
+
+        # Title column starts after: 2 + arrow(2) + dot(1) + 2 + sev(10) + rid(28) + 1
+        title_col = 46
+        title_max = max(12, cols - title_col - 2)
+        if not vis:
+            buf += f"  {_DIM}— no rules match “{query}” —{_NC}\n"
+        for idx in range(top, min(top + view_h, len(vis))):
+            r = vis[idx]
+            arrow = f"{_CYAN}▸ {_NC}" if idx == sel else "  "
             dot = f"{_GREEN}●{_NC}" if r["on"] else f"{_DIM}○{_NC}"
             sev = r["severity"]
             sev_c = _RED if sev == "CRITICAL" else _YELLOW if sev == "HIGH" else _DIM
             sev_s = f"{sev_c}{sev:<10}{_NC}"
-            rid = f"{_BOLD}{r['id']:<28}{_NC}" if i == sel else f"{r['id']:<28}"
-            title = f"{_DIM}{r['title']}{_NC}"
-            buf += f"  {arrow}{dot}  {sev_s}{rid} {title}\n"
+            rid = f"{_BOLD}{r['id']:<28}{_NC}" if idx == sel else f"{r['id']:<28}"
+            t = r["title"]
+            if len(t) > title_max:
+                t = t[:title_max - 1] + "…"
+            buf += f"  {arrow}{dot}  {sev_s}{rid} {_DIM}{t}{_NC}\n"
 
-        buf += f"\n  {_CYAN}{_BOLD}↑↓{_NC}{_DIM} move  ·  {_NC}"
-        buf += f"{_CYAN}{_BOLD}space{_NC}{_DIM} toggle  ·  {_NC}"
-        buf += f"{_CYAN}{_BOLD}a{_NC}{_DIM} all  ·  {_NC}"
-        buf += f"{_CYAN}{_BOLD}n{_NC}{_DIM} none  ·  {_NC}"
-        buf += f"{_CYAN}{_BOLD}enter{_NC}{_DIM} save  ·  {_NC}"
-        buf += f"{_CYAN}{_BOLD}q{_NC}{_DIM} cancel{_NC}\n"
+        # bottom scroll indicator
+        remaining = len(vis) - (top + view_h)
+        buf += (f"  {_DIM}↓ {remaining} more{_NC}\n" if remaining > 0 else "\n")
+
+        if searching:
+            buf += f"  {_CYAN}{_BOLD}/{_NC}{query}{_BOLD}▏{_NC}   {_DIM}type to filter · enter apply · esc clear{_NC}\n"
+        else:
+            buf += f"  {_CYAN}{_BOLD}↑↓{_NC}{_DIM} move · {_NC}"
+            buf += f"{_CYAN}{_BOLD}space{_NC}{_DIM} toggle · {_NC}"
+            buf += f"{_CYAN}{_BOLD}/{_NC}{_DIM} search · {_NC}"
+            buf += f"{_CYAN}{_BOLD}a{_NC}{_DIM}/{_NC}{_CYAN}{_BOLD}n{_NC}{_DIM} all/none · {_NC}"
+            buf += f"{_CYAN}{_BOLD}enter{_NC}{_DIM} save · {_NC}"
+            buf += f"{_CYAN}{_BOLD}q{_NC}{_DIM} cancel{_NC}\n"
         sys.stdout.write(buf)
         sys.stdout.flush()
 
         key = _read_key()
-        if key == 'ESC[A':    sel = (sel - 1) % len(all_rules)
-        elif key == 'ESC[B':  sel = (sel + 1) % len(all_rules)
-        elif key == ' ':      all_rules[sel]["on"] = not all_rules[sel]["on"]
-        elif key in ('a','A'):
-            for r in all_rules: r["on"] = True
-        elif key in ('n','N'):
-            for r in all_rules: r["on"] = False
+
+        if searching:
+            # While searching: printable chars filter live; arrows still move.
+            if key in ('\r', '\n'):
+                searching = False
+            elif key == '\x1b':            # bare ESC clears the filter
+                searching = False; query = ""; sel = 0; top = 0
+            elif key in ('\x7f', '\b'):
+                query = query[:-1]; sel = 0; top = 0
+            elif key == 'ESC[A':
+                if vis: sel = (sel - 1) % len(vis)
+            elif key == 'ESC[B':
+                if vis: sel = (sel + 1) % len(vis)
+            elif len(key) == 1 and key.isprintable():
+                query += key; sel = 0; top = 0
+            continue
+
+        if key == 'ESC[A':
+            if vis: sel = (sel - 1) % len(vis)
+        elif key == 'ESC[B':
+            if vis: sel = (sel + 1) % len(vis)
+        elif key == 'ESC[H':            # Home
+            sel = 0
+        elif key == 'ESC[F':            # End
+            sel = max(0, len(vis) - 1)
+        elif key == ' ':
+            if vis: vis[sel]["on"] = not vis[sel]["on"]
+        elif key == '/':
+            searching = True
+        elif key in ('a', 'A'):         # all (within current filter)
+            for r in vis: r["on"] = True
+        elif key in ('n', 'N'):         # none (within current filter)
+            for r in vis: r["on"] = False
         elif key in ('\r', '\n'):
             break  # save
         elif key in ('q', 'Q', '\x03'):

--- a/warden/cloaking/hooks/userprompt-guard.sh
+++ b/warden/cloaking/hooks/userprompt-guard.sh
@@ -44,10 +44,14 @@ fi
 prismor_load_patterns
 [[ "${#PATTERNS[@]}" -gt 0 ]] || exit 0
 
+# Strip already-cloaked placeholders before scanning so that @@SECRET:name@@
+# syntax in the prompt never triggers a false positive match.
+scan_text="$(printf '%s' "$prompt" | sed 's/@@SECRET:[^@]*@@//g')"
+
 # Collect unique matches across all patterns.
 matches="$(
   for pat in "${PATTERNS[@]}"; do
-    printf '%s' "$prompt" | grep -oE "$pat" || true
+    printf '%s' "$scan_text" | grep -oE "$pat" || true
   done | awk 'NF && !seen[$0]++'
 )"
 

--- a/warden/dashboard.html
+++ b/warden/dashboard.html
@@ -390,6 +390,67 @@
   .policy-scope-pane { display: none; }
   .policy-scope-pane.active { display: block; }
 
+  /* Per-rule toggle list */
+  .rules-toolbar { display:flex; align-items:center; gap:8px; margin:12px 0; }
+  .rules-search {
+    flex:1; font-family:inherit; font-size:13px; padding:8px 12px;
+    border:1px solid var(--gray-200); border-radius:6px; color:var(--gray-900);
+    background:#fff; outline:none;
+  }
+  .rules-search:focus { border-color: var(--accent, #5b6cff); }
+  .rules-count { font-size:12px; color:var(--gray-500); white-space:nowrap; }
+  .rules-list {
+    border:1px solid var(--gray-200); border-radius:8px; overflow:hidden;
+    max-height:520px; overflow-y:auto; background:#fff;
+  }
+  .rule-row {
+    display:flex; align-items:center; gap:12px; padding:10px 14px;
+    border-bottom:1px solid var(--gray-100);
+  }
+  .rule-row:last-child { border-bottom:none; }
+  .rule-row.off { background: var(--gray-50, #fafafa); }
+  .rule-row.off .rule-id, .rule-row.off .rule-title { opacity:.5; }
+  .rule-main { flex:1; min-width:0; }
+  .rule-id { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12.5px; font-weight:600; color:var(--gray-900); }
+  .rule-title { font-size:12px; color:var(--gray-500); margin-top:2px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .rule-sev {
+    font-size:10px; font-weight:700; letter-spacing:.04em; padding:2px 7px;
+    border-radius:4px; white-space:nowrap;
+  }
+  .rule-sev.CRITICAL { background:#fde8e8; color:#c81e1e; }
+  .rule-sev.HIGH     { background:#fef3c7; color:#b45309; }
+  .rule-sev.MEDIUM   { background:#e0f2fe; color:#0369a1; }
+  .rule-sev.LOW      { background:var(--gray-100); color:var(--gray-500); }
+  /* toggle switch */
+  .rule-toggle { position:relative; width:38px; height:22px; flex:0 0 auto; cursor:pointer; }
+  .rule-toggle input { opacity:0; width:0; height:0; position:absolute; }
+  .rule-track {
+    position:absolute; inset:0; background:var(--gray-300,#cbd5e1); border-radius:22px;
+    transition:.15s;
+  }
+  .rule-track::before {
+    content:""; position:absolute; height:16px; width:16px; left:3px; top:3px;
+    background:#fff; border-radius:50%; transition:.15s;
+  }
+  .rule-toggle input:checked + .rule-track { background:#16a34a; }
+  .rule-toggle input:checked + .rule-track::before { transform:translateX(16px); }
+  .rules-dirty { color:#b45309; }
+
+  /* "More from Prismor" CTA */
+  .prismor-cta {
+    margin-top:20px; padding:18px 20px; border-radius:10px;
+    background:linear-gradient(135deg,#1e1b4b,#312e81); color:#e0e7ff;
+    display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap;
+  }
+  .prismor-cta-text strong { display:block; font-size:14px; color:#fff; margin-bottom:3px; }
+  .prismor-cta-text span { font-size:12.5px; color:#c7d2fe; }
+  .prismor-cta-btn {
+    background:#fff; color:#312e81; font-weight:600; font-size:13px;
+    padding:9px 18px; border-radius:7px; text-decoration:none; white-space:nowrap;
+    transition:.15s;
+  }
+  .prismor-cta-btn:hover { background:#eef2ff; }
+
   .policy-header {
     display: flex; align-items: center; justify-content: space-between;
     margin-bottom: 12px; flex-wrap: wrap; gap: 8px;
@@ -949,14 +1010,41 @@
   <div id="workspaceBanner"></div>
 
   <div class="policy-scope-nav">
-    <button class="policy-scope-btn active" data-pscope="global">Global</button>
+    <button class="policy-scope-btn active" data-pscope="rules">Rules</button>
+    <button class="policy-scope-btn" data-pscope="global">Global</button>
     <button class="policy-scope-btn" data-pscope="project">Project</button>
     <button class="policy-scope-btn" data-pscope="enterprise">Enterprise</button>
     <button class="policy-scope-btn" data-pscope="effective">Effective (merged)</button>
   </div>
 
+  <!-- Per-rule toggle list (project-scoped) -->
+  <div id="pscope-rules" class="policy-scope-pane active">
+    <div class="banner banner-info">
+      <span class="banner-icon">🛡️</span>
+      <div class="banner-text">
+        <strong>Detection rules</strong>
+        Toggle individual rules for <strong>this project</strong>. Disabling a rule stops it
+        blocking <em>and</em> flagging. Saved to <code>.prismor-warden/policy.yaml</code>;
+        live agents pick it up within 30&nbsp;s.
+      </div>
+    </div>
+    <div class="rules-toolbar">
+      <input id="rulesSearch" class="rules-search" type="text" spellcheck="false"
+             placeholder="Search rules by name, category, or description…" />
+      <span id="rulesCount" class="rules-count">—</span>
+      <button class="btn-ghost" id="rulesAll">Enable all</button>
+      <button class="btn-ghost" id="rulesNone">Disable all</button>
+    </div>
+    <div id="rulesList" class="rules-list"><div class="empty">Loading…</div></div>
+    <div class="policy-actions">
+      <button class="btn-primary" id="rulesSave">Save rules</button>
+      <button class="btn-ghost" id="rulesDiscard">Discard changes</button>
+      <span id="rulesSaveStatus" class="policy-status"></span>
+    </div>
+  </div>
+
   <!-- Global policy -->
-  <div id="pscope-global" class="policy-scope-pane active">
+  <div id="pscope-global" class="policy-scope-pane">
     <div class="banner banner-info">
       <span class="banner-icon">🌐</span>
       <div class="banner-text">
@@ -1068,6 +1156,15 @@
   </div>
 </div>
 
+<!-- ═══ MORE FROM PRISMOR (CTA) ══════════════════════════════════════════ -->
+<div class="prismor-cta">
+  <div class="prismor-cta-text">
+    <strong>Want team dashboards, signed remote policy &amp; audit history?</strong>
+    <span>This is the local agent. Prismor Cloud adds org-wide fleet visibility, centrally-managed policy, and long-term audit trails.</span>
+  </div>
+  <a class="prismor-cta-btn" href="https://prismor.dev?utm_source=immunity_dashboard&utm_medium=cta" target="_blank" rel="noopener">Explore Prismor Cloud →</a>
+</div>
+
 <!-- ═══ LOADING SCREEN ═══════════════════════════════════════════════════ -->
 <div id="loadingScreen">
   <div id="loadingCard">
@@ -1144,6 +1241,7 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
       // Render from cache instantly, refresh in background
       if (_policyCache) renderPolicyTab(_policyCache);
       loadPolicy();           // silent background refresh
+      loadRules();            // per-rule toggle list
     }
   });
 });
@@ -2217,6 +2315,92 @@ function setPolicySaveStatus(elId, msg, cls) {
     setTimeout(() => { el.textContent = ''; el.className = 'policy-status'; }, 3500);
   }
 }
+
+// ── Per-rule toggle list ────────────────────────────────────────────────────
+let _rulesCatalog = [];   // [{id,severity,category,title,action,enabled}]
+let _rulesState   = {};   // id -> desired enabled state
+
+async function loadRules() {
+  const ws = _serverWorkspace;
+  const params = ws ? ('?workspace=' + encodeURIComponent(ws)) : '';
+  try {
+    const data = await apiFetch('/api/policy/rules' + params);
+    _rulesCatalog = data.rules || [];
+    _rulesState = {};
+    _rulesCatalog.forEach(r => { _rulesState[r.id] = r.enabled; });
+    renderRules();
+  } catch (e) {
+    document.getElementById('rulesList').innerHTML = '<div class="empty">Failed to load rules.</div>';
+  }
+}
+
+function _rulesDirty() {
+  return _rulesCatalog.some(r => _rulesState[r.id] !== r.enabled);
+}
+
+function renderRules() {
+  const q = (document.getElementById('rulesSearch').value || '').toLowerCase();
+  const list = document.getElementById('rulesList');
+  const vis = _rulesCatalog.filter(r =>
+    !q || r.id.toLowerCase().includes(q)
+       || (r.title || '').toLowerCase().includes(q)
+       || (r.category || '').toLowerCase().includes(q));
+  const onCount = _rulesCatalog.filter(r => _rulesState[r.id]).length;
+  document.getElementById('rulesCount').innerHTML =
+    onCount + '/' + _rulesCatalog.length + ' on'
+    + (_rulesDirty() ? ' <span class="rules-dirty">• unsaved</span>' : '');
+  if (!vis.length) { list.innerHTML = '<div class="empty">No rules match.</div>'; return; }
+  list.innerHTML = vis.map(r => {
+    const on = _rulesState[r.id];
+    return '<div class="rule-row ' + (on ? '' : 'off') + '">'
+      + '<span class="rule-sev ' + safeAttr(r.severity) + '">' + safe(r.severity) + '</span>'
+      + '<div class="rule-main"><div class="rule-id">' + safe(r.id) + '</div>'
+      + '<div class="rule-title">' + safe(r.title) + '</div></div>'
+      + '<label class="rule-toggle"><input type="checkbox" data-rid="' + safeAttr(r.id) + '"'
+      + (on ? ' checked' : '') + '><span class="rule-track"></span></label>'
+      + '</div>';
+  }).join('');
+  list.querySelectorAll('input[data-rid]').forEach(cb => {
+    cb.addEventListener('change', () => {
+      _rulesState[cb.dataset.rid] = cb.checked;
+      renderRules();
+    });
+  });
+}
+
+document.getElementById('rulesSearch').addEventListener('input', renderRules);
+document.getElementById('rulesAll').addEventListener('click', () => {
+  _rulesCatalog.forEach(r => { _rulesState[r.id] = true; }); renderRules();
+});
+document.getElementById('rulesNone').addEventListener('click', () => {
+  _rulesCatalog.forEach(r => { _rulesState[r.id] = false; }); renderRules();
+});
+document.getElementById('rulesDiscard').addEventListener('click', () => {
+  _rulesCatalog.forEach(r => { _rulesState[r.id] = r.enabled; }); renderRules();
+});
+document.querySelector('.policy-scope-btn[data-pscope="rules"]')?.addEventListener('click', loadRules);
+document.getElementById('rulesSave').addEventListener('click', async () => {
+  const ws = _serverWorkspace;
+  if (!ws) { setPolicySaveStatus('rulesSaveStatus', 'No project workspace detected', 'status-err'); return; }
+  const disabled = _rulesCatalog.filter(r => !_rulesState[r.id]).map(r => r.id);
+  setPolicySaveStatus('rulesSaveStatus', 'Saving…', 'status-saving');
+  try {
+    const result = await apiFetch('/api/policy/rules', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspace: ws, disabled }),
+    });
+    if (result.ok) {
+      _rulesCatalog.forEach(r => { r.enabled = _rulesState[r.id]; });
+      setPolicySaveStatus('rulesSaveStatus', '✓ Saved · ' + disabled.length + ' disabled', 'status-ok');
+      renderRules();
+    } else {
+      setPolicySaveStatus('rulesSaveStatus', '✗ ' + (result.error || 'Save failed'), 'status-err');
+    }
+  } catch (e) {
+    setPolicySaveStatus('rulesSaveStatus', '✗ ' + e, 'status-err');
+  }
+});
 
 // Global policy save / discard / reset
 document.getElementById('globalPolicySave').addEventListener('click', async () => {

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -248,9 +248,12 @@ def _dispatcher_command(*, repo_root: Path, workspace: Path, agent: str, mode: s
     # — rather than a raw path to warden/cli.py — keeps the hook working across
     # editable installs (no physical file to vanish) and avoids depending on the
     # `immunity` console-script being on PATH inside the IDE's hook environment.
+    #
+    # PYTHONPATH is prepended so the hook works regardless of how the IDE/agent
+    # launcher configures the environment (Claude Code strips user site-packages).
     py = sys.executable or "python3"
     return (
-        f'"{py}" -m warden.immunity_cli hook-dispatch '
+        f'PYTHONPATH="{repo_root}" "{py}" -m warden.immunity_cli hook-dispatch '
         f'--agent {agent} --workspace "{workspace}" --mode {mode}'
     )
 

--- a/warden/scoped_agent.py
+++ b/warden/scoped_agent.py
@@ -66,6 +66,7 @@ Rules:
 - If the task involves reading/editing code, allow Read/Edit/Write for relevant paths
 - If the task does NOT mention network, web, fetch, install, or download, set deny_network: true
 - Always include Read in allowed_tools (agents need to read files to orient)
+- If the task prompt contains @@SECRET:name@@ placeholders, always include Bash in allowed_tools — the runtime cloaking layer requires shell execution (curl/bash) to substitute and scrub secrets at execution time
 """
 
 
@@ -129,11 +130,31 @@ def synthesize_scoped_rules(
         rules["allowed_tools"] = [t for t in rules["allowed_tools"] if t in available_set]
         rules["deny_tools"] = [t for t in rules["deny_tools"] if t in available_set]
 
-        return rules
+        return _apply_cloak_invariant(rules, goal)
 
     except Exception as exc:
         sys.stderr.write(f"[warden] scoped agent API error: {exc} — using static fallback.\n")
         return _static_fallback_rules(goal, available_tools)
+
+
+def _apply_cloak_invariant(rules: Dict[str, Any], goal: str) -> Dict[str, Any]:
+    """Enforce the cloaking invariant deterministically, regardless of how the
+    rules were produced (LLM or static heuristic).
+
+    A prompt that references a cloaked secret (``@@SECRET:name@@``) can only be
+    fulfilled by a shell tool call — the decloak hook substitutes the real value
+    into a Bash command at execution time. So Bash MUST be allowed and network
+    MUST be permitted whenever the goal carries a placeholder. The LLM path is
+    advisory and sometimes drops Bash; this code-level guard makes the
+    invariant non-negotiable so the secret-cloaking flow never self-blocks.
+    """
+    if "@@secret:" not in goal.lower():
+        return rules
+    allowed = [t for t in rules.get("allowed_tools", []) if t != "Bash"]
+    rules["allowed_tools"] = allowed + ["Bash"]
+    rules["deny_tools"] = [t for t in rules.get("deny_tools", []) if t != "Bash"]
+    rules["deny_network"] = False
+    return rules
 
 
 def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, Any]:
@@ -162,12 +183,14 @@ def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, A
 
     deny = [t for t in available_tools if t not in allowed]
 
-    return {
+    rules = {
         "allowed_tools": sorted(allowed),
         "allowed_paths": ["**"],  # broad by default in static mode
         "deny_tools": deny,
         "deny_network": deny_network,
     }
+    # Cloaked-secret placeholders always require Bash (decloak runs in shell).
+    return _apply_cloak_invariant(rules, goal)
 
 
 # ── Sidecar persistence ───────────────────────────────────────────────────

--- a/warden/server.py
+++ b/warden/server.py
@@ -44,6 +44,8 @@ from warden.store import (
     get_enrollment,
     read_policy_layer,
     write_policy_layer,
+    get_policy_rule_catalog,
+    set_project_rule_states,
     get_session_scoped_detail,
     update_session_control,
 )
@@ -158,6 +160,19 @@ class WardenRequestHandler(BaseHTTPRequestHandler):
             self._send_json(result)
             return
 
+        if path == "/api/policy/rules":
+            workspace = self._resolve_workspace(qs)
+            try:
+                rules = get_policy_rule_catalog(workspace)
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=500)
+                return
+            self._send_json({
+                "rules": rules,
+                "workspace": str(workspace) if workspace else None,
+            })
+            return
+
         if path == "/api/stats":
             try:
                 days = max(1, qint("days", 7))
@@ -264,6 +279,24 @@ class WardenRequestHandler(BaseHTTPRequestHandler):
                     return
                 result = write_policy_layer("project", content, workspace)
                 self._send_json(result, status=200 if result["ok"] else 400)
+            except Exception as exc:
+                self._send_json({"ok": False, "error": str(exc)}, status=500)
+            return
+
+        if path == "/api/policy/rules":
+            try:
+                body = self._read_json_body()
+                disabled = body.get("disabled", [])
+                ws_str = body.get("workspace")
+                workspace = Path(ws_str) if ws_str else _SERVER_WORKSPACE
+                if not workspace:
+                    self._send_json({"ok": False, "error": "workspace required"}, status=400)
+                    return
+                if not isinstance(disabled, list):
+                    self._send_json({"ok": False, "error": "disabled must be a list"}, status=400)
+                    return
+                result = set_project_rule_states(workspace, [str(x) for x in disabled])
+                self._send_json(result, status=200 if result.get("ok") else 400)
             except Exception as exc:
                 self._send_json({"ok": False, "error": str(exc)}, status=500)
             return

--- a/warden/store.py
+++ b/warden/store.py
@@ -1,10 +1,73 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+
+# ── Re-cloaking: never persist a raw secret value to the audit store ─────────
+#
+# A decloak hook substitutes the real secret into a command for execution. The
+# PostToolUse event therefore carries the resolved command (and possibly the
+# command's stdout/stderr). Storing that verbatim would leak the secret into the
+# session log and SQLite store — defeating the whole cloaking guarantee. We scrub
+# every registered secret value back to its @@SECRET:name@@ placeholder at the
+# single persistence choke point, so no event can ever land a raw value on disk.
+
+def _secrets_dir() -> Path:
+    env = os.environ.get("PRISMOR_SECRETS_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".prismor" / "secrets"
+
+
+def _load_secret_map() -> List[tuple[str, str]]:
+    """Return [(real_value, placeholder), …], longest value first so that a
+    value which is a substring of another is replaced after the longer one.
+    Only values of length >= 8 are considered, to avoid over-eager replacement
+    of short, low-entropy strings."""
+    sdir = _secrets_dir()
+    if not sdir.is_dir():
+        return []
+    pairs: List[tuple[str, str]] = []
+    for f in sdir.iterdir():
+        if not f.is_file():
+            continue
+        try:
+            value = f.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if len(value) >= 8:
+            pairs.append((value, f"@@SECRET:{f.name}@@"))
+    pairs.sort(key=lambda p: len(p[0]), reverse=True)
+    return pairs
+
+
+def _recloak_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Replace any raw secret value with its placeholder across all string
+    fields of an event (recursively). Returns a scrubbed copy; the input is not
+    mutated. A no-op when the vault is empty or no value appears in the event."""
+    secret_map = _load_secret_map()
+    if not secret_map:
+        return event
+
+    def scrub(obj: Any) -> Any:
+        if isinstance(obj, str):
+            s = obj
+            for real, placeholder in secret_map:
+                if real in s:
+                    s = s.replace(real, placeholder)
+            return s
+        if isinstance(obj, list):
+            return [scrub(x) for x in obj]
+        if isinstance(obj, dict):
+            return {k: scrub(v) for k, v in obj.items()}
+        return obj
+
+    return scrub(event)
 
 
 # ── Global workspace registry ────────────────────────────────────────────────
@@ -82,6 +145,7 @@ def session_log_path(workspace: Path, session_id: str) -> Path:
 
 def append_session_event(workspace: Path, session_id: str, event: Dict[str, Any]) -> Path:
     ensure_data_dirs(workspace)
+    event = _recloak_event(event)
     log_path = session_log_path(workspace, session_id)
     with log_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(event))
@@ -235,6 +299,9 @@ def save_session_snapshot(
     analysis: Dict[str, Any],
 ) -> Path:
     db_path = initialize_database(workspace)
+    # Defense in depth: ensure no raw secret value reaches the SQLite store,
+    # even if a caller passes events that did not pass through append_session_event.
+    events = [_recloak_event(e) for e in events]
     timestamps = sorted(event.get("ts") for event in events if event.get("ts"))
     started_at = timestamps[0] if timestamps else None
     updated_at = timestamps[-1] if timestamps else None
@@ -1701,6 +1768,89 @@ def write_policy_layer(scope: str, content: str, workspace: Optional[Path] = Non
         return {"ok": True, "path": str(path)}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
+
+
+def get_policy_rule_catalog(workspace: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Return every rule from the bundled default policy with its current
+    enabled state — the data behind the dashboard's per-rule toggle list.
+    A rule is "off" when the project override lists it with enabled: false.
+    """
+    from warden.policy_engine import _load_yaml
+
+    disabled: set = set()
+    if workspace:
+        ppath = _project_policy_path(workspace)
+        if ppath.exists():
+            try:
+                pdata = _load_yaml(ppath) or {}
+                for r in pdata.get("rules", []):
+                    if isinstance(r, dict) and not r.get("enabled", True):
+                        disabled.add(r.get("id"))
+            except Exception:
+                pass
+
+    default_path = Path(__file__).resolve().parent / "default_policy.yaml"
+    rules: List[Dict[str, Any]] = []
+    try:
+        data = _load_yaml(default_path) or {}
+        for r in data.get("rules", []):
+            rid = r.get("id")
+            if not rid:
+                continue
+            rules.append({
+                "id": rid,
+                "severity": r.get("severity", "MEDIUM"),
+                "category": r.get("category", ""),
+                "title": r.get("title", rid),
+                "action": r.get("action", ""),
+                "enabled": rid not in disabled,
+            })
+    except Exception:
+        pass
+    return rules
+
+
+def set_project_rule_states(workspace: Path, disabled_ids: List[str]) -> Dict[str, Any]:
+    """Persist per-rule enable/disable to the project policy, preserving any
+    other settings (mode, allowlists) already in the file. ``disabled_ids`` is
+    the list of rule ids to turn off; everything else stays enabled."""
+    if not workspace:
+        return {"ok": False, "error": "workspace required"}
+    from warden.policy_engine import _load_yaml
+
+    ppath = _project_policy_path(workspace)
+    data: Dict[str, Any] = {}
+    if ppath.exists():
+        try:
+            loaded = _load_yaml(ppath)
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+
+    data.setdefault("version", "1.0")
+    seen: List[str] = []
+    rules_block: List[Dict[str, Any]] = []
+    for rid in disabled_ids or []:
+        if rid and rid not in seen:
+            seen.append(rid)
+            rules_block.append({"id": rid, "enabled": False})
+    data["rules"] = rules_block
+
+    try:
+        import yaml
+        content = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    except Exception:
+        lines = [f'version: "{data.get("version", "1.0")}"', "", "rules:"]
+        if rules_block:
+            for r in rules_block:
+                lines.append(f"  - id: {r['id']}")
+                lines.append("    enabled: false")
+        else:
+            lines[-1] = "rules: []"
+        content = "\n".join(lines) + "\n"
+
+    return write_policy_layer("project", content, workspace)
 
 
 def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Hardens the secret-cloaking path end-to-end and improves the policy-management UX in both the CLI and the dashboard. All changes were developed and verified together this session (locally on macOS and on a Linux box).

## Cloaking — keep real secret values out of model context and the audit log

- **scoped_agent**: force-allow `Bash` whenever a prompt references a `@@SECRET` placeholder. The scoped-agent was synthesizing per-session rules that put `Bash` in `deny_tools` for "fetch"-type tasks, so the decloak flow self-blocked. The invariant is now enforced in code on both the LLM and static-fallback paths, so it can't be dropped.
- **store**: re-cloak every event before persistence. The PostToolUse event was logging the *decloaked* command (real token in plaintext) to the session log and SQLite store. Now every registered secret value is scrubbed back to its placeholder at the single persistence choke point — no raw value ever lands on disk.
- **userprompt-guard**: strip already-cloaked `@@SECRET:name@@` placeholders before scanning, so the placeholder syntax itself no longer trips secret detection.
- **hooks**: bake `PYTHONPATH` into the dispatcher command so the `warden` module resolves under Claude Code's stripped environment.

## Setup wizard

- Replace the binary "enable cloaking? y/n" prompt with a flat multi-select hook checklist (one line + description per hook).

## Policy editor (CLI)

- Rewrite `immunity policy edit`: scrolling viewport + title truncation (fixes wrapping and the cursor running off-screen), live `/` search, and `a`/`n` operating on the filtered set. Arrow keys fixed by reading at the raw fd level (the previous `select()` + buffered-stdin combo swallowed arrow sequences) with SS3 cursor support.

## Dashboard

- New **per-rule toggle list** in Policy Control: search, enable/disable switches, save to the project policy. Backed by `GET /api/policy/rules` (catalog with enabled state) and `PUT /api/policy/rules` (writes project policy, preserving other settings).
- **"Explore Prismor Cloud" CTA** linking to prismor.dev.

## Verification

- Cloak flow recorded end-to-end; audit log shows only placeholders.
- Blocking/warn scenarios verified via `immunity check` on macOS **and** a Linux box — identical results.
- Policy-edit TUI driven through a PTY: scrolling, search, truncation, and arrow movement (CSI + SS3) all confirmed.
- Dashboard endpoints exercised live (catalog read, save roundtrip); inline JS passes `node --check`.

> Note: visual screenshot of the dashboard wasn't possible in this environment — please eyeball the rendered Rules pane + CTA.

https://claude.ai/code/session_012E7H5FyKpBJphE1HyE2TzT
