### PR TITLE
refactor: rebrand Immunity Agent → Prismor (user-facing strings)

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -66,7 +66,7 @@ _Last updated: 2026-06-17._
 
 ### Hermes (NousResearch gateway)
 
-Immunity Agent integrates with Hermes at two complementary layers:
+Prismor integrates with Hermes at two complementary layers:
 
 **1. Runtime hooks** (for policy enforcement and session monitoring):
 - **Config:** `~/.hermes/config.json` — registers a JS plugin scaffolded at `warden/hermes-plugin/`.

--- a/PYPI.md
+++ b/PYPI.md
@@ -8,7 +8,7 @@ Runtime security for AI coding agents. Policy enforcement, secret prevention, su
 
 ## What it does
 
-AI coding agents execute shell commands, read files, call APIs, and install packages autonomously. Immunity Agent sits between the agent and the operating system to:
+AI coding agents execute shell commands, read files, call APIs, and install packages autonomously. Prismor sits between the agent and the operating system to:
 
 - **Block dangerous actions** before they run — destructive commands, privilege escalation, reverse shells, secret exfiltration
 - **Intercept package installs** and score them for supply-chain risk before they touch your disk

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 
 ## Capabilities
 
-![Immunity Agent Architecture](assets/immunity-highlevel.png)
+![Prismor Architecture](assets/immunity-highlevel.png)
 
 - 🛡️ [Warden](docs/warden.md) covers the policy engine, session logs, security audit, and CLI reference
 - 📦 [Supply Chain](docs/supply-chain.md) covers install-time enforcement, IOC matching, and risk scoring
@@ -80,7 +80,7 @@ Detects your environment and uses the right install method automatically.
 
 **Option B: give your agent a skill (zero-interrupt setup):**
 
-Point your agent at [`SKILL.md`](SKILL.md). It is a standing instruction file: the agent reads it at session start, checks whether Immunity is installed, and follows the decision tree throughout the session without pausing your workflow.
+Point your agent at [`SKILL.md`](SKILL.md). It is a standing instruction file: the agent reads it at session start, checks whether Prismor is installed, and follows the decision tree throughout the session without pausing your workflow.
 
 For Claude Code, add to your `CLAUDE.md`:
 
@@ -158,7 +158,7 @@ prismor install-hooks --agent all --mode enforce    # honor policy enforce rules
 
 ---
 
-## Disabling Immunity Agent
+## Disabling Prismor
 
 There are three independent layers that can each restrict an agent session. Disabling one does not disable the others — pick the layer that matches what you're actually trying to turn off.
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -2,7 +2,7 @@
 
 **Status:** ✅ Shipped (v1.6.0)
 
-Immunity Agent's secret cloaking layer is available for [Hermes Agent](https://hermes-agent.nousresearch.com) (Nous Research's AI agent platform). This doc covers setup, architecture, and behavior.
+Prismor's secret cloaking layer is available for [Hermes Agent](https://hermes-agent.nousresearch.com) (Nous Research's AI agent platform). This doc covers setup, architecture, and behavior.
 
 ---
 

--- a/docs/issues-fix/scoped-agent-blocks-implementation.md
+++ b/docs/issues-fix/scoped-agent-blocks-implementation.md
@@ -19,10 +19,10 @@ Every subsequent tool call in the session checks against that cached file. If th
 ## Observed Behavior
 
 ```
-PreToolUse:Bash hook error: Prismor Immunity Agent blocked this action:
+PreToolUse:Bash hook error: Prismor blocked this action:
   [HIGH] [scoped agent] Tool 'Bash' is explicitly denied for this session
 
-PreToolUse:Edit hook error: Prismor Immunity Agent blocked this action:
+PreToolUse:Edit hook error: Prismor blocked this action:
   [HIGH] [scoped agent] Tool 'Edit' is explicitly denied for this session
 ```
 

--- a/docs/policy-layers-and-exemptions.md
+++ b/docs/policy-layers-and-exemptions.md
@@ -1,6 +1,6 @@
 # Layered Policy & Admin-Granted Exemptions
 
