### PR TITLE
feat(sinks): OCSF formatter + native Splunk HEC & Datadog sinks

### DIFF
--- a/tests/test_sinks_ocsf.py
+++ b/tests/test_sinks_ocsf.py
@@ -1,0 +1,98 @@
+"""Tests for OCSF formatting and the Splunk/Datadog sink dispatchers."""
+import json
+from pathlib import Path
+
+from warden import sinks
+
+
+def _event():
+    finding = {
+        "severity": "CRITICAL",
+        "category": "secret_exfiltration",
+        "ruleId": "secret-exfiltration",
+        "action": "block",
+        "title": "Secret file piped to network",
+        "evidence": ".env | curl webhook.site",
+        "id": "sess_4f2a:finding-1",
+    }
+    return sinks._build_event(finding, extra={"subject": {"user_id": "alice"}})
+
+
+def test_format_ocsf_shape():
+    ocsf = sinks._format_ocsf(_event())
+    # Detection Finding class + matching type_uid (class_uid*100 + activity_id).
+    assert ocsf["class_uid"] == 2004
+    assert ocsf["category_uid"] == 2
+    assert ocsf["type_uid"] == 200401
+    assert ocsf["activity_id"] == 1
+    # CRITICAL maps to OCSF severity_id 5.
+    assert ocsf["severity_id"] == 5
+    assert ocsf["metadata"]["product"]["vendor_name"] == "Prismor"
+    assert ocsf["finding_info"]["title"] == "Secret file piped to network"
+    assert ocsf["unmapped"]["rule_id"] == "secret-exfiltration"
+    assert ocsf["unmapped"]["subject"] == {"user_id": "alice"}
+    # Must be JSON-serializable (SIEMs ingest JSON).
+    json.dumps(ocsf)
+
+
+def test_severity_mapping():
+    for name, sid in (("LOW", 2), ("MEDIUM", 3), ("HIGH", 4), ("CRITICAL", 5)):
+        ev = sinks._build_event({"severity": name, "title": "t"})
+        assert sinks._format_ocsf(ev)["severity_id"] == sid
+
+
+def test_file_sink_ocsf_format(tmp_path: Path):
+    out = tmp_path / "audit.log"
+    sinks._dispatch_file({"path": str(out), "format": "ocsf"}, _event())
+    line = out.read_text().strip()
+    parsed = json.loads(line)  # one OCSF JSON object per line
+    assert parsed["class_uid"] == 2004
+    assert parsed["severity_id"] == 5
+
+
+def test_dispatchers_registered():
+    assert "splunk" in sinks._DISPATCHERS
+    assert "datadog" in sinks._DISPATCHERS
+
+
+def test_splunk_and_datadog_post(monkeypatch):
+    # Capture the outbound request instead of hitting the network.
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, *_):
+            return b""
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = {k.lower(): v for k, v in req.header_items()}
+        captured["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    sinks._dispatch_splunk_hec(
+        {"url": "https://splunk.example:8088/services/collector", "token": "tok123"}, _event()
+    )
+    assert captured["headers"]["authorization"] == "Splunk tok123"
+    assert captured["body"]["event"]["class_uid"] == 2004
+
+    sinks._dispatch_datadog({"api_key": "ddkey"}, _event())
+    assert captured["headers"]["dd-api-key"] == "ddkey"
+    assert "datadoghq.com" in captured["url"]
+    # Datadog payload is a list with one log record carrying the OCSF message.
+    assert json.loads(captured["body"][0]["message"])["class_uid"] == 2004
+
+
+def test_dispatchers_swallow_errors_without_config():
+    # Missing required config must no-op, never raise (dispatch is best-effort).
+    sinks._dispatch_splunk_hec({}, _event())
+    sinks._dispatch_datadog({}, _event())

--- a/warden/sinks.py
+++ b/warden/sinks.py
@@ -12,7 +12,14 @@ Supported sink types (configured under ``settings.outputs`` in policy.yaml):
       facility: local7
     - type: file
       path: ~/.prismor/audit.log
