### PR TITLE
chore(oss): open-core scaffolding — license boundary, leak guard, contributor spec

### DIFF
--- a/.github/workflows/oss-guard.yml
+++ b/.github/workflows/oss-guard.yml
@@ -1,0 +1,26 @@
+name: OSS safety guard
+
+# Fails the build if the private signing key, a secret, or other
+# must-never-ship material is tracked in the public runtime repo. The signing
+# private key and the curated premium feed live only in the private repos —
+# this is the CI gate that keeps the open-core boundary honest.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  oss-safe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Scan tracked files for leaks
+        run: python3 scripts/check_oss_safe.py
+      - name: Guard self-tests
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest tests/test_oss_guard.py -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Prismor Warden
+
+Thanks for helping make AI agents safer to run. The highest-leverage
+contribution is a **new detection rule** — every rule you add becomes a guard
+that protects every Prismor user. This is the open coverage model: the community
+extends the ruleset the way the Sigma, Falco, and Semgrep communities do.
+
+## Quick dev setup
+
+```bash
+git clone https://github.com/PrismorSec/prismor
+cd prismor
+python3 -m pip install -e .
+python3 -m pytest -q          # run the suite
+python3 scripts/check_oss_safe.py   # OSS-safety guard (no secrets/keys committed)
+```
+
+## Contributing a detection rule
+
+Rules live in [`warden/default_policy.yaml`](warden/default_policy.yaml) and follow
+the schema in [`warden/policy_schema.json`](warden/policy_schema.json). A rule is:
+
+```yaml
+- id: kebab-case-id              # unique, stable
+  severity: CRITICAL             # CRITICAL | HIGH | MEDIUM | LOW
+  category: secret_exfiltration  # one of the documented categories
+  title: One-line human description of what this blocks
+  event_types: [shell]           # shell | network | file_read | file_write | prompt | tool_result | skill_manifest
+  fields: [command]              # which event fields the patterns match against
+  patterns:
+    - 'regex that matches the dangerous payload'   # Python `re` syntax
+```
+
+**Rules ship in OBSERVE mode by default** — they log a would-be block but never
+break a user until an operator promotes them to enforce. So a good detection that
+occasionally over-matches is safe to land; a missed detection is the real cost.
+
+### Requirements for a rule PR
+
+1. **A test.** Every rule PR must add a test that proves the rule fires on the
+   malicious case **and** does not fire on a benign look-alike. Add it under
+   [`tests/`](tests/) (see `tests/test_detection_improvements.py` for the
+   pattern). False positives erode trust faster than false negatives — prove both
+   directions.
+2. **Evidence.** In the PR description, link the real attack/technique the rule
+   defends against (advisory, write-up, or a reproduction).
+3. **Patterns matched against argument *values*, not `key=value`** — the
+   `command` field carries the argument value only. (A common gotcha: a
+   word-boundary regex like `\brm -rf /` fails to match `=rm -rf /`.)
+4. **No weakening of core rules.** Rules in the non-overridable floor are
+   add-only — you may strengthen (add patterns), never disable.
+
+### How rules are reviewed
+
+`python3 -m pytest -q` is the CI gate; your test is the proof. A maintainer
+reviews for over-matching, severity/category fit, and floor safety. Curated,
+signed, real-time threat intel ships in the commercial feed — community rules are
+the open baseline everyone gets.
+
+## Contributing a framework adapter
+
+Adapters live in [`adapters/`](adapters/) and are **MIT-licensed** for maximum
+reuse. An adapter wraps a framework's tool-execution surface and routes each call
+through `warden.runtime.evaluate_tool_call()`. Mirror an existing adapter
+(`adapters/langchain`, `adapters/openai-agents`) and add a test under `tests/`.
+
+## Security & the open-core boundary
+
+- **Never commit secrets or private keys.** `scripts/check_oss_safe.py` runs in
+  CI and as a recommended pre-commit hook; it blocks PEM private keys, cloud
+  credentials, and the signing key from entering the public repo.
+- See [`OPEN_CORE.md`](OPEN_CORE.md) for what lives in the open runtime vs the
+  commercial control plane.
+- Report vulnerabilities privately — see [`SECURITY.md`](SECURITY.md).
+
+## License of contributions
+
+Contributions to the runtime are accepted under the repository's root license
+(Apache-2.0); contributions to `adapters/` under MIT. By submitting a PR you
+agree your contribution is licensed under the applicable license.

