### PR TITLE
Fix curl installer, ship missing sandbox module, clean rename leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,12 @@ prismor setup          # interactive 4-step onboarding wizard
 **Option D: git clone + wizard:**
 
 ```bash
-pip3 install pyyaml                          # required dependency
+pip3 install pyyaml                          # on Debian/Ubuntu use: sudo apt install python3-yaml
 git clone https://github.com/PrismorSec/prismor.git ~/.prismor
 PRISMOR_MODE=enforce PRISMOR_CLOAK=1 bash ~/.prismor/scripts/init.sh .
 ```
+
+> On externally-managed Pythons (PEP 668 — Ubuntu 23.04+, Homebrew) `pip3 install` refuses to run; install PyYAML from your system package manager instead (`sudo apt install python3-yaml`, `brew install pyyaml`, …). `init.sh` will tell you if it's missing.
 
 This installs enforce-mode Warden hooks and the Cloak prevention layer. To register a secret, run `prismor cloak add stripe_key` and enter the value when prompted. Reference it in tool calls as `@@SECRET:stripe_key@@` and the hook handles the rest.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,6 +2,8 @@
 
 When running AI agents in containers (Docker, Kubernetes, CI runners), Warden provides runtime monitoring but containers require additional hardening to be secure. The agent process has the same filesystem and network access as any other process running as that user.
 
+Warden also includes an opt-in Docker-backed command sandbox for Claude Code Bash tool calls. This is defense in depth: Warden still evaluates the original command against policy first, then rewrites allowed Bash commands to run through `immunity sandbox run`.
+
 ## Prerequisites
 
 Warden requires **PyYAML** for its policy engine. Without it, all rules are silently disabled:
@@ -38,6 +40,55 @@ settings:
     - "api.anthropic.com"
 ```
 
+## Warden Bash Sandbox
+
+Enable the Docker-backed sandbox per project:
+
+```yaml
+# .prismor-warden/policy.yaml
+version: "1.0"
+
+settings:
+  sandbox:
+    enabled: true
+    mode: enforce
+    image: python:3.12-slim
+    network: none
+    workspace_mount: rw
+    read_only_root: true
+    resource_limits:
+      cpus: "1.0"
+      memory: 1g
+      pids_limit: 256
+      timeout_seconds: 300
+
+rules: []
+allowlists: []
+```
+
+Check readiness:
+
+```bash
+immunity sandbox status
+immunity sandbox check
+immunity sandbox run -- "echo hello from sandbox"
+```
+
+Install regular Warden hooks for Claude. No separate sandbox hook is needed:
+
+```bash
+immunity install-hooks --agent claude --mode enforce
+```
+
+When sandboxing is enabled, the Claude `PreToolUse:Bash` hook path works in this order:
+
+1. Normalize the original Bash command.
+2. Evaluate Warden policy, scoped-agent rules, IAM, and evasion checks.
+3. If the command is allowed, rewrite it to `immunity sandbox run --encoded ...`.
+4. The sandbox runner executes the original command inside Docker with a bind-mounted workspace, dropped capabilities, no-new-privileges, resource limits, and the configured network mode.
+
+`network: allowlist` currently fails closed to Docker `--network none`. Docker alone cannot enforce domain allowlists; use `network: none` for hard isolation or `network: bridge` / `host` only when the task genuinely needs outbound access.
+
 ## Known Limitations
 
 Warden monitors tool-use events (shell commands, file reads/writes, network calls). The following attack patterns cannot be detected by tool-level hooks alone:
@@ -49,6 +100,8 @@ Warden monitors tool-use events (shell commands, file reads/writes, network call
 | Symlink reads (after creation)         | File read hook sees the apparent path, not the symlink target                    | Symlink creation is detected; resolve symlinks in your hook scripts                 |
 | Multi-step social engineering          | Each step (read file, encode, send) is individually benign                       | Session-level correlation (roadmap)                                                 |
 | Project-level policy overrides         | `.prismor-warden/policy.yaml` can disable rules                                  | Make policy files read-only: `chmod 444 .prismor-warden/policy.yaml`                |
+| Domain allowlists inside Docker        | Docker has network modes, not domain-aware egress policy                         | `network: none` by default; use proxy/firewall integration in a future backend      |
+| Non-Claude agent command mutation      | Not every agent hook API supports safe input rewriting                           | Use `immunity sandbox run -- <cmd>` directly; hook-based sandboxing starts with Claude Bash |
 
 ## Post-Install Verification
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
 set -e
 
-# Prismor immunity-agent installer
+# Prismor installer
 # Usage: curl -sSL https://prismor.dev/install | sh
 
-PACKAGE="immunity-agent"
+# The `prismor` distribution owns the console entry points (prismor, immunity,
+# warden). Installing the legacy `immunity-agent` shim instead makes pipx
+# refuse ("No apps associated with package") and leaves nothing on PATH.
+PACKAGE="prismor"
 
-echo "Installing Prismor immunity-agent..."
+echo "Installing Prismor..."
 
 install_pipx() {
     if command -v apt-get >/dev/null 2>&1; then
@@ -23,6 +26,12 @@ install_pipx() {
     fi
 }
 
+pipx_install() {
+    pipx install "$PACKAGE"
+    # Make sure pipx's bin dir (~/.local/bin) is on PATH for new shells.
+    pipx ensurepath >/dev/null 2>&1 || true
+}
+
 try_pip_install() {
     local pip_cmd="$1"
     output=$($pip_cmd install "$PACKAGE" 2>&1)
@@ -35,20 +44,20 @@ try_pip_install() {
 
 # 1. pipx already available — preferred path
 if command -v pipx >/dev/null 2>&1; then
-    pipx install "$PACKAGE"
+    pipx_install
 # 2. pip available — try it; fall back to pipx if externally managed
 elif command -v pip >/dev/null 2>&1; then
     if ! try_pip_install pip; then
         echo "pip blocked by externally-managed environment. Installing pipx..."
         install_pipx
-        pipx install "$PACKAGE"
+        pipx_install
     fi
 # 3. pip3 available — same logic
 elif command -v pip3 >/dev/null 2>&1; then
     if ! try_pip_install pip3; then
         echo "pip3 blocked by externally-managed environment. Installing pipx..."
         install_pipx
-        pipx install "$PACKAGE"
+        pipx_install
     fi
 else
     echo "Error: Python pip not found. Install Python from https://python.org and try again."
@@ -56,4 +65,4 @@ else
 fi
 
 echo ""
-echo "Run 'prismor setup' to get started."
+echo "Run 'prismor setup' to get started (open a new shell if the command is not found)."

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -640,7 +640,9 @@ def do_install(target, mode, rules, agents, hooks=None):
     def info(k, v):
         print(f"  {w(k + ':', GRN)}  {w(v, DIM)}")
     n_hooks = sum(1 for d in HOOK_DEFS if hooks.get(d["id"], d["default"]))
-    info("Hooks",      f"{n_hooks}/{len(HOOK_DEFS)} installed  (mode: {mode})")
+    hooks_off = [d["label"] for d in HOOK_DEFS if not hooks.get(d["id"], d["default"])]
+    off_note = f"  — off by choice: {', '.join(hooks_off)}" if hooks_off else ""
+    info("Hooks",      f"{n_hooks}/{len(HOOK_DEFS)} layers enabled  (mode: {mode}){off_note}")
     if "claude" in agents:
         info("Skill",  str(target / ".claude" / "skills" / "immunity-agent").replace(home, "~"))
     info("Docs",       "https://github.com/PrismorSec/prismor")

--- a/supplychain/cli.py
+++ b/supplychain/cli.py
@@ -118,7 +118,7 @@ def _print_report(event, verdicts, feed_hits: list, recommendations=None) -> Non
     recommendations = recommendations or {}
 
     print()
-    print(f"  {_c('IMMUNITY', _BOLD)}  supply chain  {_c(f'[{event.ecosystem}]', _DIM)}")
+    print(f"  {_c('PRISMOR', _BOLD)}  supply chain  {_c(f'[{event.ecosystem}]', _DIM)}")
     print(f"  {_c('─' * 52, _DIM)}")
     print()
 

--- a/supplychain/hardener.py
+++ b/supplychain/hardener.py
@@ -330,7 +330,7 @@ def print_harden_report(
 ) -> None:
     print()
     suffix = _c("  [dry run — no files written]", _YELLOW) if dry_run else ""
-    print(f"  {_c('IMMUNITY', _BOLD)}  harden  {_c(str(root), _DIM)}{suffix}")
+    print(f"  {_c('PRISMOR', _BOLD)}  harden  {_c(str(root), _DIM)}{suffix}")
     print(f"  {_c('─' * 60, _DIM)}")
     print()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,11 @@ class TestCliExitCodes(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
         self.assertIn("--agent", r.stdout)
 
+    def test_sandbox_help(self):
+        r = run_cli("sandbox", "--help")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("Docker-backed sandbox", r.stdout)
+
 
 class TestCliCommandConsolidation(unittest.TestCase):
     """info→status, dashboard/serve, and status --all consolidation."""
@@ -170,7 +175,7 @@ class TestImmunityUmbrella(unittest.TestCase):
         # Every advertised domain must appear in the top-level help.
         for domain in (
             "warden", "cloak", "policy", "sweep",
-            "iam", "canary", "scope", "learn", "supplychain",
+            "iam", "sandbox", "canary", "scope", "learn", "supplychain",
         ):
             self.assertIn(domain, r.stdout, f"domain '{domain}' missing from --help")
         # Quick-start shortcuts must appear too.

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,119 @@
+"""Tests for Docker-backed Warden sandbox support."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from warden import sandbox
+from warden.cli import build_parser
+from warden.policy_engine import PolicyEngine, validate_policy
+
+
+class TestSandboxConfig(unittest.TestCase):
+    def test_default_config_is_disabled_and_safe(self):
+        cfg = sandbox.effective_config({})
+        self.assertFalse(cfg["enabled"])
+        self.assertEqual(cfg["backend"], "docker")
+        self.assertEqual(cfg["network"], "none")
+        self.assertTrue(cfg["read_only_root"])
+
+    def test_policy_engine_loads_sandbox_config(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "policy.yaml"
+            p.write_text(
+                'version: "1.0"\n'
+                "settings:\n"
+                "  sandbox:\n"
+                "    enabled: true\n"
+                "    mode: enforce\n"
+                "    network: none\n"
+                "rules: []\n",
+                encoding="utf-8",
+            )
+            engine = PolicyEngine(policy_path=p)
+            cfg = sandbox.effective_config(engine.sandbox_config)
+            self.assertTrue(cfg["enabled"])
+            self.assertEqual(cfg["mode"], "enforce")
+
+    def test_schema_accepts_sandbox_settings(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(
+                'version: "1.0"\n'
+                "settings:\n"
+                "  sandbox:\n"
+                "    enabled: true\n"
+                "    backend: docker\n"
+                "    mode: enforce\n"
+                "    network: none\n"
+                "rules: []\n"
+            )
+            path = Path(f.name)
+        try:
+            self.assertEqual(validate_policy(path), [])
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestSandboxCommandHandling(unittest.TestCase):
+    def test_command_round_trip_encoding(self):
+        command = "printf '%s\\n' hello && echo done"
+        encoded = sandbox.encode_command(command)
+        self.assertEqual(sandbox.decode_command(encoded), command)
+
+    def test_docker_argv_keeps_original_command_as_single_container_arg(self):
+        cfg = sandbox.effective_config({
+            "image": "example/sandbox:latest",
+            "network": "allowlist",
+            "resource_limits": {
+                "cpus": "2.0",
+                "memory": "2g",
+                "pids_limit": 128,
+                "timeout_seconds": 60,
+            },
+        })
+        command = "echo safe; touch /tmp/proof"
+        argv = sandbox.build_docker_argv(command, workspace=Path("/tmp/work"), config=cfg)
+        self.assertIn("--network", argv)
+        self.assertEqual(argv[argv.index("--network") + 1], "none")
+        self.assertIn("--cap-drop", argv)
+        self.assertIn("no-new-privileges", argv)
+        mount = argv[argv.index("--mount") + 1]
+        self.assertEqual(mount, f"type=bind,src={Path('/tmp/work').resolve()},dst=/workspace")
+        self.assertEqual(argv[-3:], ["/bin/sh", "-lc", command])
+
+    def test_docker_argv_uses_readonly_for_ro_workspace_mount(self):
+        cfg = sandbox.effective_config({"workspace_mount": "ro"})
+        argv = sandbox.build_docker_argv("echo ok", workspace=Path("/tmp/work"), config=cfg)
+        mount = argv[argv.index("--mount") + 1]
+        self.assertEqual(mount, f"type=bind,src={Path('/tmp/work').resolve()},dst=/workspace,readonly")
+
+    def test_claude_updated_input_uses_encoded_runner(self):
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hello", "description": "test"},
+        }
+        update = sandbox.claude_updated_input(
+            payload,
+            workspace=Path("/tmp/work"),
+            mode="enforce",
+        )
+        self.assertIsNotNone(update)
+        updated = update["hookSpecificOutput"]["updatedInput"]
+        self.assertEqual(updated["description"], "test")
+        self.assertIn("sandbox --workspace /tmp/work run", updated["command"])
+        self.assertIn("--encoded", updated["command"])
+        self.assertNotIn("echo hello", updated["command"])
+
+    def test_sandbox_run_parser_does_not_clobber_top_level_command(self):
+        args = build_parser().parse_args(["sandbox", "run", "--encoded", "abc"])
+        self.assertEqual(args.command, "sandbox")
+        self.assertEqual(args.sandbox_command, "run")
+        self.assertEqual(args.encoded, "abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warden/audit.py
+++ b/warden/audit.py
@@ -8,6 +8,7 @@ Performs a single-shot check across all Warden subsystems:
   5. Feed signature        — Ed25519 signature verification
   6. Egress allowlist      — is network lockdown configured?
   7. Network isolation     — are network rules enabled?
+  8. Sandbox readiness     — is Docker sandboxing configured and available?
 
 Each check returns findings with a severity, a human-readable message,
 and an optional auto-fix function for ``prismor audit --fix``.
@@ -80,6 +81,7 @@ def run_audit(
     findings.extend(_check_feed_signature(repo_root))
     findings.extend(_check_egress_allowlist(workspace))
     findings.extend(_check_network_rules(workspace))
+    findings.extend(_check_sandbox(workspace))
     findings.extend(_check_lockfile_presence(workspace))
 
     findings.sort(key=lambda f: AuditFinding.SEVERITY_ORDER.get(f.severity, 99))
@@ -468,6 +470,89 @@ def _check_network_rules(workspace: Path) -> List[AuditFinding]:
             severity="PASS",
             category="network",
             message=f"All {len(network_rule_ids)} network isolation rules active",
+        ))
+
+    return findings
+
+
+def _check_sandbox(workspace: Path) -> List[AuditFinding]:
+    """Check Docker sandbox configuration and backend readiness."""
+    findings: List[AuditFinding] = []
+
+    try:
+        from warden import sandbox as sandbox_mod
+    except ImportError:
+        findings.append(AuditFinding(
+            severity="MEDIUM",
+            category="sandbox",
+            message="Sandbox module not available",
+        ))
+        return findings
+
+    engine = PolicyEngine(workspace=workspace)
+    cfg = sandbox_mod.effective_config(getattr(engine, "sandbox_config", {}))
+
+    if not cfg.get("enabled"):
+        findings.append(AuditFinding(
+            severity="LOW",
+            category="sandbox",
+            message="Docker sandboxing is disabled — Bash commands run on the host after policy checks",
+        ))
+        return findings
+
+    status = sandbox_mod.docker_status()
+    if not status.get("cli_found"):
+        findings.append(AuditFinding(
+            severity="HIGH" if cfg.get("mode") == "enforce" else "MEDIUM",
+            category="sandbox",
+            message="Docker sandboxing is enabled but the docker CLI was not found",
+        ))
+    elif not status.get("server_reachable"):
+        findings.append(AuditFinding(
+            severity="HIGH" if cfg.get("mode") == "enforce" else "MEDIUM",
+            category="sandbox",
+            message=f"Docker sandboxing is enabled but Docker is not reachable: {status.get('error') or 'unknown error'}",
+        ))
+    else:
+        findings.append(AuditFinding(
+            severity="PASS",
+            category="sandbox",
+            message=f"Docker sandbox backend available (image: {cfg.get('image')})",
+        ))
+
+    if cfg.get("network") in {"host", "bridge"}:
+        findings.append(AuditFinding(
+            severity="MEDIUM",
+            category="sandbox",
+            message=f"Sandbox network mode is {cfg.get('network')} — use 'none' for strongest exfiltration protection",
+        ))
+    else:
+        findings.append(AuditFinding(
+            severity="PASS",
+            category="sandbox",
+            message="Sandbox network is disabled by default",
+        ))
+
+    if not cfg.get("read_only_root", True):
+        findings.append(AuditFinding(
+            severity="MEDIUM",
+            category="sandbox",
+            message="Sandbox read_only_root is disabled",
+        ))
+
+    limits = cfg.get("resource_limits") or {}
+    missing_limits = [name for name in ("cpus", "memory", "pids_limit", "timeout_seconds") if not limits.get(name)]
+    if missing_limits:
+        findings.append(AuditFinding(
+            severity="MEDIUM",
+            category="sandbox",
+            message=f"Sandbox resource limits missing: {', '.join(missing_limits)}",
+        ))
+    else:
+        findings.append(AuditFinding(
+            severity="PASS",
+            category="sandbox",
+            message="Sandbox resource limits configured",
         ))
 
     return findings

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1019,7 +1019,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     sys.stderr.write(f"error: invalid encoded command: {exc}\n")
                     raise SystemExit(1)
             elif not cmd:
-                pieces = getattr(args, "command", None) or []
+                pieces = getattr(args, "sandbox_args", None) or []
                 if pieces and pieces[0] == "--":
                     pieces = pieces[1:]
                 cmd = " ".join(pieces)
@@ -1869,7 +1869,7 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox_run = sandbox_sub.add_parser("run", help="Run a command inside the configured sandbox")
     sandbox_run.add_argument("--mode", choices=["observe", "enforce"], help="Override sandbox mode for this run")
     sandbox_run.add_argument("--encoded", help="Base64url-encoded command string (used by hooks)")
-    sandbox_run.add_argument("command", nargs=argparse.REMAINDER, help="Command after --")
+    sandbox_run.add_argument("sandbox_args", nargs=argparse.REMAINDER, help="Command after --")
     sandbox_run.add_argument("--command-string", help=argparse.SUPPRESS)
 
     # ── status ─────────────────────────────────────────────────────────

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1164,7 +1164,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
         if subcmd == "list" or subcmd is None:
             agents = _list_agents(workspace)
-            print(f"\n  {_color('PRISMOR IMMUNITY', _BOLD)}  named agents\n")
+            print(f"\n  {_color('PRISMOR', _BOLD)}  named agents\n")
             print(_fmt_agent_table(agents))
             print()
             return

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -41,6 +41,30 @@ settings:
   #     - "api.anthropic.com"
   #     - "api.openai.com"
 
+  # Docker-backed shell sandboxing. Disabled by default so existing installs
+  # do not change behavior until an operator opts in. When enabled for Claude
+  # Code, Warden evaluates the original Bash command first, then rewrites the
+  # allowed command to run through `immunity sandbox run`.
+  sandbox:
+    enabled: false
+    backend: docker
+    mode: observe
+    image: python:3.12-slim
+    workdir: /workspace
+    network: none
+    workspace_mount: rw
+    read_only_root: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=256m
+    env_allowlist:
+      - NO_COLOR
+      - TERM
+    resource_limits:
+      cpus: "1.0"
+      memory: 1g
+      pids_limit: 256
+      timeout_seconds: 300
+
   # Action for MCP remote-transport static findings raised by `warden scan`:
   # cleartext transport (http://), raw-IP endpoints, endpoints not on the
   # egress allowlist, and hardcoded secrets in a server's headers/env.

--- a/warden/policy_schema.json
+++ b/warden/policy_schema.json
@@ -57,6 +57,70 @@
                     "type": "object",
                     "description": "Settings for the optional LLM-assisted semantic prompt-injection layer.",
                     "additionalProperties": true
+                },
+                "sandbox": {
+                    "type": "object",
+                    "description": "Docker-backed shell sandbox settings for constraining allowed Bash commands.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether hook-dispatch rewrites supported Bash tool calls through the sandbox runner."
+                        },
+                        "backend": {
+                            "type": "string",
+                            "enum": ["docker"],
+                            "description": "Sandbox backend. Docker is the v1 backend."
+                        },
+                        "mode": {
+                            "type": "string",
+                            "enum": ["observe", "enforce"],
+                            "description": "observe logs unavailable sandbox state; enforce fails closed when the sandbox is unavailable."
+                        },
+                        "image": {
+                            "type": "string",
+                            "description": "Container image used for sandboxed shell execution."
+                        },
+                        "workdir": {
+                            "type": "string",
+                            "description": "Container working directory for the workspace mount."
+                        },
+                        "network": {
+                            "type": "string",
+                            "enum": ["none", "bridge", "host", "allowlist"],
+                            "description": "Docker network mode. allowlist currently fails closed to none because Docker cannot enforce domain allowlists by itself."
+                        },
+                        "workspace_mount": {
+                            "type": "string",
+                            "enum": ["ro", "rw"],
+                            "description": "Whether the workspace bind mount is read-only or read-write."
+                        },
+                        "read_only_root": {
+                            "type": "boolean",
+                            "description": "Run the container with a read-only root filesystem."
+                        },
+                        "tmpfs": {
+                            "type": "array",
+                            "description": "Docker --tmpfs entries for controlled writable scratch space.",
+                            "items": { "type": "string" }
+                        },
+                        "env_allowlist": {
+                            "type": "array",
+                            "description": "Host environment variable names allowed into the sandbox.",
+                            "items": { "type": "string" }
+                        },
+                        "resource_limits": {
+                            "type": "object",
+                            "description": "Docker resource limits.",
+                            "properties": {
+                                "cpus": { "type": "string" },
+                                "memory": { "type": "string" },
+                                "pids_limit": { "type": "integer" },
+                                "timeout_seconds": { "type": "integer" }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false

--- a/warden/sandbox.py
+++ b/warden/sandbox.py
@@ -1,0 +1,247 @@
+"""Docker-backed sandbox runner for Warden shell commands.
+
+The sandbox is defense in depth: Warden policy still decides whether a command
+is allowed, then this module constrains where the allowed command executes.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_SANDBOX_CONFIG: Dict[str, Any] = {
+    "enabled": False,
+    "backend": "docker",
+    "mode": "observe",
+    "image": "python:3.12-slim",
+    "workdir": "/workspace",
+    "network": "none",
+    "workspace_mount": "rw",
+    "read_only_root": True,
+    "tmpfs": ["/tmp:noexec,nosuid,size=256m"],
+    "env_allowlist": ["NO_COLOR", "TERM"],
+    "resource_limits": {
+        "cpus": "1.0",
+        "memory": "1g",
+        "pids_limit": 256,
+        "timeout_seconds": 300,
+    },
+}
+
+_VALID_NETWORKS = {"none", "bridge", "host", "allowlist"}
+_VALID_MOUNTS = {"ro", "rw"}
+
+
+def effective_config(raw: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return sandbox config with safe defaults applied."""
+    cfg = _deep_merge(DEFAULT_SANDBOX_CONFIG, raw or {})
+    cfg["backend"] = str(cfg.get("backend") or "docker").lower()
+    cfg["mode"] = str(cfg.get("mode") or "observe").lower()
+    cfg["network"] = str(cfg.get("network") or "none").lower()
+    cfg["workspace_mount"] = str(cfg.get("workspace_mount") or "rw").lower()
+
+    if cfg["backend"] != "docker":
+        cfg["backend"] = "docker"
+    if cfg["mode"] not in {"observe", "enforce"}:
+        cfg["mode"] = "observe"
+    if cfg["network"] not in _VALID_NETWORKS:
+        cfg["network"] = "none"
+    if cfg["workspace_mount"] not in _VALID_MOUNTS:
+        cfg["workspace_mount"] = "rw"
+    if not isinstance(cfg.get("tmpfs"), list):
+        cfg["tmpfs"] = []
+    if not isinstance(cfg.get("env_allowlist"), list):
+        cfg["env_allowlist"] = []
+    if not isinstance(cfg.get("resource_limits"), dict):
+        cfg["resource_limits"] = {}
+    return cfg
+
+
+def is_enabled(raw: Optional[Dict[str, Any]]) -> bool:
+    return bool(effective_config(raw).get("enabled"))
+
+
+def docker_status() -> Dict[str, Any]:
+    """Return Docker CLI/server availability without mutating state."""
+    docker = shutil.which("docker")
+    status: Dict[str, Any] = {
+        "backend": "docker",
+        "cli_found": bool(docker),
+        "cli_path": docker,
+        "server_reachable": False,
+    }
+    if not docker:
+        status["error"] = "docker CLI not found"
+        return status
+    try:
+        result = subprocess.run(
+            [docker, "info", "--format", "{{json .ServerVersion}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        status["error"] = str(exc)
+        return status
+    status["server_reachable"] = result.returncode == 0
+    if result.returncode == 0:
+        status["server_version"] = result.stdout.strip().strip('"')
+    else:
+        status["error"] = (result.stderr or result.stdout).strip()
+    return status
+
+
+def encode_command(command: str) -> str:
+    return base64.urlsafe_b64encode(command.encode("utf-8")).decode("ascii")
+
+
+def decode_command(encoded: str) -> str:
+    return base64.urlsafe_b64decode(encoded.encode("ascii")).decode("utf-8")
+
+
+def hook_update_command(*, command: str, workspace: Path, mode: str) -> str:
+    """Build the safe host command used in Claude's updated Bash input."""
+    py = shlex.quote(sys.executable or "python3")
+    ws = shlex.quote(str(workspace))
+    encoded = shlex.quote(encode_command(command))
+    mode_arg = shlex.quote(mode)
+    return f"{py} -m warden.immunity_cli sandbox --workspace {ws} run --mode {mode_arg} --encoded {encoded}"
+
+
+def claude_updated_input(payload: Dict[str, Any], *, workspace: Path, mode: str) -> Optional[Dict[str, Any]]:
+    """Return Claude hook JSON that rewrites Bash input into sandbox execution."""
+    if payload.get("tool_name") != "Bash":
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    command = str(tool_input.get("command") or "")
+    if not command:
+        return None
+    new_input = dict(tool_input)
+    new_input["command"] = hook_update_command(command=command, workspace=workspace, mode=mode)
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "updatedInput": new_input,
+        }
+    }
+
+
+def build_docker_argv(command: str, *, workspace: Path, config: Dict[str, Any]) -> List[str]:
+    """Build a Docker argv list. The original command is never interpolated locally."""
+    cfg = effective_config(config)
+    docker = shutil.which("docker") or "docker"
+    limits = cfg.get("resource_limits") or {}
+    workspace = workspace.resolve()
+    workdir = str(cfg.get("workdir") or "/workspace")
+    image = str(cfg.get("image") or DEFAULT_SANDBOX_CONFIG["image"])
+    network = cfg.get("network") or "none"
+    if network == "allowlist":
+        # Docker cannot enforce domain allowlists by itself. Fail closed by
+        # using no network; hook-level egress findings still explain intent.
+        network = "none"
+
+    mount_spec = f"type=bind,src={workspace},dst={workdir}"
+    if cfg["workspace_mount"] == "ro":
+        mount_spec += ",readonly"
+
+    argv = [
+        docker,
+        "run",
+        "--rm",
+        "--network",
+        str(network),
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--workdir",
+        workdir,
+        "--mount",
+        mount_spec,
+    ]
+
+    if cfg.get("read_only_root", True):
+        argv.append("--read-only")
+    for entry in cfg.get("tmpfs") or []:
+        if entry:
+            argv.extend(["--tmpfs", str(entry)])
+
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        argv.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+
+    if limits.get("cpus"):
+        argv.extend(["--cpus", str(limits["cpus"])])
+    if limits.get("memory"):
+        argv.extend(["--memory", str(limits["memory"])])
+    if limits.get("pids_limit"):
+        argv.extend(["--pids-limit", str(limits["pids_limit"])])
+
+    for name in cfg.get("env_allowlist") or []:
+        name = str(name)
+        if name in os.environ:
+            argv.extend(["--env", f"{name}={os.environ[name]}"])
+
+    argv.extend([image, "/bin/sh", "-lc", command])
+    return argv
+
+
+def run(command: str, *, workspace: Path, config: Dict[str, Any]) -> int:
+    """Run command inside the configured Docker sandbox."""
+    cfg = effective_config(config)
+    status = docker_status()
+    if not status.get("cli_found") or not status.get("server_reachable"):
+        sys.stderr.write(f"Prismor sandbox unavailable: {status.get('error') or 'Docker is not reachable'}\n")
+        return 127
+
+    argv = build_docker_argv(command, workspace=workspace, config=cfg)
+    timeout = cfg.get("resource_limits", {}).get("timeout_seconds", 300)
+    try:
+        proc = subprocess.run(argv, timeout=float(timeout) if timeout else None)
+        return int(proc.returncode)
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"Prismor sandbox timed out after {timeout} second(s)\n")
+        return 124
+    except OSError as exc:
+        sys.stderr.write(f"Prismor sandbox failed: {exc}\n")
+        return 127
+
+
+def status_report(config: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = effective_config(config)
+    return {
+        "enabled": bool(cfg.get("enabled")),
+        "mode": cfg.get("mode"),
+        "backend": cfg.get("backend"),
+        "image": cfg.get("image"),
+        "network": cfg.get("network"),
+        "workspace_mount": cfg.get("workspace_mount"),
+        "read_only_root": bool(cfg.get("read_only_root")),
+        "docker": docker_status(),
+    }
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in base.items():
+        if isinstance(value, dict):
+            result[key] = _deep_merge(value, {})
+        elif isinstance(value, list):
+            result[key] = list(value)
+        else:
+            result[key] = value
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result

--- a/warden/setup_wizard.py
+++ b/warden/setup_wizard.py
@@ -595,7 +595,7 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
         _spinner_run("Updating Prismor", _update)
     else:
         def _pip_note():
-            return True, "run `pip install --upgrade immunity-agent` to update"
+            return True, "run `pip install --upgrade prismor` to update"
         _spinner_run("Prismor (pip install)", _pip_note)
 
     # 2. Policy overrides for disabled rules


### PR DESCRIPTION
## What

Fixes found by a fresh-install UX pass of every README command on a clean Ubuntu 24.04 box (Lightsail).

### 1. `curl -sSL https://prismor.dev/install | sh` was broken on fresh machines (P0)
The installer ran `pipx install immunity-agent`, but the `immunity-agent` shim no longer owns any console scripts (they live in the `prismor` distribution), so pipx aborts with *"No apps associated with package immunity-agent"* and **nothing lands on PATH**. Since pip is externally-managed (PEP 668) on Ubuntu 23.04+/Homebrew, the pipx path is the default path — i.e. the README's "easiest" install option failed for most new users.