-*How Immunity policy applies at global / project / repo levels, and how a
+*How Prismor policy applies at global / project / repo levels, and how a
 developer gets an exemption for a specific repo without being able to silently
 bypass security — with full telemetry visibility. Companion to the
 scoped-agent design ([docs/scoped-agent.md](scoped-agent.md)) and

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -1,6 +1,6 @@
 # Supply Chain Enforcement
 
-Immunity Agent wraps your package manager so every install is evaluated before it runs. The `prismor` CLI intercepts the command, scores each package against live threat intelligence, then either passes through to the real package manager or blocks with a reason.
+Prismor wraps your package manager so every install is evaluated before it runs. The `prismor` CLI intercepts the command, scores each package against live threat intelligence, then either passes through to the real package manager or blocks with a reason.
 
 ---
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -276,7 +276,7 @@ def header_lines(step=None, total=None, label=None):
     tw = term_width()
     out = [
         "",
-        f"  {w('PRISMOR IMMUNITY AGENT', BOLD, CYAN)}  {w('· ' + VERSION, DIM)}",
+        f"  {w('PRISMOR', BOLD, CYAN)}  {w('· ' + VERSION, DIM)}",
     ]
     if step and label:
         out.append(f"  {w(f'Step {step}/{total}', DIM)}  {w(label, BOLD)}")
@@ -473,7 +473,7 @@ def do_install(target, mode, rules, agents, hooks=None):
     sys.stdout.write(ALT_OFF)
     sys.stdout.write("\033[H\033[J" + HIDE)
     sys.stdout.flush()
-    print(w("  Installing Prismor Immunity Agent...\n", BOLD, CYAN))
+    print(w("  Installing Prismor...\n", BOLD, CYAN))
 
     if hooks is None:
         hooks = _default_hooks()
@@ -546,8 +546,8 @@ def do_install(target, mode, rules, agents, hooks=None):
     def update_claude():
         md = target / "CLAUDE.md"
         block = (
-            "\n## Security (Prismor Immunity Agent)\n\n"
-            "This workspace is protected by Prismor Immunity Agent — runtime "
+            "\n## Security (Prismor)\n\n"
+            "This workspace is protected by Prismor — runtime "
             "security hooks that monitor tool calls in real time (destructive "
             "commands, secret leaks, supply-chain risk, prompt injection).\n\n"
             "Run `prismor status` at the start of a session to check protection "
@@ -634,7 +634,7 @@ def do_install(target, mode, rules, agents, hooks=None):
     home = str(Path.home())
     print()
     print(w("  ╭───────────────────────────────────────────╮", DIM))
-    print(w("  │", DIM) + w("  Prismor Immunity Agent installed successfully!    ", GRN, BOLD) + w("│", DIM))
+    print(w("  │", DIM) + w("  Prismor installed successfully!    ", GRN, BOLD) + w("│", DIM))
     print(w("  ╰───────────────────────────────────────────╯", DIM))
     print()
     def info(k, v):

--- a/supplychain/__init__.py
+++ b/supplychain/__init__.py
@@ -1,1 +1,1 @@
-"""Immunity supply chain enforcement — intercepts package installs before execution."""
+"""Prismor supply chain enforcement — intercepts package installs before execution."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestCliExitCodes(unittest.TestCase):
     def test_help_exits_zero(self):
         r = run_cli("--help")
         self.assertEqual(r.returncode, 0)
-        self.assertIn("Prismor Immunity Agent", r.stdout)
+        self.assertIn("Prismor", r.stdout)
 
     def test_version_exits_zero(self):
         r = run_cli("--version")
@@ -51,7 +51,7 @@ class TestCliExitCodes(unittest.TestCase):
     def test_bare_invocation_exits_zero(self):
         r = run_cli()
         self.assertEqual(r.returncode, 0)
-        self.assertIn("Prismor Immunity Agent", r.stdout)
+        self.assertIn("Prismor", r.stdout)
 
     def test_analyze_help(self):
         r = run_cli("analyze", "--help")
@@ -106,7 +106,7 @@ class TestCliAnalyze(unittest.TestCase):
     def test_analyze_text_output(self):
         r = run_cli("analyze", "--input", SAMPLE)
         self.assertEqual(r.returncode, 0)
-        self.assertIn("Prismor Immunity Agent Report", r.stdout)
+        self.assertIn("Prismor Report", r.stdout)
         self.assertIn("Findings:", r.stdout)
         self.assertIn("CRITICAL", r.stdout)
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prismor Immunity Agent CLI — local session-security utility for AI coding agents.
+"""Prismor CLI — local session-security utility for AI coding agents.
 
 Commands:
   check         Quick pre-check a command or file path against policy rules
@@ -478,7 +478,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         summary = result["summary"]
 
         print()
-        print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  skill scanner")
+        print(f"  {_color('PRISMOR', _BOLD)}  skill scanner")
         print(f"  {_color('─' * 50, _DIM)}")
         print()
 
@@ -543,7 +543,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             return
 
         print()
-        print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  dependency check")
+        print(f"  {_color('PRISMOR', _BOLD)}  dependency check")
         print(f"  {_color('─' * 50, _DIM)}")
         print()
 
@@ -614,7 +614,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             return
 
         print()
-        print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  security audit")
+        print(f"  {_color('PRISMOR', _BOLD)}  security audit")
         print(f"  {_color('─' * 58, _DIM)}")
         print()
 
@@ -1010,7 +1010,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     reason += f"\nRecommended fix: {blocking['remediation']}"
                 sys.stdout.write(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}) + "\n")
             else:
