### PR TITLE
docs(adapters): how to trace findings to the control plane

### DIFF
--- a/adapters/browser-use/README.md
+++ b/adapters/browser-use/README.md
@@ -48,3 +48,19 @@ with use_subject("user:alice"):                # per-request
 
 Denied actions return a string to the LLM (`⛔ Prismor Warden blocked …`) so the
 agent recovers gracefully. Use `raise_on_block=True` to raise `WardenBlocked` instead.
+
+## Trace findings to your control plane
+
+Guarding evaluates tool calls, but findings only **upload** when the machine is
+enrolled (`~/.prismor/identity.json`) **and** the workspace policy enables the
+telemetry sink:
+
+```yaml
+# .prismor-warden/policy.yaml
+settings:
+  outputs:
+    - type: prismor        # POSTs each finding to {api_base}/api/telemetry/ingest
+```
+
+Set `api_base` to `http://localhost:3000` to trace into a local dev control
+plane instead of prod. No sink → the agent runs but nothing reaches the dashboard.

--- a/adapters/crewai/README.md
+++ b/adapters/crewai/README.md
@@ -28,3 +28,19 @@ is log-only.
 
 `subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes policy,
 IAM profile selection, and telemetry to the end-user.
+
+## Trace findings to your control plane
+
+Guarding evaluates tool calls, but findings only **upload** when the machine is
+enrolled (`~/.prismor/identity.json`) **and** the workspace policy enables the
+telemetry sink:
+
+```yaml
+# .prismor-warden/policy.yaml
+settings:
+  outputs:
+    - type: prismor        # POSTs each finding to {api_base}/api/telemetry/ingest
+```
+
+Set `api_base` to `http://localhost:3000` to trace into a local dev control
+plane instead of prod. No sink → the agent runs but nothing reaches the dashboard.

--- a/adapters/langchain/README.md
+++ b/adapters/langchain/README.md
@@ -46,3 +46,31 @@ agent.invoke({...}, config={"callbacks": [WardenCallbackHandler(subject="user:al
 
 Captures and evaluates every tool call via `on_tool_start` even for tools you did
 not wrap (raises to abort the call in enforce mode).
+
+## Trace findings to your control plane
+
+Guarding a tool evaluates it, but findings only **upload** to your Prismor
+control plane if two things are in place — otherwise `evaluate_tool_call` runs
+locally and silently ships nothing:
+
+1. **An enrolled identity** at `~/.prismor/identity.json` (or `$PRISMOR_HOME`),
+   written by `prismor enroll <token>`. It carries the `device_key` +
+   `api_base` the telemetry sink authenticates with.
+
+2. **The `prismor` telemetry sink** in your workspace policy — this is the
+   switch that turns findings into uploads:
+
+   ```yaml
+   # .prismor-warden/policy.yaml
+   settings:
+     outputs:
+       - type: prismor        # POSTs each finding to {api_base}/api/telemetry/ingest
+   ```
+
+Each finding is then attributed with the framework (`langchain`), the
+`subject` (end-user), the device, verdict, and category. Point `api_base` at
+`http://localhost:3000` to trace into a local dev control plane instead of prod.
+
+> If your agent runs but nothing shows up in the dashboard, it's almost always a
+> missing `outputs: [{type: prismor}]` in the active policy, or an un-enrolled
+> machine.

--- a/adapters/openai-agents/README.md
+++ b/adapters/openai-agents/README.md
@@ -60,3 +60,19 @@ By default the emitted event `type` is `shell`, so existing rules like
 `destructive-command` and `secret-exfiltration` apply to tool arguments. Pass
 `event_type="file_write"` / `"network"` / `"tool_result"` (and a
 `command_builder`) for tools whose risk lives in a path, URL, or output.
+
+## Trace findings to your control plane
+
+Guarding evaluates tool calls, but findings only **upload** when the machine is
+enrolled (`~/.prismor/identity.json`) **and** the workspace policy enables the
+telemetry sink:
+
+```yaml
+# .prismor-warden/policy.yaml
+settings:
+  outputs:
+    - type: prismor        # POSTs each finding to {api_base}/api/telemetry/ingest
+```
+
+Set `api_base` to `http://localhost:3000` to trace into a local dev control
+plane instead of prod. No sink → the agent runs but nothing reaches the dashboard.


### PR DESCRIPTION
## The issue I hit
While standing up the live telemetry harness with real LangChain agents on two machines, the agents guarded and evaluated tool calls correctly — but **nothing showed up in the dashboard**. The cause: findings only upload when the workspace policy has the `prismor` telemetry sink in `settings.outputs`, and that requirement was **undocumented**. `evaluate_tool_call` runs fine without it and silently ships nothing.

## Fix
Adds a **"Trace findings to your control plane"** section to all four adapter READMEs (full version in `langchain`, concise pointer in `crewai` / `openai-agents` / `browser-use`):

```yaml
# .prismor-warden/policy.yaml
settings:
  outputs:
    - type: prismor        # POSTs each finding to {api_base}/api/telemetry/ingest
```

Also documents enrollment (`~/.prismor/identity.json`) and pointing `api_base` at `http://localhost:3000` for local testing. Verified end-to-end: with the sink enabled, findings arrived fully attributed (framework + subject + device + verdict). Docs-only.