- `scripts/install.sh`: `PACKAGE="prismor"`, plus `pipx ensurepath` so `~/.local/bin` is on PATH in new shells.
- Verified on a clean HOME on a real Ubuntu 24.04 box: `prismor`, `immunity`, `warden` all install and run.

### 2. `prismor sandbox` crashed on the released package
`warden/cli.py` on main references `warden.sandbox`, but `warden/sandbox.py` only existed on the unmerged `fix/enterprise-audit-p0` branch. Effects on shipped 1.13.0:
- `prismor sandbox status` → `ModuleNotFoundError` traceback (while `--help` advertises the command)
- every benign Bash `hook-dispatch` printed `[warden] sandbox error: cannot import name 'sandbox'` into agent sessions

Cherry-picked the sandbox commit (module + 119-line test file + policy schema + docker docs). The one conflict (`immunity_cli.py` static command tables) resolved to main's introspection-driven routing, which picks up the `sandbox` subparser automatically.

### 3. README Option D prerequisite fails under PEP 668
`pip3 install pyyaml` refuses on externally-managed Pythons; it only worked in testing because Ubuntu preinstalls `python3-yaml`. README now points to the system package.

### 4. Rename leftovers + confusing summary
- `prismor setup` told users to `pip install --upgrade immunity-agent` right after they installed `prismor`
- `harden` / `supplychain` banners still said `IMMUNITY` (everything else says `PRISMOR`)
- setup's `Hooks: 4/5 installed` reads like a partial failure when the 5th layer (Session sweep) is just off by default — now says `4/5 layers enabled — off by choice: Session sweep`

## Testing
- `pytest tests/` — 662 passed (includes the restored `test_sandbox.py`)
- `prismor sandbox status` runs clean; benign `hook-dispatch` no longer prints sandbox noise
- Fixed installer executed end-to-end on a fresh HOME on a real Ubuntu box