### PR TITLE
feat(telemetry): carry the agent instance name to the control plane

### DIFF
--- a/tests/test_enterprise_telemetry.py
+++ b/tests/test_enterprise_telemetry.py
@@ -89,6 +89,20 @@ def test_redacted_record_carries_no_free_text():
     telemetry.assert_redacted(rec)  # must not raise
 
 
+def test_record_carries_agent_instance_name():
+    # The adapter's per-instance `name=` label must reach the control plane so
+    # the org dashboard can tell "checkout-bot" apart from other agents on the
+    # same framework. Absent a name, the field is None (framework id only).
+    named = telemetry.build_record(
+        SECRET_FINDING, SECRET_EVENT,
+        extra={"agent": "openai-agents", "agent_name": "checkout-bot"})
+    assert named["agent"] == "openai-agents"
+    assert named["agent_name"] == "checkout-bot"
+    unnamed = telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={"agent": "claude"})
+    assert unnamed["agent_name"] is None
+    telemetry.assert_redacted(named)  # names are labels, never evidence
+
+
 def test_evidence_hash_is_stable_and_distinct():
     a = telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={})
     b = telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={})

--- a/warden/enterprise/telemetry.py
+++ b/warden/enterprise/telemetry.py
@@ -175,6 +175,9 @@ def build_record(
         # org dashboard for production framework agents serving many users.
         "subject": extra.get("subject"),
         "agent": extra.get("agent"),
+        # Instance label (adapter `name=`) — distinct from the framework id, so
+        # the org dashboard can name every SDK-built agent individually.
+        "agent_name": extra.get("agent_name"),
         "mode": extra.get("mode"),
         "type": event_type,
         "verdict": _verdict(finding),

--- a/warden/runtime.py
+++ b/warden/runtime.py
@@ -189,6 +189,7 @@ def evaluate_tool_call(
         event=event,
         workspace=workspace,
         agent=agent,
+        agent_name=_agent_name if _agent_name != agent else None,
         mode=mode,
         session_id=session_id,
         subject=subject,
@@ -231,6 +232,7 @@ def _dispatch_telemetry(
     event: Dict[str, Any],
     workspace: Path,
     agent: str,
+    agent_name: Optional[str] = None,
     mode: str,
     session_id: str,
     subject: Subject,
@@ -263,7 +265,7 @@ def _dispatch_telemetry(
                 # Instance label (adapter `name=`), distinct from the framework
                 # id above — lets the org dashboard tell "checkout-bot" apart
                 # from every other agent on the same framework.
-                "agent_name": _agent_name if _agent_name != agent else None,
+                "agent_name": agent_name,
                 "mode": mode,
                 "workspace": str(workspace),
                 "policy_scope": policy_scope,

--- a/warden/runtime.py
+++ b/warden/runtime.py
@@ -260,6 +260,10 @@ def _dispatch_telemetry(
             extra={
                 "session_id": session_id,
                 "agent": agent,
+                # Instance label (adapter `name=`), distinct from the framework
+                # id above — lets the org dashboard tell "checkout-bot" apart
+                # from every other agent on the same framework.
+                "agent_name": _agent_name if _agent_name != agent else None,
                 "mode": mode,
                 "workspace": str(workspace),
                 "policy_scope": policy_scope,


### PR DESCRIPTION
Adapters already accept a per-instance `name=` (`guard_agent(agent, name='checkout-bot')`) and the runtime resolves per-agent control (kill-switch, mode, IAM profile) by that name — but telemetry only carried the framework id, so the org dashboard could never tell one SDK-built agent from another on the same framework.

- `warden/runtime.py`: sink `extra` now includes `agent_name` (only when it differs from the framework id — unnamed callers send null, no behavior change).
- `warden/enterprise/telemetry.py`: record carries `agent_name`.
- Test: named record carries both fields; unnamed stays null; `assert_redacted` still passes (names are labels, never evidence).

Server half (prismor-web): `TelemetryEvent.agentName` column + ingest mapping + per-instance rows in the admin Connections view — PR'd separately.

Full suite: 662 passed. Note: the `agent_activity` heartbeat stays framework-level (it's one aggregated counter per device); findings carry the instance name.