--- a/OPEN_CORE.md
+++ b/OPEN_CORE.md
@@ -1,0 +1,55 @@
+# Prismor open-core model
+
+Prismor is **open-core**. The runtime that guards your agents is open source and
+runs locally — you can read every line that touches your tool calls and secrets.
+Governing agents across a team or organization is the commercial product.
+
+The principle: **single-player is free and open; multiplayer (org governance) is
+paid.** Nothing is ever removed from the open runtime to push you to pay — the
+paid tier adds the fleet/governance layer that doesn't exist in single-player.
+
+## What's open source (this repo)
+
+| Component | Path | License |
+|---|---|---|
+| Warden runtime — interception, policy engine, enforcement | `warden/` | Apache-2.0 (root `LICENSE`) |
+| All 61 default detection rules + the rule format | `warden/default_policy.yaml`, `warden/policy_schema.json` | Apache-2.0 |
+| Coding-agent hooks (Claude Code, Cursor, Codex, …) | `warden/cloaking/hooks/` | Apache-2.0 |
+| Cloak — local secret substitution | `warden/cloaking/` | Apache-2.0 |
+| Per-machine IAM / scoped access | `warden/iam.py`, `warden/scoped_agent.py` | Apache-2.0 |
+| Local telemetry sinks (webhook, syslog, file, OCSF/CEF) | `warden/sinks.py` | Apache-2.0 |
+| Framework adapters (LangChain, CrewAI, OpenAI Agents, browser-use, Vercel AI) | `adapters/` | **MIT** (`adapters/LICENSE`) |
+| The enrolled-device **client** protocol (so you can audit what leaves the box) | `warden/enterprise/` | Apache-2.0 |
+| Public verification key | `keys/public.pub` | Apache-2.0 |
+| Eval harness / detection scenarios | `bench/`, `tests/` | Apache-2.0 |
+
+The open runtime enforces all six control dimensions **locally**, on one machine,
+with unlimited agents, tool calls, and rules — free forever.
+
+## What's commercial (not in this repo)
+
+The control plane (`prismor-web`) and the assets that anchor trust at scale:
+
+- Org dashboard, fleet observability, and cross-device telemetry aggregation
+- **Signed remote policy distribution** and the Ed25519 **signing private key**
+- SSO/SCIM, per-user/per-team policy at scale, approval workflows
+- Tamper-evident audit + org-scale OCSF/SIEM export, compliance reporting
+- The **curated, signed premium threat feed** (the open runtime ships with a
+  baseline ruleset; the real-time signed feed is a subscription)
+- Roadmap: credential broker, workload attestation
+
+The boundary is enforced by **cryptography and entitlement**, not license terms:
+the runtime holds only the *public* key and verifies-before-applies signed
+policy (fail-closed to local-only if unsigned). It can never forge policy or mint
+identities. CI (`scripts/check_oss_safe.py`) blocks the private key, secrets, and
+feed blobs from ever entering this public repo.
+
+## Licensing note (open decision)
+
+The runtime is currently **Apache-2.0**. We are evaluating moving the runtime to
+**FSL-1.1-Apache** (Functional Source License — free for all use except building a
+directly competing product, converting to Apache-2.0 after two years) to harden
+against a platform repackaging the runtime as a competing managed service, while
+keeping near-permissive adoption. Adapters stay **MIT** regardless. This is a
+deliberate, not-yet-final decision — see the discussion in the PR that added this
+file. Until decided, Apache-2.0 is authoritative.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+Prismor Warden is a security tool that sits inline with agent tool calls and
+secrets. We take vulnerabilities seriously and appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security reports.** Instead:
+
+- Use GitHub's private **"Report a vulnerability"** advisory on this repository, or
+- Email **security@prismor.dev** with details and a reproduction.
+
+Please include the affected version/commit, impact, and steps to reproduce. We
+aim to acknowledge within 3 business days and to ship or coordinate a fix before
+public disclosure.
+
+## Scope
+
+In scope: the Warden runtime, the framework adapters, the detection rules, and
+the enrolled-device client protocol in this repository. The commercial control
+plane is handled separately — note it in your report and we will route it.
+
+## Secrets and keys
+
+The signing **private key** and any real secrets must never appear in this public
+repo. `scripts/check_oss_safe.py` enforces this in CI. If you discover an exposed
+secret in the history, report it privately so we can rotate it.