-                sys.stderr.write(f"Prismor Immunity Agent blocked this action: [{blocking['severity']}] {blocking['title']}\n")
+                sys.stderr.write(f"Prismor blocked this action: [{blocking['severity']}] {blocking['title']}\n")
                 if blocking.get("evidence"):
                     sys.stderr.write(f"{blocking['evidence']}\n")
                 if blocking.get("remediation"):
@@ -1084,7 +1084,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 print(json.dumps(report, indent=2))
                 return
             print()
-            print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  sandbox status")
+            print(f"  {_color('PRISMOR', _BOLD)}  sandbox status")
             print(f"  {_color('─' * 50, _DIM)}")
             print()
             print(f"  {_color('Enabled:', _GREEN)}      {report['enabled']}")
@@ -1182,7 +1182,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
         if subcmd == "list" or subcmd is None:
             active = _get_agent_id()
-            print(f"\n  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  agent identities\n")
+            print(f"\n  {_color('PRISMOR', _BOLD)}  agent identities\n")
             if not agent_ids:
                 print(f"  {_color('No agents defined.', _DIM)}")
                 print(f"  Run: prismor iam init\n")
@@ -1562,7 +1562,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             if not entries:
                 print("No canaries planted. Try:  prismor canary plant ~/.aws/credentials.canary --type aws")
                 return
-            print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  canaries")
+            print(f"  {_color('PRISMOR', _BOLD)}  canaries")
             print(f"  {_color('─' * 50, _DIM)}")
             for e in entries:
                 print(f"  {e['id']}  {e['type']:7s}  {e['path']}")
@@ -1650,7 +1650,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             if not sessions:
                 print("No active scoped sessions.")
                 return
-            print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  scoped sessions")
+            print(f"  {_color('PRISMOR', _BOLD)}  scoped sessions")
             print(f"  {_color('─' * 50, _DIM)}")
             for s in sessions:
                 tools = ", ".join(s["rules"].get("allowed_tools", []))
@@ -1726,7 +1726,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             if not pending:
                 print("No pending candidate rules.")
                 return
-            print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  candidate rules")
+            print(f"  {_color('PRISMOR', _BOLD)}  candidate rules")
             print(f"  {_color('─' * 50, _DIM)}")
             for c in pending:
                 rule = c["rule"]
@@ -1805,7 +1805,7 @@ def build_parser() -> argparse.ArgumentParser:
         # usage/error strings to it instead of leaking the module filename
         # (argparse otherwise shows "immunity_cli.py" in subcommand usage/errors).
         prog="immunity",
-        description="Prismor Immunity Agent — runtime security for AI coding agents.",
+        description="Prismor — runtime security for AI coding agents.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--workspace", help="Workspace path (applies to all commands)")
@@ -2318,7 +2318,7 @@ def _print_dashboard(days: int = 7) -> None:
 
     # ── Header ────────────────────────────────────────────────────────────
     print()
