### PR TITLE
open-core: platform + SDK connection guides, comparison, and two security fixes

### DIFF
--- a/.github/workflows/oss-guard.yml
+++ b/.github/workflows/oss-guard.yml
@@ -1,0 +1,26 @@
+name: OSS safety guard
+
+# Fails the build if the private signing key, a secret, or other
+# must-never-ship material is tracked in the public runtime repo. The signing
+# private key and the curated premium feed live only in the private repos —
+# this is the CI gate that keeps the open-core boundary honest.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  oss-safe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Scan tracked files for leaks
+        run: python3 scripts/check_oss_safe.py
+      - name: Guard self-tests
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest tests/test_oss_guard.py -q

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,55 @@
+# Open Source vs Enterprise
+
+Prismor is **open-core**. The runtime that guards a single machine is open and
+local; governing a fleet of machines across a team is the commercial product.
+Every row maps to a real component in this repo or in the proprietary
+`prismor-web` / `PrismorSec/prismor-enterprise` repos. See [OPEN_CORE.md](OPEN_CORE.md)
+for the boundary, and [docs/connecting-to-the-platform.md](docs/connecting-to-the-platform.md)
+for how the open runtime connects to the platform.
+
+## Capability comparison
+
+| Capability | Open Source (`immunity-agent`) | Enterprise (`prismor-web`) |
+|---|---|---|
+| Tool-call interception | Yes — local hooks (Claude Code, Cursor, Codex, Gemini, Copilot, Hermes) + SDK adapters (`warden/cloaking/hooks/`, `warden/hooks.py`, `warden/runtime.py`) | Same runtime; centrally governed |
+| Detection rules | All **63** default rules + the rule format (`warden/default_policy.yaml`, `warden/policy_schema.json`) | Same baseline + signed premium-feed overlay |
+| Framework coverage | 5 SDK adapters — LangChain, CrewAI, OpenAI Agents, browser-use, Vercel AI (`adapters/*`, MIT). See [docs/sdk-integration.md](docs/sdk-integration.md) | Same adapters |
+| Enforcement modes | Per-rule `observe`/`enforce` + non-overridable floor (`warden/policy_engine.py`) | Org sets modes remotely; approval workflows |
+| Policy scope | Local + per-repo/per-workspace (`warden/enterprise/workspace_scope.py`, `warden/scoped_agent.py`) | Org / team / project layers at scale |
+| Policy distribution | **Verifies** signed remote policy with the bundled public key, fail-closed to local-only (`warden/enterprise/remote_policy.py`, `keys/public.pub`) | **Signs and pushes** remote policy with the Ed25519 **private** key (`keys/private.pem`, gitignored, private repo) |
+| Identity | Per-machine IAM / named agents (`warden/iam.py`, `warden/principal.py`); device-enroll **client** (`warden/enterprise/identity.py`) | SSO / SCIM, org user & device directory |
+| Telemetry | Local sinks — webhook, syslog, file, OCSF/CEF (`warden/sinks.py`); redacted client spool (`warden/enterprise/telemetry*.py`) | Cross-device aggregation, org dashboard, fleet view |
+| Audit | Local tamper-aware audit log (`warden/audit.py`) | Org-scale tamper-evident audit + SIEM/OCSF export, compliance |
+| Visibility | One machine (`warden/server.py`, `warden/dashboard.html`) | Fleet observability across all enrolled devices |
+| Threat feed | Bundled baseline advisory feed, consumed locally (`warden/feed.py`) | **Curated, signed, real-time** premium feed (subscription) |
+| Deployment | `pip install immunity-agent`, runs locally; Docker | Self-hosted / managed control plane, BYOC / on-prem |
+| License | Runtime Apache-2.0 (`LICENSE`); adapters MIT (`adapters/LICENSE`) | Commercial |
+| Account needed | None — free forever, offline-capable | Org account + entitlement |
+
+## Repo / package structure
+
+| Open package (this repo) | Enterprise (private repos) |
+|---|---|
+| `warden/` — runtime, `policy_engine.py`, `runtime.py` | `prismor-web/` — control plane, dashboard, org APIs |
+| `warden/default_policy.yaml` — 63 rules, `policy_schema.json` | Signed premium feed + `pipeline/` (NVD merge, signing) |
+| `warden/cloaking/` — Cloak secret substitution + agent hooks | `keys/private.pem` — Ed25519 signing key (gitignored) |
+| `warden/iam.py`, `scoped_agent.py`, `principal.py` — local identity | SSO/SCIM, org user & policy directory |
+| `warden/sinks.py` — webhook / syslog / file / OCSF | Org OCSF/SIEM aggregation + compliance export |
+| `warden/enterprise/` — enrolled-device **client** protocol only | Server side of enroll / policy-sign / telemetry-ingest |
+| `adapters/` — 5 SDKs (MIT) | `PrismorSec/prismor-enterprise` — feed, pipeline, boundary harness |
+| `keys/public.pub` — verify-only key | `keys/private.pem` — sign key |
+
+> `warden/enterprise/` is the **client** side only — it enrolls, *verifies*
+> signed policy (holding only the public key), and reports *redacted* telemetry.
+> Signing and aggregation live in the proprietary control plane.
+
+## Why paid
+
+The open runtime protects one machine completely and for free. The enterprise
+tier exists to **govern many machines as a fleet** — signed central policy,
+cross-device telemetry, identity, and a live threat feed that a single local
+install structurally cannot provide. Nothing is removed from the open runtime to
+push an upgrade.
+
+**Charging:** Enterprise is priced **per enrolled seat/device, never per tool
+call** — the runtime intercepts unlimited calls locally at no metered cost.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Prismor Warden
+
+Thanks for helping make AI agents safer to run. The highest-leverage
+contribution is a **new detection rule** — every rule you add becomes a guard
+that protects every Prismor user. This is the open coverage model: the community
+extends the ruleset the way the Sigma, Falco, and Semgrep communities do.
+
+## Quick dev setup
+
+```bash
+git clone https://github.com/PrismorSec/prismor
+cd prismor
+python3 -m pip install -e .
+python3 -m pytest -q          # run the suite
+python3 scripts/check_oss_safe.py   # OSS-safety guard (no secrets/keys committed)
+```
+
+## Contributing a detection rule
+
+Rules live in [`warden/default_policy.yaml`](warden/default_policy.yaml) and follow
+the schema in [`warden/policy_schema.json`](warden/policy_schema.json). A rule is:
+
+```yaml
+- id: kebab-case-id              # unique, stable
+  severity: CRITICAL             # CRITICAL | HIGH | MEDIUM | LOW
+  category: secret_exfiltration  # one of the documented categories
+  title: One-line human description of what this blocks
+  event_types: [shell]           # shell | network | file_read | file_write | prompt | tool_result | skill_manifest
+  fields: [command]              # which event fields the patterns match against
+  patterns:
+    - 'regex that matches the dangerous payload'   # Python `re` syntax
+```
+
+**Rules ship in OBSERVE mode by default** — they log a would-be block but never
+break a user until an operator promotes them to enforce. So a good detection that
+occasionally over-matches is safe to land; a missed detection is the real cost.
+
+### Requirements for a rule PR
+
+1. **A test.** Every rule PR must add a test that proves the rule fires on the
+   malicious case **and** does not fire on a benign look-alike. Add it under
+   [`tests/`](tests/) (see `tests/test_detection_improvements.py` for the
+   pattern). False positives erode trust faster than false negatives — prove both
+   directions.
+2. **Evidence.** In the PR description, link the real attack/technique the rule
+   defends against (advisory, write-up, or a reproduction).
+3. **Patterns matched against argument *values*, not `key=value`** — the
+   `command` field carries the argument value only. (A common gotcha: a
+   word-boundary regex like `\brm -rf /` fails to match `=rm -rf /`.)
+4. **No weakening of core rules.** Rules in the non-overridable floor are
+   add-only — you may strengthen (add patterns), never disable.
+
+### How rules are reviewed
+
+`python3 -m pytest -q` is the CI gate; your test is the proof. A maintainer
+reviews for over-matching, severity/category fit, and floor safety. Curated,
+signed, real-time threat intel ships in the commercial feed — community rules are
+the open baseline everyone gets.
+
+## Contributing a framework adapter
+
+Adapters live in [`adapters/`](adapters/) and are **MIT-licensed** for maximum
+reuse. An adapter wraps a framework's tool-execution surface and routes each call
+through `warden.runtime.evaluate_tool_call()`. Mirror an existing adapter
+(`adapters/langchain`, `adapters/openai-agents`) and add a test under `tests/`.
+
+## Security & the open-core boundary
+
+- **Never commit secrets or private keys.** `scripts/check_oss_safe.py` runs in
+  CI and as a recommended pre-commit hook; it blocks PEM private keys, cloud
+  credentials, and the signing key from entering the public repo.
+- See [`OPEN_CORE.md`](OPEN_CORE.md) for what lives in the open runtime vs the
+  commercial control plane.
+- Report vulnerabilities privately — see [`SECURITY.md`](SECURITY.md).
+
+## License of contributions
+
+Contributions to the runtime are accepted under the repository's root license
+(Apache-2.0); contributions to `adapters/` under MIT. By submitting a PR you
+agree your contribution is licensed under the applicable license.