--- a/adapters/LICENSE
+++ b/adapters/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 Prismor
+
+The framework adapters in this directory (prismor-warden-langchain,
+prismor-warden-crewai, prismor-warden-openai, prismor-warden-browser-use,
+prismor-warden-vercel) are licensed under MIT — the most permissive terms — so
+the ecosystem can integrate and vendor them with zero friction. The Warden
+runtime they call into is licensed separately at the repository root.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/check_oss_safe.py
+++ b/scripts/check_oss_safe.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""OSS-safety guard for the public Prismor runtime repo.
+
+Prismor is open-core: the runtime + adapters + rule format are public, while the
+control plane, the Ed25519 signing **private key**, and the curated premium
+threat feed stay proprietary. A single accidental commit of the private key or a
+secret would collapse the signing moat — so this guard fails the build if any
+must-never-ship material is tracked in the public repo.
+
+It scans the set of git-tracked files (or an explicit list) for:
+  * private key material (PEM private-key headers, *.pem / *.key files)
+  * obvious cloud/credential secrets (AWS keys, generic API tokens)
+  * an explicit path denylist (e.g. keys/private.pem, the signing key env)
+
+Exit code 0 = clean, 1 = a violation was found (CI fails). Zero third-party
+dependencies — stdlib only — so it runs anywhere, including as a pre-commit hook.
+
+Usage:
+    python3 scripts/check_oss_safe.py            # scan all git-tracked files
+    python3 scripts/check_oss_safe.py a.py b.txt # scan an explicit list
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Paths that must NEVER be tracked in the public repo. Globs, repo-relative.
+PATH_DENYLIST = [
+    "keys/private.pem",
+    "**/*.pem",          # private keys; public key is keys/public.pub (.pub, allowed)
+    "**/*.key",
+    "**/id_rsa",
+    "**/id_ed25519",
+    ".env",
+    "**/.env",
+]
+
+# Files that are allowed to match a denylist glob (the intentional exceptions).
+PATH_ALLOWLIST = {
+    "keys/public.pub",   # the verify-only public key is meant to ship
+}
+
+# Files exempt from CONTENT-signature scanning because they legitimately contain
+# key-shaped or secret-shaped material that is fake by design. Each is an
+# explicit, reviewed exception — keep this list short and justified.
+CONTENT_ALLOWLIST = {
+    "warden/canary.py",                 # honeytoken templates: a *fake* SSH key + AWS key planted as bait
+    "tests/test_cloak_secret_guard.py", # secret-detection tests: AWS example key + dummy ghp_ token fixtures
+    "tests/test_oss_guard.py",          # this guard's own tests embed a fake PEM + AWS example key as fixtures
+}
+
+# Content signatures of secret material. (label, compiled regex)
+CONTENT_SIGNATURES: List[Tuple[str, "re.Pattern[str]"]] = [
+    ("PEM private key", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----")),
+    ("AWS access key id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("AWS secret access key", re.compile(r"aws_secret_access_key\s*=\s*[A-Za-z0-9/+]{40}")),
+    ("GitHub token", re.compile(r"\bghp_[A-Za-z0-9]{36}\b")),
+    ("Generic bearer secret", re.compile(r"(?i)(?:secret|token|password|api[_-]?key)\s*[:=]\s*['\"][A-Za-z0-9/+_\-]{24,}['\"]")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+]
+
+# Don't scan obvious binary/asset blobs for content signatures (they false-positive
+# and are slow); path rules still apply to them.
+SKIP_CONTENT_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".mp4", ".pdf", ".ico", ".woff", ".woff2", ".zip", ".gz"}
+
+# This guard file itself contains the signatures it looks for — never flag it.
+SELF = "scripts/check_oss_safe.py"
+
+
+def _tracked_files() -> List[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _path_violations(rel_paths: Iterable[str]) -> List[str]:
+    problems: List[str] = []
+    for rel in rel_paths:
+        if rel in PATH_ALLOWLIST:
+            continue
+        p = Path(rel)
+        for pattern in PATH_DENYLIST:
+            if p.match(pattern):
+                problems.append(f"  [path]    {rel}  (matches denylisted pattern '{pattern}')")
+                break
+    return problems
+
+
+def _content_violations(rel_paths: Iterable[str]) -> List[str]:
+    problems: List[str] = []
+    for rel in rel_paths:
+        if rel == SELF or rel in CONTENT_ALLOWLIST:
+            continue
+        if Path(rel).suffix.lower() in SKIP_CONTENT_SUFFIXES:
+            continue
+        fpath = REPO_ROOT / rel
+        try:
+            text = fpath.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeError):
+            continue
+        for label, rx in CONTENT_SIGNATURES:
+            if rx.search(text):
+                problems.append(f"  [content] {rel}  (looks like: {label})")
+    return problems
+
+
+def scan(paths: List[str]) -> List[str]:
+    rel_paths = paths or _tracked_files()
+    return _path_violations(rel_paths) + _content_violations(rel_paths)
+
+
+def main(argv: List[str]) -> int:
+    problems = scan(argv)
+    if problems:
+        sys.stderr.write(
+            "OSS-safety guard FAILED — these must never ship in the public repo:\n"
+            + "\n".join(problems)
+            + "\n\nRemove them (and rotate any exposed secret). The private signing "
+            "key, secrets, and the premium feed belong only in the private repos.\n"
+        )
+        return 1
+    print(f"OSS-safety guard passed — scanned {len(argv or _tracked_files())} files, no leaks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_oss_guard.py
+++ b/tests/test_oss_guard.py
@@ -1,0 +1,64 @@
+"""Tests for the OSS-safety guard (scripts/check_oss_safe.py)."""
+import importlib.util
+from pathlib import Path
+
+_GUARD = Path(__file__).resolve().parent.parent / "scripts" / "check_oss_safe.py"
+_spec = importlib.util.spec_from_file_location("check_oss_safe", _GUARD)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+def test_clean_files_pass(tmp_path: Path):
+    # A normal source file with no secrets and an allowed path → no violations.
+    assert guard.scan(["warden/sinks.py"]) == []
+
+
+def test_public_key_is_allowed():
+    # The verify-only public key is meant to ship — must not be flagged.
+    assert guard._path_violations(["keys/public.pub"]) == []
+
+
+def test_private_pem_path_blocked():
+    v = guard._path_violations(["keys/private.pem"])
+    assert v and "private.pem" in v[0]
+
+
+def test_pem_and_key_suffixes_blocked():
+    v = guard._path_violations(["foo/server.pem", "secrets/app.key", "home/.env"])
+    assert len(v) == 3
+
+
+def test_pem_private_key_content_detected(tmp_path: Path):
+    f = tmp_path / "leak.txt"
+    f.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n")
+    # Point the guard at a temp tree by faking REPO_ROOT for the read.
+    orig = guard.REPO_ROOT
+    guard.REPO_ROOT = tmp_path
+    try:
+        v = guard._content_violations(["leak.txt"])
+    finally:
+        guard.REPO_ROOT = orig
+    assert v and "PEM private key" in v[0]
+
+
+def test_aws_and_github_secrets_detected(tmp_path: Path):
+    f = tmp_path / "creds.txt"
+    f.write_text("AKIAIOSFODNN7EXAMPLE\nghp_0123456789abcdefghijklmnopqrstuvwxyz\n")
+    orig = guard.REPO_ROOT
+    guard.REPO_ROOT = tmp_path
+    try:
+        v = guard._content_violations(["creds.txt"])
+    finally:
+        guard.REPO_ROOT = orig
+    assert len(v) >= 2
+
+
+def test_guard_does_not_flag_itself():
+    # The guard file contains the signature regexes; it must be exempt.
+    assert guard._content_violations([guard.SELF]) == []
+
+
+def test_repo_is_currently_clean():
+    # The live public repo (all git-tracked files) must pass — this is the real
+    # CI assertion and guards against a regression sneaking a secret in.
+    assert guard.scan([]) == []


### PR DESCRIPTION
Prep for going **open-core**: open the runtime + adapters + rule format, keep the control plane / signing key / premium feed proprietary. This PR adds the docs and the **CI gate that keeps that boundary honest**. Branched off `feat/framework-adapters` (so the adapters it licenses are present).

## What's here
- **`scripts/check_oss_safe.py`** — CI guard that fails the build if a private key, secret, or other must-never-ship material is tracked in the public repo (the "private-key leak = existential" mitigation). Stdlib-only; path denylist (`*.pem`, `*.key`, `keys/private.pem`, `.env`, …) + content signatures (PEM private keys, AWS/GitHub/Slack tokens) + an explicit, **documented allowlist** for fake-key fixtures.
- **`tests/test_oss_guard.py`** — 8 tests: catches planted PEM/AWS/GitHub secrets, honors the public-key + fixture allowlists, and asserts the live repo is currently clean.
- **`.github/workflows/oss-guard.yml`** — runs the guard + tests on every push/PR.
- **`adapters/LICENSE`** — MIT for the framework adapters (max-adoption glue).
- **`OPEN_CORE.md`** — the open/closed boundary table + the runtime-license decision.
- **`CONTRIBUTING.md`** — dev setup + the **rule-contribution spec** (the community coverage moat, Sigma/Falco/Semgrep-style; every rule PR needs a test).
- **`SECURITY.md`** — private disclosure policy.

## Findings while building it
- ✅ **The signing private key is safe** — `keys/private.pem` is already gitignored (`*.pem`); only `keys/public.pub` ships. The guard now enforces this in CI so it can't regress.
- The guard's two pre-existing content hits were **intentional and verified**: `warden/canary.py` (a *fake* SSH key honeytoken) and `tests/test_cloak_secret_guard.py` (AWS example key + dummy tokens) — both explicitly allowlisted with justification.
- ℹ️ The premium feed (`advisories/immunity-feed.json`) is currently tracked. Per the plan it should become a paid/proprietary subscription feed; **moving it is a separate packaging decision**, not done here.

## ⚠️ One decision to confirm — runtime license
This PR does **not** relicense the runtime. It stays **Apache-2.0** (status quo); `adapters/` is **MIT** (additive). `OPEN_CORE.md` flags the open question — keep Apache, or move the runtime to **FSL-1.1-Apache** (free for all use except a directly-competing managed service, → Apache after 2 yrs) to harden against a platform repackaging it. Your call; one-line swap when decided.

## Verification
- Local: guard green (204 files), `pytest tests/test_oss_guard.py` → 8 passed.
- **On st3ve**: same — guard passes + 8 tests pass; and a **negative test** (planted `-----BEGIN OPENSSH PRIVATE KEY-----` file) correctly **failed the guard (exit 1)**, proving it catches a real leak. Box restored to `main` after.