-    print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  all workspaces")
+    print(f"  {_color('PRISMOR', _BOLD)}  all workspaces")
     print(f"  {'─' * 50}")
     print()
 
@@ -2496,7 +2496,7 @@ def _print_status_overview(workspace: Path) -> None:
     ws_display = str(workspace).replace(home, "~")
 
     print()
-    print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  status")
+    print(f"  {_color('PRISMOR', _BOLD)}  status")
     print(f"  {_color('─' * 50, _DIM)}")
     print()
     print(f"  {_color('Workspace:', _GREEN)}   {ws_display}")
@@ -2672,7 +2672,7 @@ def _policy_test(workspace: Path, test_file: Optional[str] = None) -> None:
 
     result = run_cases(cases, workspace=workspace)
     print()
-    print(f"  {_color('PRISMOR IMMUNITY AGENT', _BOLD)}  policy tests ({path.name})")
+    print(f"  {_color('PRISMOR', _BOLD)}  policy tests ({path.name})")
     print(f"  {_color('─' * 50, _DIM)}")
     print()
 
@@ -2830,7 +2830,7 @@ def _policy_edit(workspace: Path) -> None:
 
         n_on = sum(1 for r in all_rules if r["on"])
         buf = "\033[H\033[J\033[?25l"  # home, clear, hide cursor
-        buf += f"\n  {_BOLD}PRISMOR IMMUNITY AGENT{_NC}  policy edit"
+        buf += f"\n  {_BOLD}PRISMOR{_NC}  policy edit"
         buf += f"   {_DIM}{n_on}/{len(all_rules)} enabled"
         if query:
             buf += f"  ·  filter {_CYAN}“{query}”{_NC}{_DIM} → {len(vis)}"