--- a/GAPS.md
+++ b/GAPS.md
@@ -1,0 +1,29 @@
+# Open-core / connection — gap register
+
+Findings from a multi-agent review of how the open-source runtime connects to the
+platform and to the framework SDKs. Each was verified against code. Items marked
+**fixed here** are addressed in this PR with tests; the rest are tracked
+follow-ups, ordered by severity.
+
+## Fixed in this PR
+
+| Sev | Gap | Fix |
+|---|---|---|
+| **Critical** | **Device-key exfiltration via the `prismor` sink `url`.** A local `.prismor-warden/policy.yaml` could set `url:` on a `type: prismor` sink; `_dispatch_prismor` forwarded it to `upload_telemetry`, which sends `Authorization: Bearer <device_key>` — redirecting the device credential to an attacker. | `warden/sinks.py`: the prismor sink is now **pinned to the enrolled `api_base`**; a local `url` override is ignored and warned. Test: `tests/test_prismor_sink_url_pin.py`. |
+| **High** | **Enforcement bypass.** The runtime folds the org per-agent control (kill-switch / forced-enforce, `runtime.py:106-107,152-155,214`) into `Decision.allow`, but every adapter re-gated on `if not decision.allow and mode == "enforce"`. An app launched in `observe` silently defeated the org's emergency control. | All 5 adapters now **honor `Decision.allow` directly**. Test: `tests/test_adapter_enforce_regression.py`. |
+| Low | Adapter license mismatch — 4 Python adapters declared Apache-2.0 in `pyproject` while `adapters/LICENSE` is MIT. | Flipped the 4 `pyproject` `license` fields to **MIT** (vercel already MIT); matches `adapters/LICENSE`. |
+| Low | `OPEN_CORE.md` said "61 default rules". | Corrected to **63** (`warden/default_policy.yaml` has 63 rule ids). |
+
+## Follow-ups (separate PRs)
+
+| Sev | Gap | Plan |
+|---|---|---|
+| **High** | **Subject is unverified and leaves the box.** `enterprise/telemetry.py` puts `subject` (user/team/org) into telemetry records even in redacted mode and `assert_redacted` doesn't scrub it; over HTTP the subject is client-asserted (`X-Warden-Subject` / body) with no verification. Together: cross-tenant attribution poisoning + PII egress. | Drop/scrub `subject` from redacted records (gate behind `full_capture`); stop trusting client-asserted subject on the eval-server path. |
+| **Med** | **eval-server has no auth, `Access-Control-Allow-Origin: *`, no rate limit.** Safe at the default `127.0.0.1` bind; risk spikes when `--host` widens it. | Add a shared-secret/bearer check + rate limit; require it before any non-loopback bind. |
+| **Med** | **Premium feed + pipeline are tracked in the PUBLIC repo.** `advisories/immunity-feed.json(.sig)` and `pipeline/` (fetch/merge/**sign**) should be proprietary; `scripts/check_oss_safe.py` `PATH_DENYLIST` does not cover them. | Move feed + pipeline to `PrismorSec/prismor-enterprise` (already mirrored there); ship a small **baseline** feed in the open repo; add the feed/pipeline paths to the leak guard (baseline allowlisted). Done together to avoid breaking `warden/feed.py`. |
+| **Med** | **Fail-open is not uniform.** The HTTP (vercel) path fails open on non-2xx; the Python adapters propagate runtime errors (ungraceful fail-closed). Same backend fault → different behavior per language. | Pick one policy across all adapters + the eval-server and document it; the registry's "fails open" note currently only describes the HTTP path. |
+| Low | **No single `immunity connect`; token passed via argv** (`immunity enroll <token>`) leaks into shell history. | Add a `connect` alias + `--token-stdin` / `$PRISMOR_ENROLL_TOKEN`; consider device-code enroll. |
+| Low | **`warden/enterprise/` reads as "paid code in the open repo."** It is client-only (enroll, verify-only policy, redacted telemetry). | Documented as the client side in `docs/connecting-to-the-platform.md`; consider renaming to `client/` later. |
+
+See `docs/connecting-to-the-platform.md` and `docs/sdk-integration.md` for the
+connection design these were found in.

--- a/OPEN_CORE.md
+++ b/OPEN_CORE.md
@@ -13,7 +13,7 @@ paid tier adds the fleet/governance layer that doesn't exist in single-player.
 | Component | Path | License |
 |---|---|---|
 | Warden runtime — interception, policy engine, enforcement | `warden/` | Apache-2.0 (root `LICENSE`) |
-| All 61 default detection rules + the rule format | `warden/default_policy.yaml`, `warden/policy_schema.json` | Apache-2.0 |
+| All 63 default detection rules + the rule format | `warden/default_policy.yaml`, `warden/policy_schema.json` | Apache-2.0 |
 | Coding-agent hooks (Claude Code, Cursor, Codex, …) | `warden/cloaking/hooks/` | Apache-2.0 |
 | Cloak — local secret substitution | `warden/cloaking/` | Apache-2.0 |
 | Per-machine IAM / scoped access | `warden/iam.py`, `warden/scoped_agent.py` | Apache-2.0 |

--- a/OPEN_CORE.md
+++ b/OPEN_CORE.md
@@ -1,0 +1,55 @@
+# Prismor open-core model
+
+Prismor is **open-core**. The runtime that guards your agents is open source and
+runs locally — you can read every line that touches your tool calls and secrets.
+Governing agents across a team or organization is the commercial product.
+
+The principle: **single-player is free and open; multiplayer (org governance) is
+paid.** Nothing is ever removed from the open runtime to push you to pay — the
+paid tier adds the fleet/governance layer that doesn't exist in single-player.
+
+## What's open source (this repo)
+
+| Component | Path | License |
+|---|---|---|
+| Warden runtime — interception, policy engine, enforcement | `warden/` | Apache-2.0 (root `LICENSE`) |
+| All 61 default detection rules + the rule format | `warden/default_policy.yaml`, `warden/policy_schema.json` | Apache-2.0 |
+| Coding-agent hooks (Claude Code, Cursor, Codex, …) | `warden/cloaking/hooks/` | Apache-2.0 |
+| Cloak — local secret substitution | `warden/cloaking/` | Apache-2.0 |
+| Per-machine IAM / scoped access | `warden/iam.py`, `warden/scoped_agent.py` | Apache-2.0 |
+| Local telemetry sinks (webhook, syslog, file, OCSF/CEF) | `warden/sinks.py` | Apache-2.0 |
+| Framework adapters (LangChain, CrewAI, OpenAI Agents, browser-use, Vercel AI) | `adapters/` | **MIT** (`adapters/LICENSE`) |
+| The enrolled-device **client** protocol (so you can audit what leaves the box) | `warden/enterprise/` | Apache-2.0 |
+| Public verification key | `keys/public.pub` | Apache-2.0 |
+| Eval harness / detection scenarios | `bench/`, `tests/` | Apache-2.0 |
+
+The open runtime enforces all six control dimensions **locally**, on one machine,
+with unlimited agents, tool calls, and rules — free forever.
+
+## What's commercial (not in this repo)
+
+The control plane (`prismor-web`) and the assets that anchor trust at scale:
+
+- Org dashboard, fleet observability, and cross-device telemetry aggregation
+- **Signed remote policy distribution** and the Ed25519 **signing private key**
+- SSO/SCIM, per-user/per-team policy at scale, approval workflows
+- Tamper-evident audit + org-scale OCSF/SIEM export, compliance reporting
+- The **curated, signed premium threat feed** (the open runtime ships with a
+  baseline ruleset; the real-time signed feed is a subscription)
+- Roadmap: credential broker, workload attestation
+
+The boundary is enforced by **cryptography and entitlement**, not license terms:
+the runtime holds only the *public* key and verifies-before-applies signed
+policy (fail-closed to local-only if unsigned). It can never forge policy or mint
+identities. CI (`scripts/check_oss_safe.py`) blocks the private key, secrets, and
+feed blobs from ever entering this public repo.
+
+## Licensing note (open decision)
+
+The runtime is currently **Apache-2.0**. We are evaluating moving the runtime to
+**FSL-1.1-Apache** (Functional Source License — free for all use except building a
+directly competing product, converting to Apache-2.0 after two years) to harden
+against a platform repackaging the runtime as a competing managed service, while
+keeping near-permissive adoption. Adapters stay **MIT** regardless. This is a
+deliberate, not-yet-final decision — see the discussion in the PR that added this
+file. Until decided, Apache-2.0 is authoritative.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@
 
 ---
 
+## Open-core
+
+Prismor is open-core: **single-player is free and open; multiplayer (org
+governance) is paid.** Nothing is stripped from the open runtime to push an
+upgrade.
+
+- **Free & open (this repo):** the full Warden runtime, all 63 detection rules,
+  Cloak secret prevention, supply-chain blocking, per-machine IAM, local
+  OCSF/syslog telemetry, and the 5 framework adapters — `pip install
+  immunity-agent`, runs locally, no account.
+- **Enterprise (`prismor-web`):** signed remote-policy distribution, fleet
+  observability, SSO/SCIM, org-scale audit/SIEM, and the curated signed threat
+  feed. Priced per seat, never per call.
+
+Read more: [OPEN_CORE.md](OPEN_CORE.md) · [COMPARISON.md](COMPARISON.md) ·
+[Connecting to the platform](docs/connecting-to-the-platform.md) ·
+[Framework SDKs](docs/sdk-integration.md)
+
 ## The Problem
 
 AI coding agents execute shell commands, read and write files, access credentials, and call external APIs. They do this autonomously, often across many steps, with limited checkpoints.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+Prismor Warden is a security tool that sits inline with agent tool calls and
+secrets. We take vulnerabilities seriously and appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security reports.** Instead:
+
+- Use GitHub's private **"Report a vulnerability"** advisory on this repository, or
+- Email **security@prismor.dev** with details and a reproduction.
+
+Please include the affected version/commit, impact, and steps to reproduce. We
+aim to acknowledge within 3 business days and to ship or coordinate a fix before
+public disclosure.
+
+## Scope
+
+In scope: the Warden runtime, the framework adapters, the detection rules, and
+the enrolled-device client protocol in this repository. The commercial control
+plane is handled separately — note it in your report and we will route it.
+
+## Secrets and keys
+
+The signing **private key** and any real secrets must never appear in this public
+repo. `scripts/check_oss_safe.py` enforces this in CI. If you discover an exposed
+secret in the history, report it privately so we can rotate it.

--- a/adapters/LICENSE
+++ b/adapters/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 Prismor
+
+The framework adapters in this directory (prismor-warden-langchain,
+prismor-warden-crewai, prismor-warden-openai, prismor-warden-browser-use,
+prismor-warden-vercel) are licensed under MIT — the most permissive terms — so
+the ecosystem can integrate and vendor them with zero friction. The Warden
+runtime they call into is licensed separately at the repository root.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/browser-use/prismor_warden_browser_use/__init__.py
+++ b/adapters/browser-use/prismor_warden_browser_use/__init__.py
@@ -161,7 +161,7 @@ def guard_controller(
             subject=resolved,
         )
 
-        if not decision.allow and mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise WardenBlocked(reason, decision)

--- a/adapters/browser-use/pyproject.toml
+++ b/adapters/browser-use/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Prismor Warden adapter for browser-use — policy-controlled browser actions"
 readme = "README.md"
 requires-python = ">=3.10"
+license = { text = "MIT" }
 dependencies = ["immunity-agent>=1.11.0"]
 
 [project.optional-dependencies]

--- a/adapters/crewai/prismor_warden_crewai/__init__.py
+++ b/adapters/crewai/prismor_warden_crewai/__init__.py
@@ -102,7 +102,7 @@ def warden_guard_tool(
             tool_name=tool_name, args=args, kwargs=kwargs, subject=subject, ws=ws,
             agent=agent, agent_name=_agent_name, mode=mode, sid=sid, event_type=event_type,
         )
-        if not decision.allow and mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise WardenBlocked(reason, decision)

--- a/adapters/crewai/pyproject.toml
+++ b/adapters/crewai/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Prismor Warden adapter for CrewAI — per-user runtime tool-call policy for production agents."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 authors = [{ name = "Prismor" }]
 keywords = ["crewai", "security", "policy", "guardrail", "prismor", "warden"]
 

--- a/adapters/langchain/prismor_warden_langchain/__init__.py
+++ b/adapters/langchain/prismor_warden_langchain/__init__.py
@@ -129,7 +129,7 @@ def warden_guard_tool(
             tool_name=tool_name, args=args, kwargs=kwargs, subject=subject, ws=ws,
             agent=agent, agent_name=_agent_name, mode=mode, sid=sid, event_type=event_type,
         )
-        if not decision.allow and mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise WardenBlocked(reason, decision)
@@ -204,5 +204,5 @@ class WardenCallbackHandler(_BaseCB):  # type: ignore[misc]
             ws=self._ws, agent=self._agent, mode=self._mode, sid=self._sid,
             event_type=self._event_type,
         )
-        if not decision.allow and self._mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             raise WardenBlocked(decision.reason or "policy violation", decision)

--- a/adapters/langchain/pyproject.toml
+++ b/adapters/langchain/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Prismor Warden adapter for LangChain / LangGraph — per-user runtime tool-call policy for production agents."
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 authors = [{ name = "Prismor" }]
 keywords = ["langchain", "langgraph", "security", "policy", "guardrail", "prismor", "warden"]
 

--- a/adapters/openai-agents/prismor_warden_openai/__init__.py
+++ b/adapters/openai-agents/prismor_warden_openai/__init__.py
@@ -186,7 +186,7 @@ def warden_guard(
         # In observe mode the call is always allowed to proceed — the finding is
         # still recorded and shipped to telemetry, so it is log-only monitoring.
         # Only enforce mode turns a denial into a hard block.
-        if not decision.allow and mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             if raise_on_block:
                 raise WardenBlocked(decision.reason or "blocked", decision)
             return decision
@@ -265,7 +265,7 @@ def _guard_function_tool(
             session_id=sid,
             subject=resolve_subject(subject),
         )
-        if not decision.allow and mode == "enforce":
+        if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise WardenBlocked(reason, decision)

--- a/adapters/openai-agents/pyproject.toml
+++ b/adapters/openai-agents/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Prismor Warden adapter for the OpenAI Agents SDK — per-user runtime tool-call policy for production agents."
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 authors = [{ name = "Prismor" }]
 keywords = ["openai", "agents", "security", "policy", "guardrail", "prismor", "warden"]
 

--- a/adapters/vercel-ai/src/index.ts
+++ b/adapters/vercel-ai/src/index.ts
@@ -122,7 +122,7 @@ export function wardenTool<
 
   const guarded = async (args: Record<string, unknown>, ctx: unknown) => {
     const decision = await evaluate(toolName, args, resolved, sid);
-    if (!decision.allow && resolved.mode === "enforce") {
+    if (!decision.allow) {  // honor the runtime decision (incl. org kill-switch), not the app-passed mode
       throw new WardenBlocked(decision.reason ?? "policy violation", decision);
     }
     return original(args, ctx);

--- a/docs/connecting-to-the-platform.md
+++ b/docs/connecting-to-the-platform.md
@@ -1,0 +1,144 @@
+# Connecting a Self-Hosted Runtime to the Prismor Platform
+
+Prismor is open-core. The runtime ("Warden"), the framework adapters, and the
+YAML rule format in this repo are open and auditable. The **control plane**
+(`prismor-web` — the org dashboard, the policy-signing private key, and the
+premium feed) is proprietary. This document describes the *open client side* of
+that link: how an enrolled Warden install talks to the control plane, what it
+trusts, and exactly what does and does not leave the machine.
+
+See also: [OPEN_CORE.md](../OPEN_CORE.md) (the boundary) ·
+[COMPARISON.md](../COMPARISON.md) · [docs/sdk-integration.md](sdk-integration.md)
+(the runtime, not the SDK, is what connects).
+
+Everything here is **opt-in**. On a plain install, `warden/enterprise/*` is the
+**client** side and a guarded no-op: `is_enrolled()` returns False and every
+control-plane path short-circuits. Local protection — the 63 default rules in
+`warden/default_policy.yaml` — is always on, enrolled or not.
+
+## Connection lifecycle at a glance
+
+```
+  Developer machine (Warden, this repo)      Prismor control plane (prismor-web, proprietary)
+  ─────────────────────────────────────      ───────────────────────────────────────────────
+  immunity enroll <token>  ──POST /api/devices/enroll──▶  validate one-time token
+   identity.enroll()           {token,label,platform}     mint revocable device_key
+   save_identity() 0600  ◀──{device_id,org_id,user_id,──  record device row
+   ~/.prismor/identity.json        device_key,org_name}
+
+  hook-dispatch (hot path)
+   remote_policy.check_and_refresh()
+     ──GET /api/policy/version?applied=N──────────────▶  {version,profileId,fullCapture,...}
+     if changed: GET /api/policy/resolve ─────────────▶  SIGN policy with PRIVATE key
+   verify_and_load() ◀────────{yaml, signature}─────────  (private key NOT in this repo)
+     openssl verify vs keys/public.pub ── fail ⇒ ignore, keep last good
+
+   evaluate_tool_call() ⇒ finding
+   _dispatch_prismor() → build_record() (redact) → assert_redacted()
+     ──POST /api/telemetry/ingest──{org_id,device_id,events[]}──▶ store
+   heartbeat.maybe_flush()  ──POST /api/telemetry/ingest (count only)──▶
+
+  on 401/403 from any call ⇒ mark_revoked() ⇒ 1h backoff; last good policy stays
+```
+
+The endpoints above are what the **client calls**; the server implementation
+lives in the proprietary control plane.
+
+## 1. Enroll (token → device key)
+
+```
+immunity enroll <TOKEN>
+immunity enroll --token <TOKEN> --label "ci-runner-3" --api-base https://prismor.dev
+```
+
+- **Token:** a one-time enrollment token from the dashboard (Admin → Devices →
+  Enroll), exchanged exactly once.
+- **What happens:** `identity.enroll()` POSTs `{token, label, platform,
+  warden_version}` to `/api/devices/enroll`; the server returns `device_id`,
+  `org_id`, `user_id`, `device_key`, `org_name`.
+- **Where the key is stored:** `save_identity()` writes
+  `~/.prismor/identity.json` (override via `$PRISMOR_HOME`) at **0600**, dir
+  0700. The `device_key` is a long-lived, revocable **bearer credential** for
+  telemetry + signed-policy *pull*; it cannot push or sign anything, and it is
+  separate from the scan API key and from cloaked secrets so revoking a laptop
+  never breaks CI scans.
+- After enroll, policy is fetched immediately so admin policy applies on the
+  first tool call.
+
+Base URL: `$PRISMOR_API_BASE` (default `https://prismor.dev`), persisted
+per-device as `api_base` so self-hosted/staging deployments repoint without a
+rebuild.
+
+## 2. Signed remote policy: verify-before-apply, fail-closed
+
+On the hot path, `remote_policy.check_and_refresh()` (debounced, clamped to
+[5s, 600s]):
+
+1. **Version probe:** `GET /api/policy/version` with `Authorization: Bearer
+   <device_key>`; a change in version/profile/capture/managed-repos triggers a
+   pull.
+2. **Pull:** `GET /api/policy/resolve` → `{yaml, signature}`.
+3. **Verify:** a detached Ed25519 signature checked with `openssl pkeyutl
+   -verify` against the bundled trust root `keys/public.pub`. **The private key
+   is never in this repo.**
+4. **Fail-closed:** an unsigned/tampered/unverifiable policy is *ignored* and the
+   last verified policy keeps applying — a compromised control plane cannot
+   inject rules.
+5. **Tighten-only floor:** the engine enforces `_NON_OVERRIDABLE_RULE_IDS`, so
+   even a *valid* signed policy can never disable the destructive-command /
+   secret-exfil protections or turn Warden off.
+6. **Offline-safe:** unreachable control plane ⇒ cached policy persists.
+
+## 3. Redacted telemetry (what leaves the box)
+
+Telemetry flows only for **org-managed** workspaces (`workspace_scope.py`).
+Personal repos emit nothing. The `prismor` sink (`warden/sinks.py`) builds
+records via `telemetry.build_record()` and runs `assert_redacted()` before upload
+— a fail-closed guard.
+
+- **Redacted mode (default):** metadata + enums + hashes only — severity,
+  category, rule_id, event type, agent, verdict, a *static* rule title
+  (paths/hosts/URLs/secrets stripped), a 16-char `evidence_hash`, tool_name,
+  managed-repo context, policy_scope, device_id, session_id, subject (principal
+  ids). **Never sent:** commands, stdout/stderr, file paths, URLs, file contents,
+  prompts, responses, payloads, matched evidence.
+- **Full capture (admin opt-in, per-org):** additionally ships evidence/content,
+  still scrubbed through the cloaking secret patterns so registered secrets never
+  leave. A flip is surfaced to the developer via a stderr `NOTICE` and in
+  `immunity enroll-status` (`capture: FULL`).
+
+Upload: `POST /api/telemetry/ingest`. An offline **spool** gives at-least-once
+delivery, written *after* redaction. Short hot-path timeout (~6s) ⇒ a slow
+control plane spools, never blocks a tool call. The destination is **pinned to
+the enrolled `api_base`** — a local policy cannot redirect the device-key-bearing
+upload elsewhere.
+
+## 4. Heartbeat
+
+`heartbeat` counts inspected tool calls locally and uploads one `agent_activity`
+record per ≤60s carrying *only a count* + agent/session enums — volume, not
+detail — gated to managed workspaces. Powers the "tool calls inspected" KPI.
+
+## 5. Revocation + backoff
+
+Any control-plane **401/403** ⇒ `mark_revoked()`; for 1h, control-plane calls
+short-circuit (no hammering). Local protection is unaffected — the last good
+signed policy keeps enforcing. `immunity logout` wipes identity, cached policy,
+spool, heartbeat, and scope map.
+
+## Trust model
+
+- **Public-key verify only.** The device holds no signing key; it only verifies
+  org policy against `keys/public.pub`. The signing key lives in the control
+  plane.
+- **No secret leaves.** Cloaked secrets and the scan API key are never sent; even
+  full capture scrubs secret-shaped values. The device key is scoped, revocable,
+  stored 0600.
+- **Admin CAN see** (managed repos only): redacted findings, per-user subject
+  ids, repo identifiers, tool-call volume; with opt-in, scrubbed raw content.
+- **Admin CANNOT see:** personal-repo activity, raw secrets, or — without
+  opt-in — any commands, paths, URLs, prompts, or file contents; and cannot
+  silently disable the local security floor.
+
+> Known follow-ups for this path (auth on the enroll UX, subject handling) are
+> tracked in [GAPS.md](../GAPS.md).

--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -1,0 +1,133 @@
+# SDK & Framework Integration
+
+Prismor guards production framework agents at the **tool-execution boundary**. An
+adapter wraps the one function a framework calls to run a tool, and routes that
+call through the **local Warden runtime** before the tool body executes.
+
+See also: [docs/connecting-to-the-platform.md](connecting-to-the-platform.md)
+(the runtime — not the SDK — is what connects to the platform) ·
+[docs/frameworks-overview.md](frameworks-overview.md) · [COMPARISON.md](../COMPARISON.md).
+
+## The one rule: the SDK talks to the LOCAL RUNTIME, never the control plane
+
+Every adapter funnels into `warden.runtime.evaluate_tool_call(...)` →
+`Decision{allow, findings, reason, subject}`. Python adapters import and call it
+in-process; non-Python adapters POST to a local sidecar (`warden/eval_server.py`)
+that calls the same function. The runtime evaluates policy locally and is the
+*only* component that phones home (telemetry, heartbeat, signed-policy pull). The
+SDK has no control-plane credentials and no control-plane URL.
+
+```
+  ┌─────────────────────────────────────────────┐
+  │ Your process (framework agent)               │
+  │  LLM ──tool call──► Adapter wrap point         │
+  │                       │                        │
+  │   (Python) in-process │  evaluate_tool_call()   │  (TS / any lang)
+  │   ──────────────────► │ ◄──────────────────────  POST /v1/evaluate
+  │              warden.runtime.evaluate_tool_call  │   (eval-server, same box)
+  │                       │ Decision                │
+  │             allow ────┴──► run tool             │
+  │             deny  ───────► blocked / WardenBlocked
+  └───────────────────────┬─────────────────────────┘
+                          │  (runtime only)
+                          ▼   redacted telemetry · signed-policy pull · heartbeat
+                 Prismor control plane
+```
+
+**Always honor `Decision.allow`.** The runtime already folds the requested mode
+*and* any org per-agent control (kill-switch / forced-enforce) into
+`Decision.allow`. Adapters must block whenever `allow` is `False` — they must not
+re-derive the verdict from a locally-passed `mode`, or an org override can be
+bypassed.
+
+The canonical event every adapter builds is identical in shape
+(`warden/hooks.py`): `{ ts, session_id, agent, agent_event, type, command|path|
+url|content, metadata{tool_name, framework, args, kwargs} }`. `type` selects the
+matched field: `shell→command`, `file_read|file_write→path`, `network→url`,
+`prompt|tool_result→content`.
+
+## Multi-tenant subjects
+
+One deployed agent serves many users. Attribute each call with `use_subject`
+(a contextvar — async/thread-safe; `warden/principal.py`):
+
+```python
+from prismor_warden_openai import use_subject
+with use_subject("user:alice"):       # also "user=alice;team=data;org=acme"
+    Runner.run_sync(agent, prompt)
+```
+
+Priority: explicit `subject=` arg → `use_subject` context → `WARDEN_SUBJECT` env
+→ enrolled device identity → anonymous.
+
+## Per framework
+
+| Framework | Wrap point (patched) | Guard call |
+|---|---|---|
+| OpenAI Agents | `FunctionTool.on_invoke_tool` | `guard_agent(agent, subject=...)` |
+| LangChain/LangGraph | `tool.func` / `tool.coroutine` (+ `WardenCallbackHandler`) | `guard_tools([...], subject=...)` |
+| CrewAI | `tool.func` / `_run` / `run` | `guard_tools([...], subject=...)` |
+| browser-use | `Registry.execute_action` | `guard_controller(controller, subject=...)` |
+| Vercel AI (TS) | `tool.execute` → HTTP | `wardenTools({...}, { subject })` |
+
+### OpenAI Agents
+```python
+from agents import Agent, Runner
+from prismor_warden_openai import guard_agent, use_subject
+agent = Agent(name="ops", tools=[run_shell])
+guard_agent(agent, subject="user:alice")     # wraps every FunctionTool
+with use_subject("user:alice"):
+    Runner.run_sync(agent, "…")
+```
+
+### LangChain / LangGraph
+```python
+from prismor_warden_langchain import guard_tools
+tools = guard_tools([run_shell, fetch_url], subject="user:alice")
+# Observability-only: config={"callbacks": [WardenCallbackHandler()]}
+```
+
+### CrewAI
+```python
+from prismor_warden_crewai import guard_tools
+tools = guard_tools([run_shell], subject="user:alice")
+```
+
+### browser-use
+```python
+from prismor_warden_browser_use import guard_controller, use_subject
+controller = Controller(); guard_controller(controller)   # patch once at startup
+with use_subject("user:alice"):
+    await Agent(task="…", llm=llm, controller=controller).run()
+```
+
+### Vercel AI SDK / any language (HTTP)
+Run the sidecar: `immunity eval-server --port 7071 --workspace .`
+```ts
+import { wardenTools } from "prismor-warden-vercel";
+const tools = wardenTools({ run_shell, search_web }, { subject: `user:${userId}` });
+await generateText({ model, tools, prompt });
+```
+`POST /v1/evaluate`:
+```json
+{ "tool_name":"run_shell", "arguments":{"command":"rm -rf /"},
+  "event_type":"shell", "agent":"vercel-ai", "mode":"enforce",
+  "session_id":"req-1", "subject":"user:alice", "workspace":"/srv/app" }
+```
+→ `200 {"allow":false,"reason":"[HIGH] …","findings":[…],"subject":{…}}`. Subject
+and agent name may also be sent as `X-Warden-Subject` / `X-Warden-Agent-Name`
+headers.
+
+## Failure behavior
+
+The eval-server is local; if it is unreachable the HTTP client treats the call as
+allowed so an infrastructure fault never breaks the agent. **Note:** failure
+handling is not yet uniform across all adapters — see [GAPS.md](../GAPS.md) for
+the open item and the intended single policy. For non-loopback binds of the
+eval-server, also see the auth follow-up in GAPS.md.
+
+## Licensing
+
+The adapters are **MIT** (`adapters/LICENSE`) — the most permissive terms, so the
+ecosystem can integrate and vendor them freely. The Warden runtime they call into
+is Apache-2.0 (repo root `LICENSE`).

--- a/scripts/check_oss_safe.py
+++ b/scripts/check_oss_safe.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""OSS-safety guard for the public Prismor runtime repo.
+
+Prismor is open-core: the runtime + adapters + rule format are public, while the
+control plane, the Ed25519 signing **private key**, and the curated premium
+threat feed stay proprietary. A single accidental commit of the private key or a
+secret would collapse the signing moat — so this guard fails the build if any
+must-never-ship material is tracked in the public repo.
+
+It scans the set of git-tracked files (or an explicit list) for:
+  * private key material (PEM private-key headers, *.pem / *.key files)
+  * obvious cloud/credential secrets (AWS keys, generic API tokens)
+  * an explicit path denylist (e.g. keys/private.pem, the signing key env)
+
+Exit code 0 = clean, 1 = a violation was found (CI fails). Zero third-party
+dependencies — stdlib only — so it runs anywhere, including as a pre-commit hook.
+
+Usage:
+    python3 scripts/check_oss_safe.py            # scan all git-tracked files
+    python3 scripts/check_oss_safe.py a.py b.txt # scan an explicit list
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Paths that must NEVER be tracked in the public repo. Globs, repo-relative.
+PATH_DENYLIST = [
+    "keys/private.pem",
+    "**/*.pem",          # private keys; public key is keys/public.pub (.pub, allowed)
+    "**/*.key",
+    "**/id_rsa",
+    "**/id_ed25519",
+    ".env",
+    "**/.env",
+]
+
+# Files that are allowed to match a denylist glob (the intentional exceptions).
+PATH_ALLOWLIST = {
+    "keys/public.pub",   # the verify-only public key is meant to ship
+}
+
+# Files exempt from CONTENT-signature scanning because they legitimately contain
+# key-shaped or secret-shaped material that is fake by design. Each is an
+# explicit, reviewed exception — keep this list short and justified.
+CONTENT_ALLOWLIST = {
+    "warden/canary.py",                 # honeytoken templates: a *fake* SSH key + AWS key planted as bait
+    "tests/test_cloak_secret_guard.py", # secret-detection tests: AWS example key + dummy ghp_ token fixtures
+    "tests/test_oss_guard.py",          # this guard's own tests embed a fake PEM + AWS example key as fixtures
+}
+
+# Content signatures of secret material. (label, compiled regex)
+CONTENT_SIGNATURES: List[Tuple[str, "re.Pattern[str]"]] = [
+    ("PEM private key", re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----")),
+    ("AWS access key id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("AWS secret access key", re.compile(r"aws_secret_access_key\s*=\s*[A-Za-z0-9/+]{40}")),
+    ("GitHub token", re.compile(r"\bghp_[A-Za-z0-9]{36}\b")),
+    ("Generic bearer secret", re.compile(r"(?i)(?:secret|token|password|api[_-]?key)\s*[:=]\s*['\"][A-Za-z0-9/+_\-]{24,}['\"]")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+]
+
+# Don't scan obvious binary/asset blobs for content signatures (they false-positive
+# and are slow); path rules still apply to them.
+SKIP_CONTENT_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".mp4", ".pdf", ".ico", ".woff", ".woff2", ".zip", ".gz"}
+
+# This guard file itself contains the signatures it looks for — never flag it.
+SELF = "scripts/check_oss_safe.py"
+
+
+def _tracked_files() -> List[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _path_violations(rel_paths: Iterable[str]) -> List[str]:
+    problems: List[str] = []
+    for rel in rel_paths:
+        if rel in PATH_ALLOWLIST:
+            continue
+        p = Path(rel)
+        for pattern in PATH_DENYLIST:
+            if p.match(pattern):
+                problems.append(f"  [path]    {rel}  (matches denylisted pattern '{pattern}')")
+                break
+    return problems
+
+
+def _content_violations(rel_paths: Iterable[str]) -> List[str]:
+    problems: List[str] = []
+    for rel in rel_paths:
+        if rel == SELF or rel in CONTENT_ALLOWLIST:
+            continue
+        if Path(rel).suffix.lower() in SKIP_CONTENT_SUFFIXES:
+            continue
+        fpath = REPO_ROOT / rel
+        try:
+            text = fpath.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeError):
+            continue
+        for label, rx in CONTENT_SIGNATURES:
+            if rx.search(text):
+                problems.append(f"  [content] {rel}  (looks like: {label})")
+    return problems
+
+
+def scan(paths: List[str]) -> List[str]:
+    rel_paths = paths or _tracked_files()
+    return _path_violations(rel_paths) + _content_violations(rel_paths)
+
+
+def main(argv: List[str]) -> int:
+    problems = scan(argv)
+    if problems:
+        sys.stderr.write(
+            "OSS-safety guard FAILED — these must never ship in the public repo:\n"
+            + "\n".join(problems)
+            + "\n\nRemove them (and rotate any exposed secret). The private signing "
+            "key, secrets, and the premium feed belong only in the private repos.\n"
+        )
+        return 1
+    print(f"OSS-safety guard passed — scanned {len(argv or _tracked_files())} files, no leaks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_adapter_enforce_regression.py
+++ b/tests/test_adapter_enforce_regression.py
@@ -1,0 +1,69 @@
+"""Regression: adapters must honor ``Decision.allow`` directly, not re-gate on the
+app-passed ``mode``.
+
+The runtime already folds mode + the org per-agent control (kill-switch /
+forced-enforce) into ``Decision.allow`` (warden/runtime.py:106-107,152-155,214).
+A deny that the control plane forces — e.g. an agent kill-switch — comes back as
+``allow=False`` even when the app launched in ``observe`` mode. The adapters used
+to re-check ``and mode == "enforce"``, which silently let the tool run and
+defeated the org's emergency control. This test fails on that old behavior.
+"""
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+for _pkg in ("langchain", "crewai"):
+    _src = _ROOT / "adapters" / _pkg
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+
+import prismor_warden_langchain as lc   # noqa: E402
+import prismor_warden_crewai as crew    # noqa: E402
+from warden.runtime import Decision     # noqa: E402
+
+
+class _Tool:
+    """A structured tool with .name + .func (what both adapters wrap)."""
+
+    def __init__(self, fn):
+        self.name = "run_shell"
+        self.func = fn
+
+
+def _force_runtime_deny(monkeypatch, mod):
+    # Simulate the org kill-switch: the runtime returns a hard deny regardless of
+    # the app-passed mode.
+    monkeypatch.setattr(
+        mod, "evaluate_tool_call",
+        lambda *a, **k: Decision(allow=False, reason="[CRITICAL] agent disabled by org"),
+    )
+
+
+def test_langchain_honors_forced_deny_even_in_observe(monkeypatch, tmp_path):
+    _force_runtime_deny(monkeypatch, lc)
+    ran = []
+    tool = _Tool(lambda command: ran.append(command) or "ok")
+    lc.guard_tools([tool], workspace=tmp_path, mode="observe")  # app runs OBSERVE
+    out = tool.func(command="anything")
+    assert "blocked" in str(out).lower()   # org kill-switch still blocks
+    assert ran == []                        # body never executed
+
+
+def test_crewai_honors_forced_deny_even_in_observe(monkeypatch, tmp_path):
+    _force_runtime_deny(monkeypatch, crew)
+    ran = []
+    tool = _Tool(lambda command: ran.append(command) or "ok")
+    crew.guard_tools([tool], workspace=tmp_path, mode="observe")
+    out = tool.func(command="anything")
+    assert "blocked" in str(out).lower()
+    assert ran == []
+
+
+def test_allow_still_runs(monkeypatch, tmp_path):
+    # Sanity: when the runtime allows, the tool runs (we didn't break the allow path).
+    monkeypatch.setattr(lc, "evaluate_tool_call", lambda *a, **k: Decision(allow=True))
+    ran = []
+    tool = _Tool(lambda command: ran.append(command) or "ok")
+    lc.guard_tools([tool], workspace=tmp_path, mode="observe")
+    assert tool.func(command="echo hi") == "ok"
+    assert ran == ["echo hi"]

--- a/tests/test_oss_guard.py
+++ b/tests/test_oss_guard.py
@@ -1,0 +1,64 @@
+"""Tests for the OSS-safety guard (scripts/check_oss_safe.py)."""
+import importlib.util
+from pathlib import Path
+
+_GUARD = Path(__file__).resolve().parent.parent / "scripts" / "check_oss_safe.py"
+_spec = importlib.util.spec_from_file_location("check_oss_safe", _GUARD)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+def test_clean_files_pass(tmp_path: Path):
+    # A normal source file with no secrets and an allowed path → no violations.
+    assert guard.scan(["warden/sinks.py"]) == []
+
+
+def test_public_key_is_allowed():
+    # The verify-only public key is meant to ship — must not be flagged.
+    assert guard._path_violations(["keys/public.pub"]) == []
+
+
+def test_private_pem_path_blocked():
+    v = guard._path_violations(["keys/private.pem"])
+    assert v and "private.pem" in v[0]
+
+
+def test_pem_and_key_suffixes_blocked():
+    v = guard._path_violations(["foo/server.pem", "secrets/app.key", "home/.env"])
+    assert len(v) == 3
+
+
+def test_pem_private_key_content_detected(tmp_path: Path):
+    f = tmp_path / "leak.txt"
+    f.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n")
+    # Point the guard at a temp tree by faking REPO_ROOT for the read.
+    orig = guard.REPO_ROOT
+    guard.REPO_ROOT = tmp_path
+    try:
+        v = guard._content_violations(["leak.txt"])
+    finally:
+        guard.REPO_ROOT = orig
+    assert v and "PEM private key" in v[0]
+
+
+def test_aws_and_github_secrets_detected(tmp_path: Path):
+    f = tmp_path / "creds.txt"
+    f.write_text("AKIAIOSFODNN7EXAMPLE\nghp_0123456789abcdefghijklmnopqrstuvwxyz\n")
+    orig = guard.REPO_ROOT
+    guard.REPO_ROOT = tmp_path
+    try:
+        v = guard._content_violations(["creds.txt"])
+    finally:
+        guard.REPO_ROOT = orig
+    assert len(v) >= 2
+
+
+def test_guard_does_not_flag_itself():
+    # The guard file contains the signature regexes; it must be exempt.
+    assert guard._content_violations([guard.SELF]) == []
+
+
+def test_repo_is_currently_clean():
+    # The live public repo (all git-tracked files) must pass — this is the real
+    # CI assertion and guards against a regression sneaking a secret in.
+    assert guard.scan([]) == []

--- a/tests/test_prismor_sink_url_pin.py
+++ b/tests/test_prismor_sink_url_pin.py
@@ -1,0 +1,40 @@
+"""Regression: the `prismor` control-plane sink ignores a local `url` override.
+
+The prismor sink uploads with `Authorization: Bearer <device_key>`
+(warden/sinks.py upload_telemetry). If a local `.prismor-warden/policy.yaml`
+could set `url:` on a `type: prismor` sink, anyone who lands a file in a repo
+could redirect that device-key credential to an attacker endpoint. The sink must
+pin the destination to the enrolled identity's api_base and ignore a local url.
+"""
+import warden.sinks as sinks
+import warden.enterprise.identity as ident
+import warden.enterprise.telemetry as telem
+
+
+def test_prismor_sink_ignores_local_url(monkeypatch, capsys):
+    captured = {}
+
+    # Pretend the machine is enrolled.
+    monkeypatch.setattr(ident, "load_identity", lambda: {
+        "device_id": "d", "org_id": "o", "user_id": "u",
+        "device_key": "SECRET-KEY", "api_base": "https://prismor.dev",
+    })
+    monkeypatch.setattr(ident, "revoked_backoff_active", lambda: False)
+    # Keep record-building trivial and deterministic.
+    monkeypatch.setattr(telem, "build_record", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr(telem, "assert_redacted", lambda rec: None)
+
+    # Capture exactly how upload_telemetry is invoked.
+    monkeypatch.setattr(sinks, "upload_telemetry", lambda records, **kw: captured.update(kw=kw, records=records))
+
+    finding = {"severity": "HIGH", "category": "x", "ruleId": "r", "title": "t", "id": "s:f"}
+    sinks._dispatch_prismor(
+        {"type": "prismor", "url": "https://evil.example/steal"},  # attacker-controlled url
+        [finding], {"type": "shell"}, {},
+    )
+
+    # The attacker url must NOT be forwarded — upload falls back to the enrolled api_base.
+    assert captured, "upload_telemetry was not called"
+    assert captured["kw"].get("url_base") in (None, "https://prismor.dev")
+    # And the override is surfaced to the operator.
+    assert "ignoring `url`" in capsys.readouterr().err

--- a/warden/sinks.py
+++ b/warden/sinks.py
@@ -217,10 +217,19 @@ def _dispatch_prismor(
     if not records:
         return
 
+    # SECURITY: the prismor sink carries the device-key bearer credential
+    # (see upload_telemetry's Authorization header). A local policy.yaml could
+    # otherwise set `url:` and redirect that credential to an attacker endpoint,
+    # so the destination is PINNED to the enrolled identity's api_base and a
+    # local `url` override is ignored for type:prismor.
+    if cfg.get("url"):
+        sys.stderr.write(
+            "[warden] ignoring `url` on the prismor sink — telemetry is pinned to the "
+            "enrolled control plane (a local url override cannot redirect the device key)\n"
+        )
     upload_telemetry(
         records,
         timeout=float(cfg.get("timeout_seconds", 6)),
-        url_base=cfg.get("url"),
     )
 
 


### PR DESCRIPTION
The comprehensive open-core change set: the open-source scaffolding (license, leak guard, OPEN_CORE, CONTRIBUTING, SECURITY — from #91, included here), **plus** the connection design (how the runtime connects to the platform and how the SDKs connect) **plus** two security fixes that a multi-agent cross-review surfaced. Supersedes #91 (close that in favor of this, or merge #91 first and this reduces to the new delta).

## How this was built
Four subagents produced the platform-connection design, the SDK-connection design, and the comparison content, then **cross-judged each other's work** to find gaps. Every disputed fact was re-verified against code.

## Docs (the "how it connects" ask)
- **`docs/connecting-to-the-platform.md`** — the *client* side of the control-plane link: enroll → verify-only signed policy (fail-closed) → redacted telemetry → heartbeat → revocation, with the full trust model (device holds only the public key; what an admin can/can't see). Frames `warden/enterprise/` explicitly as the client.
- **`docs/sdk-integration.md`** — per-framework wrap points, one-line guard calls, the eval-server HTTP path, `use_subject`, and the rule that **the SDK talks only to the local runtime — only the runtime phones home.**
- **`COMPARISON.md`** — open-source vs enterprise, capability-by-capability + repo structure, grounded in real paths.
- README open-core section; `OPEN_CORE.md` rule count corrected **61 → 63**.

## Security fixes (gaps found by the cross-judging, verified + tested)
- **CRITICAL — device-key exfiltration.** The `prismor` telemetry sink forwarded a local-policy `url:` to `upload_telemetry`, which sends `Authorization: Bearer <device_key>` — so a file landed in a repo could redirect the device credential to an attacker. Now **pinned to the enrolled `api_base`**; local `url` ignored + warned. (`warden/sinks.py`) — test: `tests/test_prismor_sink_url_pin.py`.
- **HIGH — enforcement bypass.** The runtime folds the org per-agent control (kill-switch / forced-enforce) into `Decision.allow`, but every adapter re-gated on the app-passed `mode`, so an `observe`-launched agent silently defeated the org's emergency control. **All 5 adapters now honor `Decision.allow` directly.** — test: `tests/test_adapter_enforce_regression.py`.

## Hygiene
- Adapter license reconciled to **MIT** across all 5 (matches `adapters/LICENSE`).
- **`GAPS.md`** — the full cross-judged, severity-ranked register. Deeper items are tracked follow-ups (separate PRs): subject unverified+unredacted egress, eval-server auth, the premium-feed-still-in-public migration, and fail-open uniformity.

## Verification
- Local: leak guard green (210 files); new security tests pass; **all 23 existing adapter tests still pass** (no behavior regression).
- **On st3ve** (`~/Prismor/prismor`, this branch): 19 tests pass (security regressions + adapter suite + guard self-tests) and the leak guard is clean.