### PR TITLE
chore: scrub internal hostname from public files

### DIFF
--- a/docs/frameworks-browser-use.md
+++ b/docs/frameworks-browser-use.md
@@ -98,7 +98,7 @@ URL query parameter — no additional configuration needed.
 
 ## Live-validated blocks
 
-Tested on st3ve with `browser-use 0.13.1` and the real `Controller` object:
+Tested on a Linux host with `browser-use 0.13.1` and the real `Controller` object:
 
 | Action | URL / args | Result |
 |---|---|---|

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -189,7 +189,7 @@ redeploying TypeScript code.
 ## Other languages
 
 The eval-server speaks plain JSON over HTTP, so any language can act as an
-adapter. Validated on st3ve with real OpenAI function calls:
+adapter. Validated on a Linux host with real OpenAI function calls:
 
 | Language | HTTP client | Lines of adapter code |
 |---|---|---|

--- a/warden/semantic_guard_v2.py
+++ b/warden/semantic_guard_v2.py
@@ -2,7 +2,7 @@
 SemanticGuard v2 — local LLM subagent edition.
 
 Uses the Claude Code CLI (~/.local/bin/claude) already installed and
-authenticated on st3ve as the semantic analysis subagent. No API key
+authenticated on the host as the semantic analysis subagent. No API key
 configuration required — Claude Code's own session handles auth.
 
 Pipeline:


### PR DESCRIPTION
Removes the internal machine name **st3ve** from 3 tracked files in the public repo — internal infra naming shouldn't ship in OSS:
- `docs/frameworks-browser-use.md` → "a Linux host"
- `docs/frameworks-vercel-ai.md` → "a Linux host"
- `warden/semantic_guard_v2.py` (comment) → "the host"

Audited the rest: the `prism_dev_x`/`prism_dev_abc` hits are test fixtures (fake keys), `sk-proj-abc…` is a truncated example, and `openclaw` is a documented supported-agent integration — all legitimate. No secrets, DB URLs, IPs, or local paths found in tracked files.