@@ -3012,7 +3012,7 @@ def format_sarif(
         "runs": [{
             "tool": {
                 "driver": {
-                    "name": "Prismor Immunity Agent",
+                    "name": "Prismor",
                     "version": __version__,
                     "informationUri": "https://github.com/PrismorSec/prismor",
                     "rules": sarif_rules,
@@ -3129,7 +3129,7 @@ def _redact_evidence(evidence: str) -> str:
 
 def format_sessions(payload: Dict[str, Any]) -> str:
     sessions = payload["sessions"]
-    lines = ["Prismor Immunity Agent Sessions", "======================"]
+    lines = ["Prismor Sessions", "======================"]
     if not sessions:
         lines.append("No sessions stored.")
         return "\n".join(lines)
@@ -3157,7 +3157,7 @@ def format_sessions(payload: Dict[str, Any]) -> str:
 
 def format_analysis(result: Dict[str, Any]) -> str:
     lines = [
-        "Prismor Immunity Agent Report",
+        "Prismor Report",
         "=====================",
         f"Events: {result['summary']['totalEvents']}",
         f"Findings: {result['summary']['totalFindings']}",

--- a/warden/dashboard.html
+++ b/warden/dashboard.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Prismor Immunity-agent Dashboard</title>
+<title>Prismor Dashboard</title>
 <link rel="icon" type="image/png" href="https://prismor.dev/Prismor_Logo.png" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <style>
@@ -710,7 +710,7 @@
 <!-- ═══ TOP BAR ═══════════════════════════════════════════════════ -->
 <div class="topbar">
   <div class="topbar-left">
-    <h1>Prismor Immunity</h1>
+    <h1>Prismor</h1>
   </div>
   <div class="topbar-right">
     <span id="lastUpdated" class="last-updated"></span>
@@ -1169,7 +1169,7 @@
 <div id="loadingScreen">
   <div id="loadingCard">
     <img src="https://prismor.dev/Prismor_Logo.png" id="loadingLogo" alt="Prismor" />
-    <div id="loadingTitle">Prismor Immunity</div>
+    <div id="loadingTitle">Prismor</div>
     <div id="loadingBar"><div id="loadingFill"></div></div>
     <div id="loadingLabel">Loading dashboard…</div>
   </div>

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -405,7 +405,7 @@ function dispatch(payload) {
   } catch (err) {
     if (err.status === 2) {
       const stderr = (err.stderr || "").toString().trim();
-      return { block: true, reason: stderr || "Blocked by Prismor Immunity Agent" };
+      return { block: true, reason: stderr || "Blocked by Prismor" };
     }
     return { block: false };
   }
@@ -541,7 +541,7 @@ function dispatch(payload) {
   } catch (err) {
     if (err.status === 2) {
       const stderr = (err.stderr || "").toString().trim();
-      return { block: true, reason: stderr || "Blocked by Prismor Immunity Agent" };
+      return { block: true, reason: stderr || "Blocked by Prismor" };
     }
     return { block: false };
   }

--- a/warden/setup_wizard.py
+++ b/warden/setup_wizard.py
@@ -255,7 +255,7 @@ def _header_lines(step: Optional[int] = None, total: Optional[int] = None, label
     tw = _term_width()
     out = [
         "",
-        f"  {_w('PRISMOR IMMUNITY AGENT', BOLD, CYAN)}  {_w('· ' + _VERSION, DIM)}",
+        f"  {_w('PRISMOR', BOLD, CYAN)}  {_w('· ' + _VERSION, DIM)}",
     ]
     if step and label:
         out.append(f"  {_w(f'Step {step}/{total}', DIM)}  {_w(label, BOLD)}")
@@ -486,8 +486,8 @@ def _spinner_run(label: str, fn) -> None:
 
 
 _AGENT_CONTEXT_BLOCK = (
-    "\n## Security (Prismor Immunity Agent)\n\n"
-    "This workspace is protected by Prismor Immunity Agent. "
+    "\n## Security (Prismor)\n\n"
+    "This workspace is protected by Prismor. "
     "Run `prismor status` at the start of every session.\n\n"
     "Key commands:\n\n"
     "| Action | Command |\n"
@@ -561,7 +561,7 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
     sys.stdout.write(ALT_OFF)
     sys.stdout.write("\033[H\033[J" + HIDE)
     sys.stdout.flush()
-    print(_w("  Installing Prismor Immunity Agent...\n", BOLD, CYAN))
+    print(_w("  Installing Prismor...\n", BOLD, CYAN))
 
     target = target.resolve()
 
@@ -648,8 +648,8 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
     def _update_claude():
         md = target / "CLAUDE.md"
         block = (
-            "\n## Security (Prismor Immunity Agent)\n\n"
-            "This workspace is protected by Prismor Immunity Agent — runtime "
+            "\n## Security (Prismor)\n\n"
+            "This workspace is protected by Prismor — runtime "
             "security hooks that monitor tool calls in real time (destructive "
             "commands, secret leaks, supply-chain risk, prompt injection).\n\n"
             "Run `prismor status` at the start of a session to check protection "
@@ -715,7 +715,7 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
     home = str(Path.home())
     print()
     print(_w("  ╭───────────────────────────────────────────╮", DIM))
-    print(_w("  │", DIM) + _w("  Prismor Immunity Agent installed successfully!    ", GRN, BOLD) + _w("│", DIM))
+    print(_w("  │", DIM) + _w("  Prismor installed successfully!    ", GRN, BOLD) + _w("│", DIM))
     print(_w("  ╰───────────────────────────────────────────╯", DIM))
     print()
 


### PR DESCRIPTION
## Summary

Follows the CLI/package rename (#87, merged) by rebranding the product name from "Prismor Immunity Agent" / "Immunity Agent" to just **Prismor** in user-facing strings. Pure string changes; 612 tests pass.

## What changed

- **Live block message** users see: `Prismor Immunity Agent blocked this action` → `Prismor blocked this action` (`warden/cli.py`, `warden/hooks.py`)
- CLI section banners `PRISMOR IMMUNITY AGENT` → `PRISMOR`
- Setup wizard output, session/report headers, argparse description → `Prismor`
- Dashboard title/heading → `Prismor`
- Docs brand prose (README, PYPI, AGENT_INTEGRATIONS, hermes, supply-chain, policy-layers) → `Prismor`
- `test_cli` assertions updated to match the new output

## Kept on purpose

- The `formerly Immunity Agent` notes in README/PYPI
- CHANGELOG history
- The signed advisories feed and its "Immunity Intelligence Feed" sub-brand
- The `warden.immunity_cli` module and the `.claude/skills/immunity-agent` skill path/name