-      format: json     # or: cef
+      format: json     # or: cef, ocsf
+    - type: splunk              # Splunk HTTP Event Collector (OCSF body)
+      url: https://splunk.example.com:8088/services/collector
+      token: ${SPLUNK_HEC_TOKEN}
+      sourcetype: prismor:warden:ocsf
+    - type: datadog            # Datadog Logs intake (OCSF body)
+      api_key: ${DD_API_KEY}
+      site: datadoghq.com
     - type: prismor              # first-party control-plane sink
       # No config needed — the device key + endpoint come from the enrolled
       # identity at ~/.prismor/identity.json (see `prismor enroll`). Sends a
@@ -138,10 +145,54 @@ def _dispatch_file(cfg: Dict[str, Any], event: Dict[str, Any]) -> None:
     fmt = str(cfg.get("format", "json")).lower()
     if fmt == "cef":
         line = _format_cef(event)
+    elif fmt == "ocsf":
+        line = json.dumps(_format_ocsf(event))
     else:
         line = json.dumps(event)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")
+
+
+def _dispatch_splunk_hec(cfg: Dict[str, Any], event: Dict[str, Any]) -> None:
+    """Splunk HTTP Event Collector. Wraps the OCSF finding in the HEC envelope
+    and authenticates with a token. Config: url, token, [sourcetype], [index]."""
+    import urllib.request
+
+    url = cfg.get("url")
+    token = cfg.get("token")
+    if not url or not token:
+        return
+    envelope: Dict[str, Any] = {"event": _format_ocsf(event), "sourcetype": cfg.get("sourcetype", "prismor:warden:ocsf")}
+    if cfg.get("index"):
+        envelope["index"] = cfg["index"]
+    data = json.dumps(envelope).encode("utf-8")
+    headers = {"Authorization": f"Splunk {token}", "Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=float(cfg.get("timeout_seconds", 3))) as resp:
+        resp.read(16)
+
+
+def _dispatch_datadog(cfg: Dict[str, Any], event: Dict[str, Any]) -> None:
+    """Datadog Logs intake. Sends the OCSF finding with a DD-API-KEY header.
+    Config: api_key, [site] (default datadoghq.com), [service]."""
+    import urllib.request
+
+    api_key = cfg.get("api_key")
+    if not api_key:
+        return
+    site = cfg.get("site", "datadoghq.com")
+    url = cfg.get("url") or f"https://http-intake.logs.{site}/api/v2/logs"
+    payload = {
+        "ddsource": "prismor-warden",
+        "service": cfg.get("service", "warden"),
+        "ddtags": f"severity:{str(event.get('severity', '')).lower()},category:{event.get('category', '')}",
+        "message": json.dumps(_format_ocsf(event)),
+    }
+    data = json.dumps([payload]).encode("utf-8")
+    headers = {"DD-API-KEY": str(api_key), "Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=float(cfg.get("timeout_seconds", 3))) as resp:
+        resp.read(16)
 
 
 def _format_cef(event: Dict[str, Any]) -> str:
@@ -163,6 +214,57 @@ def _format_cef(event: Dict[str, Any]) -> str:
     }
     ext_str = " ".join(f"{k}={v}" for k, v in extensions.items() if v)
     return f"{header}|{ext_str}"
+
+
+# OCSF severity_id: 0 Unknown, 1 Informational, 2 Low, 3 Medium, 4 High,
+# 5 Critical, 6 Fatal. Map Warden's four levels onto Low..Critical.
+_OCSF_SEVERITY = {"CRITICAL": 5, "HIGH": 4, "MEDIUM": 3, "LOW": 2}
+
+
+def _format_ocsf(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a Warden finding event to an OCSF Detection Finding (class_uid 2004).
+
+    OCSF (Open Cybersecurity Schema Framework) is the schema-standard format
+    SIEMs such as Splunk, Datadog and Amazon Security Lake ingest natively, so
+    findings land as structured detections rather than opaque blobs. Returns a
+    dict (callers JSON-encode it). Activity is "Create" (1); type_uid is
+    class_uid * 100 + activity_id = 200401.
+    """
+    ts = event.get("@timestamp")
+    sev_name = str(event.get("severity", "LOW")).upper()
+    return {
+        "activity_id": 1,
+        "category_uid": 2,            # Findings
+        "class_uid": 2004,            # Detection Finding
+        "type_uid": 200401,
+        "severity_id": _OCSF_SEVERITY.get(sev_name, 2),
+        "severity": sev_name.capitalize(),
+        "status_id": 1,               # New
+        "time": ts,
+        "message": event.get("title") or event.get("evidence") or "Warden finding",
+        "metadata": {
+            "product": {"name": "Warden", "vendor_name": "Prismor", "version": "1.1.0"},
+            "version": "1.1.0",       # OCSF schema version
+            "log_name": "prismor-warden",
+        },
+        "finding_info": {
+            "title": event.get("title") or event.get("rule_id") or "finding",
+            "uid": event.get("finding_id"),
+            "types": [event.get("category")] if event.get("category") else [],
+        },
+        "evidences": [{"data": event.get("evidence")}] if event.get("evidence") else [],
+        "observables": [
+            {"name": "device.hostname", "type": "Hostname", "value": event.get("hostname")},
+        ],
+        # Warden-specific fields under the OCSF "unmapped" escape hatch.
+        "unmapped": {
+            "rule_id": event.get("rule_id"),
+            "category": event.get("category"),
+            "action": event.get("action"),
+            "session_id": event.get("session_id"),
+            "subject": event.get("subject"),
+        },
+    }
 
 
 def _dispatch_prismor(
@@ -294,6 +396,8 @@ _DISPATCHERS = {
     "webhook": _dispatch_webhook,
     "syslog": _dispatch_syslog,
     "file": _dispatch_file,
+    "splunk": _dispatch_splunk_hec,
+    "datadog": _dispatch_datadog,
 }
 
 


### PR DESCRIPTION
First of the competitor-gap closers (vs identity/access players like Keycard, whose enterprise tier ships OCSF continuous export). Self-contained in `warden/sinks.py`.

## What
- **`_format_ocsf(event)`** — maps a Warden finding to an **OCSF Detection Finding** (`class_uid 2004`, `type_uid 200401`); severity LOW→2 … CRITICAL→5; Warden-specific fields (`rule_id`, `category`, `action`, `session_id`, `subject`) under the OCSF `unmapped` escape hatch.
- **`file` sink** gains `format: ocsf` alongside `json`/`cef`.
- **New `splunk` sink** — HTTP Event Collector envelope + `Authorization: Splunk <token>`, OCSF body.
- **New `datadog` sink** — Logs intake (`/api/v2/logs`) + `DD-API-KEY`, OCSF body.
- Registered both in `_DISPATCHERS`. Best-effort: missing config no-ops, never raises (consistent with existing sinks).

## Why
SIEMs (Splunk, Datadog, Amazon Security Lake) ingest OCSF natively, so findings land as structured, queryable detections instead of opaque blobs — a security-procurement checkbox.

## Tests
`tests/test_sinks_ocsf.py` — 6 tests: OCSF shape, severity mapping, file `format: ocsf` round-trip, dispatcher registration, mocked Splunk/Datadog POST (asserts auth headers + OCSF body), and error-swallowing on missing config.

## Verification
- Local: `pytest tests/test_sinks_ocsf.py` → 6 passed; existing `test_enterprise_telemetry` + `test_telemetry_title_redaction` → 16 passed (no regression).
- **On st3ve** (`~/Prismor/prismor`, this branch): same 6 tests pass, plus a live end-to-end through the public `dispatch()` — a CRITICAL finding wrote a valid OCSF line (`class_uid 2004`, `severity_id 5`, `type_uid 200401`) to a `format: ocsf` file sink.

First in a sequence; credential brokering (Cloak→broker), workload attestation, and the MCP-auth SDK follow as separate PRs (they depend on the framework-adapters `Subject` work and external infra, so they ship after this).