### PR TITLE
feat(fleet): per-instance heartbeat, registration, and org-pushed per-agent controls

### DIFF
--- a/tests/test_agents_register.py
+++ b/tests/test_agents_register.py
@@ -1,0 +1,110 @@
+"""Tests for record_seen's control-plane fleet registration (warden/agents.py).
+
+Invariants:
+  * Registration fires once per process per agent, only when enrolled AND the
+    workspace is org-managed; personal workspaces never report.
+  * The on-disk debounce suppresses re-registration across processes (<1h).
+  * The POST carries {name, framework} with '' for unnamed agents, bearer-authed.
+  * Failures never raise into the caller (hook hot path).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from warden import agents
+
+
+class _SyncThread:
+    """Run thread targets inline so tests are deterministic."""
+
+    def __init__(self, target=None, args=(), daemon=None):
+        self._target, self._args = target, args
+
+    def start(self):
+        self._target(*self._args)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    agents._SEEN_THIS_PROCESS.clear()
+    agents._CONFIG_CACHE.clear()
+    monkeypatch.setattr(agents.threading, "Thread", _SyncThread)
+    yield
+
+
+def _enroll():
+    from warden.enterprise import identity
+    identity.save_identity({
+        "device_id": "d1", "org_id": "o1", "user_id": "u1",
+        "device_key": "prism_dev_x", "api_base": "http://127.0.0.1:1",
+    })
+
+
+@pytest.fixture
+def posts(monkeypatch):
+    calls = []
+    monkeypatch.setattr(agents, "_post_registration", lambda ident, payload: calls.append((ident, payload)))
+    return calls
+
+
+def test_registers_named_agent_when_enrolled_and_managed(tmp_path, monkeypatch, posts):
+    _enroll()
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: True)
+    agents.record_seen("checkout-bot", framework="openai-agents", workspace=tmp_path)
+    assert len(posts) == 1
+    _, payload = posts[0]
+    assert payload == {"agents": [{"name": "checkout-bot", "framework": "openai-agents"}]}
+    # Local registry still written alongside.
+    assert (tmp_path / ".prismor-warden" / "agents.yaml").exists()
+
+
+def test_unnamed_agent_registers_with_empty_name(tmp_path, monkeypatch, posts):
+    _enroll()
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: True)
+    # record_seen is called with name == framework for unnamed agents.
+    agents.record_seen("claude", framework="claude", workspace=tmp_path)
+    assert posts[0][1] == {"agents": [{"name": "", "framework": "claude"}]}
+
+
+def test_noop_when_not_enrolled(tmp_path, monkeypatch, posts):
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: True)
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)
+    assert posts == []
+
+
+def test_noop_on_personal_workspace(tmp_path, monkeypatch, posts):
+    _enroll()
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: False)
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)
+    assert posts == []
+
+
+def test_once_per_process_and_disk_debounce(tmp_path, monkeypatch, posts):
+    _enroll()
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: True)
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)  # same process
+    assert len(posts) == 1
+    # New process (seen-set cleared) but within the disk debounce window.
+    agents._SEEN_THIS_PROCESS.clear()
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)
+    assert len(posts) == 1
+    debounce = json.loads(agents._register_debounce_path().read_text())
+    assert "langchain|bot" in debounce
+    # Expired debounce → registers again.
+    debounce["langchain|bot"] = 0
+    agents._register_debounce_path().write_text(json.dumps(debounce))
+    agents._SEEN_THIS_PROCESS.clear()
+    agents.record_seen("bot", framework="langchain", workspace=tmp_path)
+    assert len(posts) == 2
+
+
+def test_post_failure_never_raises(tmp_path, monkeypatch):
+    """The real _post_registration against a dead endpoint stays silent."""
+    _enroll()
+    monkeypatch.setattr("warden.enterprise.workspace_scope.is_managed", lambda ws: True)
+    # No _post_registration stub — the dead api_base (port 1) must be swallowed.
+    agents.record_seen("bot", framework="crewai", workspace=tmp_path)  # must not raise

--- a/tests/test_agents_remote_control.py
+++ b/tests/test_agents_remote_control.py
@@ -1,0 +1,122 @@
+"""Tests for org (remote) per-agent control merge (warden/agents.py) and the
+end-to-end kill-switch through evaluate_tool_call.
+
+The org controls arrive in the verified signed policy's settings.agent_controls
+(PolicyEngine.agent_controls) and merge tighten-only with the local agents.yaml.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from warden import agents
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    agents._CONFIG_CACHE.clear()
+    yield
+
+
+def _local(workspace: Path, name: str, **fields):
+    agents.upsert_agent(name, workspace, framework="openai-agents", **fields)
+
+
+# ── merge precedence matrix ────────────────────────────────────────────────
+
+def test_remote_disable_cannot_be_locally_reenabled(tmp_path):
+    _local(tmp_path, "bot", enabled=True)
+    ctl = agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": False}})
+    assert ctl.enabled is False
+    assert ctl.disabled_by == "org"
+
+
+def test_local_disable_holds_even_if_remote_enabled(tmp_path):
+    _local(tmp_path, "bot", enabled=False)
+    ctl = agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": True}})
+    assert ctl.enabled is False
+    assert ctl.disabled_by == "local"
+
+
+def test_disabled_by_both(tmp_path):
+    _local(tmp_path, "bot", enabled=False)
+    ctl = agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": False}})
+    assert ctl.enabled is False and ctl.disabled_by == "both"
+
+
+def test_remote_mode_wins_over_local(tmp_path):
+    _local(tmp_path, "bot", mode="observe")
+    ctl = agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": True, "mode": "enforce"}})
+    assert ctl.mode == "enforce"
+
+
+def test_remote_only_agent_not_in_local_registry(tmp_path):
+    # An org can control an agent this machine has never registered locally.
+    ctl = agents.resolve_agent_control("ghost", tmp_path, remote_controls={"ghost": {"enabled": False}})
+    assert ctl.enabled is False and ctl.disabled_by == "org"
+
+
+def test_iam_profile_remote_then_local_fallback(tmp_path):
+    _local(tmp_path, "bot", iam_profile="local-ro")
+    assert agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": True, "iam_profile": "org-ro"}}).iam_profile == "org-ro"
+    assert agents.resolve_agent_control("bot", tmp_path, remote_controls={"bot": {"enabled": True}}).iam_profile == "local-ro"
+
+
+def test_unregistered_agent_is_permissive(tmp_path):
+    ctl = agents.resolve_agent_control("nobody", tmp_path, remote_controls={})
+    assert ctl.enabled is True and ctl.mode is None and ctl.disabled_by is None
+
+
+# ── end-to-end: a remote kill-switch blocks a benign call ──────────────────
+
+def test_remote_killswitch_blocks_via_evaluate_tool_call(tmp_path, monkeypatch):
+    """A managed workspace whose signed policy disables 'checkout-bot' → every
+    tool call from that instance is blocked, even a benign one."""
+    from warden import runtime
+    from warden.policy_engine import PolicyEngine
+
+    # Force the engine to look managed and carry the org control, without a real
+    # enrolled device / signed policy.
+    real_init = PolicyEngine.__init__
+
+    def fake_init(self, *a, **kw):
+        real_init(self, *a, **kw)
+        self.workspace_managed = True
+        self.agent_controls = {"checkout-bot": {"enabled": False}}
+
+    monkeypatch.setattr(PolicyEngine, "__init__", fake_init)
+
+    d = runtime.evaluate_tool_call(
+        event={"type": "shell", "agent_event": "PreToolUse", "command": "echo hello", "metadata": {"tool_name": "Bash"}},
+        workspace=tmp_path, agent="openai-agents", agent_name="checkout-bot",
+        mode="observe", session_id="s1", persist=False,
+    )
+    assert d.allow is False
+    assert any(f.get("ruleId") == "agent-disabled" for f in d.findings)
+    disabled = next(f for f in d.findings if f.get("ruleId") == "agent-disabled")
+    assert "org" in disabled["evidence"] or "control plane" in disabled["evidence"]
+
+
+def test_unmanaged_workspace_ignores_remote_controls(tmp_path, monkeypatch):
+    """A personal (unmanaged) workspace never carries agent_controls, so a
+    remote pause has no effect there."""
+    from warden import runtime
+    from warden.policy_engine import PolicyEngine
+
+    real_init = PolicyEngine.__init__
+
+    def fake_init(self, *a, **kw):
+        real_init(self, *a, **kw)
+        self.workspace_managed = False
+        self.agent_controls = {}  # unmanaged → no remote overlay merged
+
+    monkeypatch.setattr(PolicyEngine, "__init__", fake_init)
+
+    d = runtime.evaluate_tool_call(
+        event={"type": "shell", "agent_event": "PreToolUse", "command": "echo hi", "metadata": {"tool_name": "Bash"}},
+        workspace=tmp_path, agent="openai-agents", agent_name="checkout-bot",
+        mode="observe", session_id="s2", persist=False,
+    )
+    assert not any(f.get("ruleId") == "agent-disabled" for f in d.findings)

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -2,10 +2,13 @@
 
 Invariants:
   * Not enrolled → record_call is a no-op (zero files, zero cost).
-  * Calls accumulate; maybe_flush respects the debounce window.
-  * A due flush emits exactly one agent_activity record carrying the count,
-    resets the counter, and never double-sends.
-  * Upload failure → the record lands in the offline spool (count preserved).
+  * Calls accumulate per agent instance (<framework>|<name>); maybe_flush
+    respects the debounce window.
+  * A due flush emits one agent_activity record PER non-zero instance key,
+    resets the counters, and never double-sends.
+  * Upload failure → the records land in the offline spool (counts preserved).
+  * v1 (flat) counter files migrate into the framework-level key.
+  * >MAX_COUNTER_KEYS instances on one device fold into the framework key.
 """
 from __future__ import annotations
 
@@ -45,7 +48,7 @@ def test_calls_accumulate_and_flush_debounces(monkeypatch):
     for _ in range(5):
         heartbeat.record_call(agent="claude", session_id="s1")
     data = json.loads(heartbeat._counter_path().read_text())
-    assert data["count"] == 5
+    assert data["counters"]["claude|"]["count"] == 5
 
     # Within the debounce window (last_flush was set on first record) → no flush.
     assert heartbeat.maybe_flush() is False
@@ -58,11 +61,72 @@ def test_calls_accumulate_and_flush_debounces(monkeypatch):
     assert rec["type"] == "agent_activity"
     assert rec["count"] == 5
     assert rec["agent"] == "claude"
+    assert "agent_name" not in rec  # unnamed instance
     assert rec["redacted"] is True
 
     # Counter reset — an immediate second flush has nothing to send.
     assert heartbeat.maybe_flush(now=time.time() + 2 * heartbeat.FLUSH_INTERVAL + 2) is False
     assert len(sent) == 1
+
+
+def test_per_instance_keying(monkeypatch):
+    """Two named agents + one unnamed on the same framework → three records."""
+    from warden.enterprise import heartbeat
+    _enroll()
+
+    sent = []
+    monkeypatch.setattr("warden.sinks.upload_telemetry", lambda recs, **kw: sent.extend(recs))
+
+    for _ in range(4):
+        heartbeat.record_call(agent="openai-agents", agent_name="checkout-bot", session_id="s1")
+    for _ in range(2):
+        heartbeat.record_call(agent="openai-agents", agent_name="support-bot", session_id="s2")
+    heartbeat.record_call(agent="openai-agents", session_id="s3")  # unnamed
+
+    counters = json.loads(heartbeat._counter_path().read_text())["counters"]
+    assert counters["openai-agents|checkout-bot"]["count"] == 4
+    assert counters["openai-agents|support-bot"]["count"] == 2
+    assert counters["openai-agents|"]["count"] == 1
+
+    assert heartbeat.maybe_flush(now=time.time() + heartbeat.FLUSH_INTERVAL + 1) is True
+    by_name = {r.get("agent_name", ""): r for r in sent}
+    assert by_name["checkout-bot"]["count"] == 4 and by_name["checkout-bot"]["agent"] == "openai-agents"
+    assert by_name["support-bot"]["count"] == 2
+    assert by_name[""]["count"] == 1 and "agent_name" not in by_name[""]
+
+
+def test_v1_file_migrates_to_framework_key(monkeypatch):
+    """A pre-existing v1 flat counter file is read as a framework-level key."""
+    from warden.enterprise import heartbeat
+    _enroll()
+    # Simulate a v1 file left by an older runtime.
+    heartbeat._counter_path().parent.mkdir(parents=True, exist_ok=True)
+    heartbeat._counter_path().write_text(json.dumps(
+        {"count": 7, "agent": "cursor", "session_id": "s9", "last_flush": 0}
+    ))
+
+    sent = []
+    monkeypatch.setattr("warden.sinks.upload_telemetry", lambda recs, **kw: sent.extend(recs))
+    assert heartbeat.maybe_flush(now=time.time() + heartbeat.FLUSH_INTERVAL + 1) is True
+    assert len(sent) == 1
+    assert sent[0]["agent"] == "cursor" and sent[0]["count"] == 7
+    assert "agent_name" not in sent[0]
+
+
+def test_key_cap_folds_into_framework_key():
+    """More than MAX_COUNTER_KEYS instances on one device fold into the
+    framework key so volume is preserved past the cap."""
+    from warden.enterprise import heartbeat
+    _enroll()
+    for i in range(heartbeat.MAX_COUNTER_KEYS + 20):
+        heartbeat.record_call(agent="langchain", agent_name=f"bot-{i}", session_id="s")
+    counters = json.loads(heartbeat._counter_path().read_text())["counters"]
+    # At most MAX_COUNTER_KEYS named instances plus the framework fold bucket.
+    assert len(counters) <= heartbeat.MAX_COUNTER_KEYS + 1
+    # Overflow landed on the framework-level key.
+    assert counters.get("langchain|", {}).get("count", 0) >= 20
+    total = sum(v["count"] for v in counters.values())
+    assert total == heartbeat.MAX_COUNTER_KEYS + 20  # nothing lost
 
 
 def test_failed_flush_lands_in_spool():
@@ -77,5 +141,5 @@ def test_failed_flush_lands_in_spool():
     assert len(spooled) == 1
     assert spooled[0]["type"] == "agent_activity"
     assert spooled[0]["count"] == 3
-    # Counter was reset — the count lives in the spool, not both places.
-    assert json.loads(heartbeat._counter_path().read_text())["count"] == 0
+    # Counters were reset — the count lives in the spool, not both places.
+    assert json.loads(heartbeat._counter_path().read_text())["counters"] == {}

--- a/tests/test_remote_policy.py
+++ b/tests/test_remote_policy.py
@@ -128,3 +128,56 @@ def test_no_remote_policy_is_inert(tmp_path, monkeypatch):
     # Default policy still loads; core rule present; no remote meta.
     assert any(r.id == "destructive-command" for r in engine.rules)
     assert engine.remote_policy_meta == {}
+    # No remote controls without a policy.
+    assert engine.agent_controls == {}
+
+
+AGENT_CONTROL_POLICY = """
+settings:
+  agent_controls:
+    checkout-bot:
+      enabled: false
+    support-bot:
+      enabled: true
+      mode: enforce
+rules: []
+"""
+
+
+def test_signed_agent_controls_reach_engine(tmp_path, monkeypatch):
+    """settings.agent_controls in the verified signed policy is lifted onto the
+    engine so the runtime can merge it with the local registry."""
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    _write_remote(tmp_path / ".prismor", AGENT_CONTROL_POLICY)
+    _enroll()
+
+    from warden.policy_engine import PolicyEngine
+    engine = PolicyEngine(workspace=tmp_path)
+    assert engine.agent_controls.get("checkout-bot", {}).get("enabled") is False
+    assert engine.agent_controls.get("support-bot", {}).get("mode") == "enforce"
+
+
+def test_agent_controls_sig_matches_server_format(tmp_path, monkeypatch):
+    """_current_agent_controls_sig reproduces the server's agentControlsSig
+    (sorted key:enabled:mode:iam → sha256 → 16 hex) so a control change triggers
+    a re-pull; empty when there are no controls."""
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    from warden.enterprise import remote_policy
+
+    _write_remote(tmp_path / ".prismor", AGENT_CONTROL_POLICY)
+    _enroll()
+    sig = remote_policy._current_agent_controls_sig()
+    assert sig and len(sig) == 16
+
+    # Reproduce the server side independently and compare.
+    import hashlib
+    lines = sorted([
+        "checkout-bot:0::",
+        "support-bot:1:enforce:",
+    ])
+    expected = hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()[:16]
+    assert sig == expected
+
+    # No controls → empty signature.
+    _write_remote(tmp_path / ".prismor", "settings: {}\nrules: []\n")
+    assert remote_policy._current_agent_controls_sig() == ""

--- a/tests/test_rule_exemptions.py
+++ b/tests/test_rule_exemptions.py
@@ -1,0 +1,115 @@
+"""Tests for eval-time rule exemptions (warden/runtime._apply_rule_exemptions)
+and the re-pull signature (warden/enterprise/remote_policy).
+
+An exemption {ruleId, scope, scopeId, action, expires} relaxes ('allow' → drop)
+or downgrades ('flag' → warn, non-blocking) a finding for the current
+user/device/session. Core/floor rules can never be exempted.
+"""
+from __future__ import annotations
+
+from warden.runtime import _apply_rule_exemptions
+from warden.principal import Subject
+
+
+def _finding(rule_id, category="tool_call_abuse", mode="enforce"):
+    return {"ruleId": rule_id, "category": category, "mode": mode, "title": rule_id}
+
+
+SUBJ = Subject(source="device", user_id="alice", team_id=None, org_id="o1")
+
+
+def test_no_exemptions_is_passthrough():
+    fs = [_finding("curl-pipe-sh")]
+    assert _apply_rule_exemptions(fs, None, session_id="s1", subject=SUBJ) == fs
+    assert _apply_rule_exemptions(fs, [], session_id="s1", subject=SUBJ) == fs
+
+
+def test_session_allow_drops_finding():
+    ex = [{"ruleId": "curl-pipe-sh", "scope": "session", "scopeId": "s1", "action": "allow"}]
+    out = _apply_rule_exemptions([_finding("curl-pipe-sh")], ex, session_id="s1", subject=SUBJ)
+    assert out == []  # allowed → dropped
+
+
+def test_session_scope_miss_keeps_finding():
+    ex = [{"ruleId": "curl-pipe-sh", "scope": "session", "scopeId": "OTHER", "action": "allow"}]
+    out = _apply_rule_exemptions([_finding("curl-pipe-sh")], ex, session_id="s1", subject=SUBJ)
+    assert len(out) == 1
+
+
+def test_user_allow():
+    ex = [{"ruleId": "r", "scope": "user", "scopeId": "alice", "action": "allow"}]
+    assert _apply_rule_exemptions([_finding("r")], ex, session_id="s", subject=SUBJ) == []
+    ex_miss = [{"ruleId": "r", "scope": "user", "scopeId": "bob", "action": "allow"}]
+    assert len(_apply_rule_exemptions([_finding("r")], ex_miss, session_id="s", subject=SUBJ)) == 1
+
+
+def test_device_allow(monkeypatch):
+    # device_id comes from the enrolled identity, not the Subject.
+    monkeypatch.setattr("warden.enterprise.identity.load_identity", lambda: {"device_id": "dev_1"})
+    ex = [{"ruleId": "r", "scope": "device", "scopeId": "dev_1", "action": "allow"}]
+    assert _apply_rule_exemptions([_finding("r")], ex, session_id="s", subject=SUBJ) == []
+    ex_miss = [{"ruleId": "r", "scope": "device", "scopeId": "dev_2", "action": "allow"}]
+    assert len(_apply_rule_exemptions([_finding("r")], ex_miss, session_id="s", subject=SUBJ)) == 1
+
+
+def test_flag_downgrades_but_keeps():
+    ex = [{"ruleId": "r", "scope": "session", "scopeId": "s1", "action": "flag"}]
+    out = _apply_rule_exemptions([_finding("r", mode="enforce")], ex, session_id="s1", subject=SUBJ)
+    assert len(out) == 1
+    assert out[0]["mode"] == "observe"      # no longer blocks
+    assert out[0]["exempted"] == "flag"     # marked for the dashboard
+
+
+def test_expired_exemption_ignored():
+    ex = [{"ruleId": "r", "scope": "session", "scopeId": "s1", "action": "allow",
+           "expires": "2000-01-01T00:00:00Z"}]  # long past
+    out = _apply_rule_exemptions([_finding("r")], ex, session_id="s1", subject=SUBJ)
+    assert len(out) == 1  # expired → not applied
+
+
+def test_floor_rule_never_exemptable():
+    # A core rule id and a core category both stay, even with a matching exemption.
+    ex = [
+        {"ruleId": "destructive-command", "scope": "session", "scopeId": "s1", "action": "allow"},
+        {"ruleId": "secret-leak", "scope": "session", "scopeId": "s1", "action": "allow"},
+    ]
+    fs = [_finding("destructive-command", category="destructive_command"),
+          _finding("secret-leak", category="secret_exfiltration")]
+    out = _apply_rule_exemptions(fs, ex, session_id="s1", subject=SUBJ)
+    assert len(out) == 2  # both floor findings survive
+
+
+def test_kill_switch_never_exemptable():
+    ex = [{"ruleId": "agent-disabled", "scope": "session", "scopeId": "s1", "action": "allow"}]
+    fs = [_finding("agent-disabled", category="agent-control")]
+    assert len(_apply_rule_exemptions(fs, ex, session_id="s1", subject=SUBJ)) == 1
+
+
+def test_scoped_agent_finding_is_exemptable():
+    # The whole point: a scoped-agent denial (not a policy rule) can be relaxed.
+    ex = [{"ruleId": "scoped-agent", "scope": "session", "scopeId": "s1", "action": "allow"}]
+    fs = [_finding("scoped-agent", category="scoped_agent")]
+    assert _apply_rule_exemptions(fs, ex, session_id="s1", subject=SUBJ) == []
+
+
+def test_sig_round_trips(tmp_path, monkeypatch):
+    """_current_rule_exemptions_sig reproduces the server's format so a change
+    triggers a re-pull; empty when there are none."""
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    from warden.enterprise import remote_policy
+    import hashlib
+
+    exemptions = [
+        {"id": "re_1", "ruleId": "curl-pipe-sh", "scope": "session", "scopeId": "s1", "action": "allow", "expires": "2099-01-01T00:00:00Z"},
+        {"id": "re_2", "ruleId": "scoped-agent", "scope": "user", "scopeId": "alice", "action": "flag"},
+    ]
+    monkeypatch.setattr(remote_policy, "verify_and_load", lambda: {"settings": {"rule_exemptions": exemptions}})
+    sig = remote_policy._current_rule_exemptions_sig()
+    lines = sorted([
+        "re_1:curl-pipe-sh:session:s1:allow:2099-01-01T00:00:00Z",
+        "re_2:scoped-agent:user:alice:flag:",
+    ])
+    assert sig == hashlib.sha256("\n".join(lines).encode()).hexdigest()[:16]
+
+    monkeypatch.setattr(remote_policy, "verify_and_load", lambda: {"settings": {}})
+    assert remote_policy._current_rule_exemptions_sig() == ""

--- a/warden/agents.py
+++ b/warden/agents.py
@@ -23,7 +23,10 @@ is responsible for using ``control.iam_profile`` when calling check_iam.
 """
 from __future__ import annotations
 
+import json
 import sys
+import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +38,10 @@ _PROJECT_AGENTS_FILE = "agents.yaml"
 # Module-level seen-set: throttle record_seen() so we only update the YAML
 # once per agent per process, not on every tool call.
 _SEEN_THIS_PROCESS: set = set()
+
+# On-disk debounce for control-plane registration: 1000 short-lived processes
+# must not turn into 1000 POSTs per agent per day.
+_REGISTER_DEBOUNCE_SECONDS = 3600.0
 
 # (path+mtime) → parsed config
 _CONFIG_CACHE: Dict[Any, Dict[str, Any]] = {}
@@ -195,7 +202,13 @@ def upsert_agent(name: str, workspace: Path, **fields: Any) -> AgentControl:
 
 
 def record_seen(name: str, framework: str, workspace: Optional[Path]) -> None:
-    """Auto-register a discovered agent; best-effort, once per process per agent."""
+    """Auto-register a discovered agent; best-effort, once per process per agent.
+
+    Registers locally (project agents.yaml) and, for enrolled devices working
+    in an org-managed workspace, tells the control plane the instance exists —
+    so a deployed agent shows up in the org's fleet view even before it emits
+    its first finding.
+    """
     if not name or not workspace:
         return
     seen_key = (name, str(workspace))
@@ -210,6 +223,80 @@ def record_seen(name: str, framework: str, workspace: Optional[Path]) -> None:
         )
     except Exception as exc:
         sys.stderr.write(f"[warden/agents] record_seen error: {exc}\n")
+    try:
+        _register_remote(name, framework, workspace)
+    except Exception:
+        pass  # never let fleet bookkeeping affect the tool-call path
+
+
+def _register_debounce_path() -> Path:
+    from warden.enterprise import identity as _identity
+    return _identity.prismor_home() / "agent-register.json"
+
+
+def _register_remote(name: str, framework: str, workspace: Path) -> None:
+    """Best-effort fleet registration with the org control plane.
+
+    Guards (all must hold): device enrolled, no revoked-key backoff, workspace
+    org-managed (personal workspaces never report anything). Debounced on disk
+    per instance so short-lived processes don't hammer the endpoint; the POST
+    itself runs on a daemon thread so the hook hot path never waits on the
+    network. Failures are silent — the control plane's ingest-side upsert is
+    the safety net for anything missed here.
+    """
+    from warden.enterprise import identity as _identity
+    ident = _identity.load_identity()
+    if not ident or _identity.revoked_backoff_active():
+        return
+    from warden.enterprise import workspace_scope as _scope
+    if not _scope.is_managed(workspace):
+        return
+
+    # On-disk debounce (optimistic: marked before the POST; a failed POST waits
+    # out the window, which the ingest-side upsert covers).
+    key = f"{framework}|{name if name != framework else ''}"
+    now = time.time()
+    path = _register_debounce_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            data = {}
+    except (OSError, ValueError):
+        data = {}
+    if now - float(data.get(key, 0) or 0) < _REGISTER_DEBOUNCE_SECONDS:
+        return
+    data[key] = now
+    # Keep the debounce file bounded: drop entries older than a day.
+    data = {k: v for k, v in data.items() if now - float(v or 0) < 86400.0}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+    except OSError:
+        pass
+
+    payload = {"agents": [{"name": "" if name == framework else name, "framework": framework}]}
+    threading.Thread(target=_post_registration, args=(dict(ident), payload), daemon=True).start()
+
+
+def _post_registration(ident: Dict[str, Any], payload: Dict[str, Any]) -> None:
+    """POST the registration; swallow every failure (best-effort by design)."""
+    try:
+        import urllib.request
+        from warden.enterprise import identity as _identity
+        base = str(ident.get("api_base") or _identity.api_base()).rstrip("/")
+        req = urllib.request.Request(
+            f"{base}/api/agents/register",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {ident.get('device_key')}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass
 
 
 # ── Kill-switch finding ────────────────────────────────────────────────────────

--- a/warden/agents.py
+++ b/warden/agents.py
@@ -108,48 +108,81 @@ class AgentControl:
     mode: Optional[str] = None   # None = inherit global mode; "observe"/"enforce"
     iam_profile: Optional[str] = None  # IAM profile name to enforce for this agent
     last_seen: Optional[str] = None
+    # Which layer disabled the agent: "local" (agents.yaml), "org" (the signed
+    # remote policy's settings.agent_controls), "both", or None when enabled.
+    disabled_by: Optional[str] = None
 
 
 _DEFAULT = AgentControl(name="")  # sentinel — used for agents not in the registry
 
 
-def resolve_agent_control(name: str, workspace: Optional[Path] = None) -> AgentControl:
-    """Return the AgentControl for ``name``.
+def resolve_agent_control(
+    name: str,
+    workspace: Optional[Path] = None,
+    remote_controls: Optional[Dict[str, Any]] = None,
+) -> AgentControl:
+    """Return the AgentControl for ``name``, merging local and org controls.
+
+    ``remote_controls`` is the org's ``settings.agent_controls`` map from the
+    VERIFIED signed policy (present only on org-managed workspaces — the
+    runtime passes ``engine.agent_controls``). The merge is tighten-only:
+
+    * ``enabled`` — local AND remote: an org kill-switch cannot be re-enabled
+      locally, and a local disable holds even if the org says enabled.
+    * ``mode`` — remote wins when set (the org admin is the same authority
+      that sets the global mode); else local.
+    * ``iam_profile`` — remote wins when set. The named profile must be
+      defined in the local/project iam.yaml (remote selects among locally
+      defined profiles; it doesn't ship definitions).
 
     Returns a permissive default (enabled=True, mode=None, iam_profile=None)
-    when the agent is not in the registry, so unregistered agents are
-    unaffected by the new control layer.
+    when the agent is in neither registry, so unregistered agents are
+    unaffected by the control layer.
     """
     if not name:
         return AgentControl(name=name)
     config = load_agents_config(workspace)
-    entry = config.get("agents", {}).get(name)
-    if entry is None:
+    entry = config.get("agents", {}).get(name) or {}
+    remote = (remote_controls or {}).get(name)
+    remote = remote if isinstance(remote, dict) else {}
+    if not entry and not remote:
         return AgentControl(name=name)
+
+    local_enabled = bool(entry.get("enabled", True))
+    remote_enabled = bool(remote.get("enabled", True))
+    remote_mode = remote.get("mode") if remote.get("mode") in ("observe", "enforce") else None
+    disabled_by = (
+        "both" if not local_enabled and not remote_enabled
+        else "org" if not remote_enabled
+        else "local" if not local_enabled
+        else None
+    )
     return AgentControl(
         name=name,
         framework=entry.get("framework", ""),
-        enabled=bool(entry.get("enabled", True)),
-        mode=entry.get("mode") or None,
-        iam_profile=entry.get("iam_profile") or None,
+        enabled=local_enabled and remote_enabled,
+        mode=remote_mode or entry.get("mode") or None,
+        iam_profile=remote.get("iam_profile") or entry.get("iam_profile") or None,
         last_seen=entry.get("last_seen"),
+        disabled_by=disabled_by,
     )
 
 
-def list_agents(workspace: Optional[Path] = None) -> List[AgentControl]:
-    """Return all agents defined in the active config."""
+def list_agents(
+    workspace: Optional[Path] = None,
+    remote_controls: Optional[Dict[str, Any]] = None,
+) -> List[AgentControl]:
+    """Return all agents known to either registry (local config + org controls).
+
+    Each entry is the merged effective control (see resolve_agent_control), so
+    the union of locally-configured and org-controlled agents is returned with
+    ``disabled_by`` set to whichever layer(s) apply.
+    """
     config = load_agents_config(workspace)
-    out = []
-    for name, entry in config.get("agents", {}).items():
-        out.append(AgentControl(
-            name=name,
-            framework=entry.get("framework", ""),
-            enabled=bool(entry.get("enabled", True)),
-            mode=entry.get("mode") or None,
-            iam_profile=entry.get("iam_profile") or None,
-            last_seen=entry.get("last_seen"),
-        ))
-    return out
+    names = set(config.get("agents", {}).keys())
+    if isinstance(remote_controls, dict):
+        names.update(remote_controls.keys())
+    return [resolve_agent_control(name, workspace, remote_controls) for name in sorted(names)]
 
 
 # ── Writes ────────────────────────────────────────────────────────────────────
@@ -301,8 +334,27 @@ def _post_registration(ident: Dict[str, Any], payload: Dict[str, Any]) -> None:
 
 # ── Kill-switch finding ────────────────────────────────────────────────────────
 
-def make_disabled_finding(name: str, session_id: str = "") -> Dict[str, Any]:
-    """Return a CRITICAL blocking finding for a disabled (paused) agent."""
+def make_disabled_finding(
+    name: str, session_id: str = "", disabled_by: Optional[str] = None
+) -> Dict[str, Any]:
+    """Return a CRITICAL blocking finding for a disabled (paused) agent.
+
+    ``disabled_by`` names the layer that pulled the kill switch ("local",
+    "org", "both") so the developer sees WHERE to go to lift it — a local
+    re-enable can never lift an org-pushed pause.
+    """
+    if disabled_by == "org":
+        evidence = f"agent '{name}' is paused by your org's control plane (signed policy)"
+        remediation = f"Ask an org admin to re-enable '{name}' in the dashboard's fleet view."
+    elif disabled_by == "both":
+        evidence = f"agent '{name}' is paused locally AND by your org's control plane"
+        remediation = (
+            f"Ask an org admin to re-enable '{name}' in the dashboard, "
+            f"then: prismor agents set {name} --enabled"
+        )
+    else:
+        evidence = f"agent '{name}' is disabled in .prismor-warden/agents.yaml"
+        remediation = f"Re-enable via dashboard or: prismor agents set {name} --enabled"
     return {
         "id": f"{session_id}:agent-disabled:{name}",
         "ruleId": "agent-disabled",
@@ -310,11 +362,9 @@ def make_disabled_finding(name: str, session_id: str = "") -> Dict[str, Any]:
         "category": "agent-control",
         "mode": "enforce",  # always blocks regardless of policy mode
         "title": f"[agent:{name}] Agent is paused — all tool calls blocked",
-        "evidence": f"agent '{name}' is disabled in .prismor-warden/agents.yaml",
+        "evidence": evidence,
         "eventIndex": 0,
-        "remediation": (
-            f"Re-enable via dashboard or: immunity agents set {name} --enabled"
-        ),
+        "remediation": remediation,
     }
 
 
@@ -324,12 +374,15 @@ def format_agent_table(agents: List[AgentControl]) -> str:
     if not agents:
         return "  (no named agents registered)"
     lines = [
-        f"  {'NAME':<20} {'FRAMEWORK':<16} {'ENABLED':<8} {'MODE':<10} {'IAM PROFILE':<20}",
-        "  " + "-" * 76,
+        f"  {'NAME':<20} {'FRAMEWORK':<16} {'ENABLED':<8} {'MODE':<10} {'IAM PROFILE':<18} {'SOURCE':<8}",
+        "  " + "-" * 84,
     ]
     for a in agents:
+        # SOURCE reflects where a disable came from (org/local/both); an enabled
+        # agent shows blank so the column only draws attention to kill switches.
+        source = a.disabled_by or ""
         lines.append(
             f"  {a.name:<20} {a.framework:<16} {'yes' if a.enabled else 'NO':<8} "
-            f"{(a.mode or '(global)'):<10} {(a.iam_profile or ''):<20}"
+            f"{(a.mode or '(global)'):<10} {(a.iam_profile or ''):<18} {source:<8}"
         )
     return "\n".join(lines)

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1163,7 +1163,16 @@ def main(argv: Optional[List[str]] = None) -> None:
         subcmd = getattr(args, "agents_subcommand", None)
 
         if subcmd == "list" or subcmd is None:
-            agents = _list_agents(workspace)
+            # Merge org controls (from the cached verified policy) so the table
+            # shows org-pushed pauses, not just local ones.
+            _remote_ctl = None
+            try:
+                from warden.enterprise import remote_policy as _rp
+                _pol = _rp.verify_and_load()
+                _remote_ctl = ((_pol or {}).get("settings") or {}).get("agent_controls")
+            except Exception:
+                _remote_ctl = None
+            agents = _list_agents(workspace, remote_controls=_remote_ctl)
             print(f"\n  {_color('PRISMOR', _BOLD)}  named agents\n")
             print(_fmt_agent_table(agents))
             print()

--- a/warden/enterprise/heartbeat.py
+++ b/warden/enterprise/heartbeat.py
@@ -2,13 +2,18 @@
 
 Findings-only telemetry tells the org what was *flagged*; it says nothing about
 how much the agent actually did. This module counts every hook-dispatched tool
-call locally and, at most once per ``FLUSH_INTERVAL`` seconds, uploads a single
-``agent_activity`` record carrying the accumulated count. The control plane
-sums the ``count`` column for the "tool calls inspected" KPI.
+call locally and, at most once per ``FLUSH_INTERVAL`` seconds, uploads one
+``agent_activity`` record *per agent instance* carrying the accumulated count.
+The control plane sums the ``count`` column for the "tool calls inspected" KPI.
+
+Counts are keyed per agent instance (``<framework>|<name>``) so a fleet of many
+agents on the same framework reports separate volume — "checkout-bot did 400
+calls, support-bot did 30" — instead of one indistinguishable device total. An
+unnamed agent uses the empty name (key ``<framework>|``).
 
 Privacy: the heartbeat carries *only* a number plus the same metadata enums as
-any redacted record (agent name, session id). No commands, paths, or content —
-it is volume, not activity detail.
+any redacted record (agent id, agent name, session id). No commands, paths, or
+content — it is volume, not activity detail.
 
 Cost: one fcntl-locked JSON read/write per tool call (sub-millisecond) and one
 HTTP POST per minute at most, with the same short-timeout + offline-spool
@@ -28,21 +33,51 @@ from warden.enterprise import identity as _identity
 
 FLUSH_INTERVAL = 60.0
 
+# Bound the counter file + flush fan-out. A single device running >64 distinct
+# agent instances is not a real topology (instances spread across a fleet of
+# devices); overflow folds into the framework-level key so volume is never lost,
+# only its per-instance attribution past the cap.
+MAX_COUNTER_KEYS = 64
+
 
 def _counter_path() -> Path:
     return _identity.prismor_home() / "heartbeat.json"
 
 
+def _counter_key(agent: Optional[str], agent_name: Optional[str]) -> str:
+    return f"{agent or ''}|{agent_name or ''}"
+
+
 def _load(path: Path) -> Dict[str, Any]:
+    """Load the counter file, migrating the v1 flat shape to v2 keyed counters.
+
+    v1: {"count": N, "agent": a, "session_id": s, "last_flush": t}
+    v2: {"v": 2, "last_flush": t, "counters": {"<framework>|<name>": {count, session_id}}}
+    """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
     except (OSError, ValueError):
-        return {}
+        return {"v": 2, "last_flush": time.time(), "counters": {}}
+    if not isinstance(data, dict):
+        return {"v": 2, "last_flush": time.time(), "counters": {}}
+    if data.get("v") == 2 and isinstance(data.get("counters"), dict):
+        return data
+    # Migrate v1 → v2: fold the flat counter into a single framework-level key.
+    counters: Dict[str, Any] = {}
+    count = int(data.get("count", 0) or 0)
+    if count > 0:
+        key = _counter_key(data.get("agent"), "")
+        counters[key] = {"count": count, "session_id": data.get("session_id")}
+    return {"v": 2, "last_flush": float(data.get("last_flush", time.time())), "counters": counters}
 
 
-def record_call(agent: Optional[str] = None, session_id: Optional[str] = None) -> None:
-    """Count one inspected tool call. Never raises; no-op when not enrolled."""
+def record_call(
+    agent: Optional[str] = None,
+    session_id: Optional[str] = None,
+    agent_name: Optional[str] = None,
+) -> None:
+    """Count one inspected tool call for one agent instance. Never raises; no-op
+    when not enrolled."""
     if not _identity.is_enrolled():
         return
     path = _counter_path()
@@ -53,12 +88,18 @@ def record_call(agent: Optional[str] = None, session_id: Optional[str] = None) -
             fcntl.flock(lock_f, fcntl.LOCK_EX)
             try:
                 data = _load(path)
-                data["count"] = int(data.get("count", 0)) + 1
-                if agent:
-                    data["agent"] = agent
+                counters: Dict[str, Any] = data.setdefault("counters", {})
+                key = _counter_key(agent, agent_name)
+                # Cap: an instance past the limit folds into the framework key so
+                # its volume still counts, bounding file size and flush fan-out.
+                if key not in counters and len(counters) >= MAX_COUNTER_KEYS:
+                    key = _counter_key(agent, "")
+                slot = counters.setdefault(key, {"count": 0, "session_id": None})
+                slot["count"] = int(slot.get("count", 0)) + 1
                 if session_id:
-                    data["session_id"] = session_id
+                    slot["session_id"] = session_id
                 data.setdefault("last_flush", time.time())
+                data["v"] = 2
                 path.write_text(json.dumps(data), encoding="utf-8")
                 try:  # audit #18: keep session metadata 0600, not world-readable
                     path.chmod(0o600)
@@ -71,19 +112,20 @@ def record_call(agent: Optional[str] = None, session_id: Optional[str] = None) -
 
 
 def maybe_flush(now: Optional[float] = None) -> bool:
-    """Upload the accumulated count as one agent_activity record, at most once
-    per FLUSH_INTERVAL. Returns True if a flush was attempted. Never raises.
+    """Upload the accumulated counts as one agent_activity record *per agent
+    instance*, at most once per FLUSH_INTERVAL. Returns True if a flush was
+    attempted. Never raises.
 
-    The counter is reset *before* the upload; on failure the record lands in
-    the offline spool (see sinks.upload_telemetry), so the count is never lost
-    and never double-sent.
+    Counters are reset *before* the upload; on failure the records land in the
+    offline spool (see sinks.upload_telemetry), so counts are never lost and
+    never double-sent. All per-instance records ship in one batched upload.
     """
     ident = _identity.load_identity()
     if not ident or _identity.revoked_backoff_active():
         return False
 
     path = _counter_path()
-    record: Optional[Dict[str, Any]] = None
+    records: list = []
     try:
         import fcntl
         if not path.exists():
@@ -92,26 +134,36 @@ def maybe_flush(now: Optional[float] = None) -> bool:
             fcntl.flock(lock_f, fcntl.LOCK_EX)
             try:
                 data = _load(path)
-                count = int(data.get("count", 0))
+                counters: Dict[str, Any] = data.get("counters", {}) or {}
                 last = float(data.get("last_flush", 0))
                 t = time.time() if now is None else now
-                if count <= 0 or (t - last) < FLUSH_INTERVAL:
+                total = sum(int(v.get("count", 0)) for v in counters.values())
+                if total <= 0 or (t - last) < FLUSH_INTERVAL:
                     return False
                 import uuid
-                record = {
-                    "schema": "warden.telemetry.v1",
-                    "event_id": "evt_" + uuid.uuid4().hex,
-                    "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                    "type": "agent_activity",
-                    "verdict": "observed",
-                    "title": "Agent activity heartbeat",
-                    "agent": data.get("agent"),
-                    "session_id": data.get("session_id"),
-                    "count": count,
-                    "redacted": True,
-                }
+                for key, slot in counters.items():
+                    count = int(slot.get("count", 0))
+                    if count <= 0:
+                        continue
+                    agent, _, agent_name = key.partition("|")
+                    rec = {
+                        "schema": "warden.telemetry.v1",
+                        "event_id": "evt_" + uuid.uuid4().hex,
+                        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        "type": "agent_activity",
+                        "verdict": "observed",
+                        "title": "Agent activity heartbeat",
+                        "agent": agent or None,
+                        "session_id": slot.get("session_id"),
+                        "count": count,
+                        "redacted": True,
+                    }
+                    if agent_name:
+                        rec["agent_name"] = agent_name
+                    records.append(rec)
+                # Reset all counters, keep the flush timestamp.
                 path.write_text(
-                    json.dumps({**data, "count": 0, "last_flush": t}), encoding="utf-8"
+                    json.dumps({"v": 2, "last_flush": t, "counters": {}}), encoding="utf-8"
                 )
                 try:  # audit #18
                     path.chmod(0o600)
@@ -122,11 +174,11 @@ def maybe_flush(now: Optional[float] = None) -> bool:
     except (OSError, ValueError):
         return False
 
-    if record is None:
+    if not records:
         return False
     try:
         from warden.sinks import upload_telemetry
-        upload_telemetry([record])
+        upload_telemetry(records)
     except Exception as exc:  # spooled by upload_telemetry; just note it
         sys.stderr.write(f"[warden] heartbeat upload deferred: {exc}\n")
     return True

--- a/warden/enterprise/remote_policy.py
+++ b/warden/enterprise/remote_policy.py
@@ -194,7 +194,16 @@ def check_and_refresh(interval: Optional[float] = None) -> bool:
         latest_repos_sig is not None
         and str(latest_repos_sig) != str(_current_managed_repos_sig())
     )
-    if version_changed or profile_changed or capture_changed or repos_changed:
+    # Per-agent controls (kill-switch / forced mode / IAM) are served in the
+    # resolved policy but deliberately do NOT bump the profile version — the
+    # server exposes their signature instead, so an org pause reaches every
+    # device within one debounce interval regardless of profile scope.
+    latest_controls_sig = body.get("agentControlsSig")
+    controls_changed = (
+        latest_controls_sig is not None
+        and str(latest_controls_sig) != str(_current_agent_controls_sig())
+    )
+    if version_changed or profile_changed or capture_changed or repos_changed or controls_changed:
         return fetch(force=True)
     return False
 
@@ -218,6 +227,28 @@ def _current_managed_repos_sig() -> str:
         import hashlib
         sig_input = "\n".join([*pats, "|", *ex_parts])
         return hashlib.sha256(sig_input.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def _current_agent_controls_sig() -> str:
+    """Signature of the cached policy's per-agent controls, matching the
+    server's agentControlsSig format (sorted ``key:enabled:mode:iam`` lines →
+    sha256 → 16 hex chars; empty when no controls are set) so the device
+    re-pulls the moment an org admin pauses or reconfigures an agent."""
+    try:
+        pol = verify_and_load()
+        controls = ((pol or {}).get("settings") or {}).get("agent_controls") or {}
+        if not isinstance(controls, dict) or not controls:
+            return ""
+        lines = sorted(
+            f"{name}:{'1' if c.get('enabled', True) else '0'}:{c.get('mode') or ''}:{c.get('iam_profile') or ''}"
+            for name, c in controls.items() if isinstance(c, dict)
+        )
+        if not lines:
+            return ""
+        import hashlib
+        return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()[:16]
     except Exception:
         return ""
 

--- a/warden/enterprise/remote_policy.py
+++ b/warden/enterprise/remote_policy.py
@@ -203,7 +203,16 @@ def check_and_refresh(interval: Optional[float] = None) -> bool:
         latest_controls_sig is not None
         and str(latest_controls_sig) != str(_current_agent_controls_sig())
     )
-    if version_changed or profile_changed or capture_changed or repos_changed or controls_changed:
+    # Per-event rule exemptions (relax/flag a rule for a user/device/session)
+    # also live in the resolved policy without a version bump — compare their
+    # signature so an admin's exempt reaches the device within one debounce.
+    latest_rule_ex_sig = body.get("ruleExemptionsSig")
+    rule_ex_changed = (
+        latest_rule_ex_sig is not None
+        and str(latest_rule_ex_sig) != str(_current_rule_exemptions_sig())
+    )
+    if (version_changed or profile_changed or capture_changed
+            or repos_changed or controls_changed or rule_ex_changed):
         return fetch(force=True)
     return False
 
@@ -227,6 +236,29 @@ def _current_managed_repos_sig() -> str:
         import hashlib
         sig_input = "\n".join([*pats, "|", *ex_parts])
         return hashlib.sha256(sig_input.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def _current_rule_exemptions_sig() -> str:
+    """Signature of the cached policy's rule exemptions, matching the server's
+    ruleExemptionsSig format (sorted ``id:ruleId:scope:scopeId:action:expires``
+    lines → sha256 → 16 hex; empty when none) so the device re-pulls when an
+    exemption is added, revoked, or expires."""
+    try:
+        pol = verify_and_load()
+        exemptions = ((pol or {}).get("settings") or {}).get("rule_exemptions") or []
+        if not isinstance(exemptions, list) or not exemptions:
+            return ""
+        lines = sorted(
+            f"{e.get('id')}:{e.get('ruleId') or ''}:{e.get('scope') or ''}:"
+            f"{e.get('scopeId') or ''}:{e.get('action') or 'allow'}:{e.get('expires') or ''}"
+            for e in exemptions if isinstance(e, dict) and e.get("id")
+        )
+        if not lines:
+            return ""
+        import hashlib
+        return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()[:16]
     except Exception:
         return ""
 

--- a/warden/policy_engine.py
+++ b/warden/policy_engine.py
@@ -481,6 +481,14 @@ class PolicyEngine:
         # tighten-only merge with the local agents.yaml.
         _ac = settings.get("agent_controls")
         self.agent_controls: Dict[str, Any] = _ac if isinstance(_ac, dict) else {}
+        # Per-event rule exemptions (relax/flag a rule for a specific user,
+        # device, or session) from the verified signed policy. A list matched at
+        # evaluation time against the current context (see runtime), NOT a
+        # profile — so it works for session scope and can relax any finding,
+        # including scoped-agent. Floor rules can never be exempted. Managed
+        # workspaces only.
+        _re = settings.get("rule_exemptions")
+        self.rule_exemptions: List[Dict[str, Any]] = _re if isinstance(_re, list) else []
         # Global observe/enforce default for rules that don't set their own mode.
         # Defaults to "observe" — a fresh policy blocks nothing until an admin
         # flips rules (or this) to enforce.

--- a/warden/policy_engine.py
+++ b/warden/policy_engine.py
@@ -474,6 +474,13 @@ class PolicyEngine:
 
         # Compile settings.
         self.block_categories = set(settings.get("block_categories", []))
+        # Org per-agent controls (kill-switch / forced mode / IAM profile per
+        # named agent) from the verified signed remote policy. Only populated on
+        # org-managed workspaces (the remote overlay is only merged there); the
+        # runtime passes this into agents.resolve_agent_control for the
+        # tighten-only merge with the local agents.yaml.
+        _ac = settings.get("agent_controls")
+        self.agent_controls: Dict[str, Any] = _ac if isinstance(_ac, dict) else {}
         # Global observe/enforce default for rules that don't set their own mode.
         # Defaults to "observe" — a fresh policy blocks nothing until an admin
         # flips rules (or this) to enforce.

--- a/warden/policy_schema.json
+++ b/warden/policy_schema.json
@@ -1,249 +1,367 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Prismor Warden Policy Schema",
-    "description": "Schema for Warden YAML policy files that define detection rules, allowlists, and enforcement actions.",
-    "type": "object",
-    "required": ["version", "rules"],
-    "properties": {
-        "version": {
-            "type": "string",
-            "description": "Policy schema version",
-            "enum": ["1.0"]
-        },
-        "rules": {
-            "type": "array",
-            "description": "Detection rules evaluated against agent events",
-            "items": {
-                "$ref": "#/definitions/rule"
-            }
-        },
-        "allowlists": {
-            "type": "array",
-            "description": "Allowlist entries that suppress specific rule matches",
-            "items": {
-                "$ref": "#/definitions/allowlist_entry"
-            }
-        },
-        "settings": {
-            "type": "object",
-            "description": "Policy-level settings that control enforcement behaviour",
-            "properties": {
-                "default_mode": {
-                    "type": "string",
-                    "enum": ["observe", "enforce"],
-                    "description": "Global observe/enforce default for rules that don't set their own `mode`. Defaults to observe (nothing blocks until a rule is flipped to enforce)."
-                },
-                "block_categories": {
-                    "type": "array",
-                    "description": "Legacy: finding categories eligible to block. Enforcement is now decided per-rule via `mode`/`default_mode`; this is retained for compatibility.",
-                    "items": { "type": "string" }
-                },
-                "manifest_patterns": {
-                    "type": "array",
-                    "description": "Regex patterns that identify dependency manifest files (used for severity upgrades)",
-                    "items": { "type": "string" }
-                },
-                "egress_allowlist": {
-                    "type": "array",
-                    "description": "Outbound domains allowed without a warning (supports wildcards, e.g. \"*.github.com\"). Empty allows all.",
-                    "items": { "type": "string" }
-                },
-                "mcp_transport_action": {
-                    "type": "string",
-                    "enum": ["warn", "block"],
-                    "description": "Action for insecure MCP remote-transport findings raised by scan (cleartext/raw-IP/off-allowlist/hardcoded-secret). Defaults to warn."
-                },
-                "semantic_guard": {
-                    "type": "object",
-                    "description": "Settings for the optional LLM-assisted semantic prompt-injection layer.",
-                    "additionalProperties": true
-                },
-                "sandbox": {
-                    "type": "object",
-                    "description": "Docker-backed shell sandbox settings for constraining allowed Bash commands.",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Whether hook-dispatch rewrites supported Bash tool calls through the sandbox runner."
-                        },
-                        "backend": {
-                            "type": "string",
-                            "enum": ["docker"],
-                            "description": "Sandbox backend. Docker is the v1 backend."
-                        },
-                        "mode": {
-                            "type": "string",
-                            "enum": ["observe", "enforce"],
-                            "description": "observe logs unavailable sandbox state; enforce fails closed when the sandbox is unavailable."
-                        },
-                        "image": {
-                            "type": "string",
-                            "description": "Container image used for sandboxed shell execution."
-                        },
-                        "workdir": {
-                            "type": "string",
-                            "description": "Container working directory for the workspace mount."
-                        },
-                        "network": {
-                            "type": "string",
-                            "enum": ["none", "bridge", "host", "allowlist"],
-                            "description": "Docker network mode. allowlist currently fails closed to none because Docker cannot enforce domain allowlists by itself."
-                        },
-                        "workspace_mount": {
-                            "type": "string",
-                            "enum": ["ro", "rw"],
-                            "description": "Whether the workspace bind mount is read-only or read-write."
-                        },
-                        "read_only_root": {
-                            "type": "boolean",
-                            "description": "Run the container with a read-only root filesystem."
-                        },
-                        "tmpfs": {
-                            "type": "array",
-                            "description": "Docker --tmpfs entries for controlled writable scratch space.",
-                            "items": { "type": "string" }
-                        },
-                        "env_allowlist": {
-                            "type": "array",
-                            "description": "Host environment variable names allowed into the sandbox.",
-                            "items": { "type": "string" }
-                        },
-                        "resource_limits": {
-                            "type": "object",
-                            "description": "Docker resource limits.",
-                            "properties": {
-                                "cpus": { "type": "string" },
-                                "memory": { "type": "string" },
-                                "pids_limit": { "type": "integer" },
-                                "timeout_seconds": { "type": "integer" }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Prismor Warden Policy Schema",
+  "description": "Schema for Warden YAML policy files that define detection rules, allowlists, and enforcement actions.",
+  "type": "object",
+  "required": [
+    "version",
+    "rules"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Policy schema version",
+      "enum": [
+        "1.0"
+      ]
     },
-    "additionalProperties": false,
-    "definitions": {
-        "rule": {
-            "type": "object",
-            "required": ["id", "severity", "category", "title", "event_types", "patterns", "action"],
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "Unique rule identifier (e.g., destructive-command)",
-                    "pattern": "^[a-z0-9][a-z0-9-]*$"
-                },
-                "severity": {
-                    "type": "string",
-                    "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
-                    "description": "Finding severity when this rule matches"
-                },
-                "category": {
-                    "type": "string",
-                    "description": "Finding category for grouping and feed correlation"
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Human-readable title shown in findings"
-                },
-                "event_types": {
-                    "type": "array",
-                    "description": "Event types this rule applies to (shell, file_read, file_write, network, prompt, tool_result)",
-                    "items": {
-                        "type": "string",
-                        "enum": ["shell", "file_read", "file_write", "network", "prompt", "tool_result"]
-                    },
-                    "minItems": 1
-                },
-                "fields": {
-                    "type": "array",
-                    "description": "Event fields to match against. Defaults to the canonical field for the event type (command for shell, path for file_*, url for network, combined_text for prompt/tool_result).",
-                    "items": {
-                        "type": "string",
-                        "enum": ["command", "path", "url", "combined_text"]
-                    }
-                },
-                "patterns": {
-                    "type": "array",
-                    "description": "Regex patterns (Python re syntax). A match on ANY pattern triggers the rule.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "minItems": 1
-                },
-                "action": {
-                    "type": "string",
-                    "enum": ["block", "warn", "log"],
-                    "description": "Legacy/decorative classification. Observe vs enforce is now controlled by `mode`/`default_mode`, not this field."
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": ["observe", "enforce"],
-                    "description": "Per-rule observe/enforce override. observe = detect + log only; enforce = block on a pre-action event. Omit to inherit settings.default_mode (default observe)."
-                },
-                "add_patterns": {
-                    "type": "array",
-                    "description": "Extra regex patterns to add to this rule on top of its defaults. Custom org-specific detections — strengthen-only.",
-                    "items": { "type": "string" }
-                },
-                "disable_patterns": {
-                    "type": "array",
-                    "description": "Default regex patterns to disable for this rule, referenced by their exact regex string. Not allowed on core protections. A no-match entry is ignored (drift fails toward more detection).",
-                    "items": { "type": "string" }
-                },
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Whether this rule is active. Defaults to true.",
-                    "default": true
-                },
-                "severity_on_write": {
-                    "type": "string",
-                    "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
-                    "description": "Override severity when the matched event_type is file_write"
-                },
-                "severity_on_manifest": {
-                    "type": "string",
-                    "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
-                    "description": "Override severity when the matched path is a dependency manifest file"
-                }
-            },
-            "additionalProperties": false
+    "rules": {
+      "type": "array",
+      "description": "Detection rules evaluated against agent events",
+      "items": {
+        "$ref": "#/definitions/rule"
+      }
+    },
+    "allowlists": {
+      "type": "array",
+      "description": "Allowlist entries that suppress specific rule matches",
+      "items": {
+        "$ref": "#/definitions/allowlist_entry"
+      }
+    },
+    "settings": {
+      "type": "object",
+      "description": "Policy-level settings that control enforcement behaviour",
+      "properties": {
+        "default_mode": {
+          "type": "string",
+          "enum": [
+            "observe",
+            "enforce"
+          ],
+          "description": "Global observe/enforce default for rules that don't set their own `mode`. Defaults to observe (nothing blocks until a rule is flipped to enforce)."
         },
-        "allowlist_entry": {
-            "type": "object",
-            "required": ["id", "rule_ids", "patterns"],
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "Unique allowlist entry identifier",
-                    "pattern": "^[a-z0-9][a-z0-9-]*$"
+        "block_categories": {
+          "type": "array",
+          "description": "Legacy: finding categories eligible to block. Enforcement is now decided per-rule via `mode`/`default_mode`; this is retained for compatibility.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "manifest_patterns": {
+          "type": "array",
+          "description": "Regex patterns that identify dependency manifest files (used for severity upgrades)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "egress_allowlist": {
+          "type": "array",
+          "description": "Outbound domains allowed without a warning (supports wildcards, e.g. \"*.github.com\"). Empty allows all.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mcp_transport_action": {
+          "type": "string",
+          "enum": [
+            "warn",
+            "block"
+          ],
+          "description": "Action for insecure MCP remote-transport findings raised by scan (cleartext/raw-IP/off-allowlist/hardcoded-secret). Defaults to warn."
+        },
+        "semantic_guard": {
+          "type": "object",
+          "description": "Settings for the optional LLM-assisted semantic prompt-injection layer.",
+          "additionalProperties": true
+        },
+        "sandbox": {
+          "type": "object",
+          "description": "Docker-backed shell sandbox settings for constraining allowed Bash commands.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether hook-dispatch rewrites supported Bash tool calls through the sandbox runner."
+            },
+            "backend": {
+              "type": "string",
+              "enum": [
+                "docker"
+              ],
+              "description": "Sandbox backend. Docker is the v1 backend."
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "observe",
+                "enforce"
+              ],
+              "description": "observe logs unavailable sandbox state; enforce fails closed when the sandbox is unavailable."
+            },
+            "image": {
+              "type": "string",
+              "description": "Container image used for sandboxed shell execution."
+            },
+            "workdir": {
+              "type": "string",
+              "description": "Container working directory for the workspace mount."
+            },
+            "network": {
+              "type": "string",
+              "enum": [
+                "none",
+                "bridge",
+                "host",
+                "allowlist"
+              ],
+              "description": "Docker network mode. allowlist currently fails closed to none because Docker cannot enforce domain allowlists by itself."
+            },
+            "workspace_mount": {
+              "type": "string",
+              "enum": [
+                "ro",
+                "rw"
+              ],
+              "description": "Whether the workspace bind mount is read-only or read-write."
+            },
+            "read_only_root": {
+              "type": "boolean",
+              "description": "Run the container with a read-only root filesystem."
+            },
+            "tmpfs": {
+              "type": "array",
+              "description": "Docker --tmpfs entries for controlled writable scratch space.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "env_allowlist": {
+              "type": "array",
+              "description": "Host environment variable names allowed into the sandbox.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "resource_limits": {
+              "type": "object",
+              "description": "Docker resource limits.",
+              "properties": {
+                "cpus": {
+                  "type": "string"
                 },
-                "rule_ids": {
-                    "type": "array",
-                    "description": "Rule IDs this allowlist applies to. Use ['*'] for all rules.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "minItems": 1
+                "memory": {
+                  "type": "string"
                 },
-                "patterns": {
-                    "type": "array",
-                    "description": "Regex patterns that, when matched, suppress the finding.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "minItems": 1
+                "pids_limit": {
+                  "type": "integer"
                 },
-                "reason": {
-                    "type": "string",
-                    "description": "Human-readable reason for this allowlist entry"
+                "timeout_seconds": {
+                  "type": "integer"
                 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "agent_controls": {
+          "type": "object",
+          "description": "Org-pushed per-agent controls, keyed by agent instance name (the adapter's name=) or framework id for unnamed agents. Served only in the signed remote policy; merged tighten-only with the local agents.yaml (an org kill-switch cannot be re-enabled locally).",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "false = kill switch: every tool call from this agent blocks"
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "observe",
+                  "enforce"
+                ],
+                "description": "Forced mode override for this agent"
+              },
+              "iam_profile": {
+                "type": "string",
+                "description": "IAM profile to enforce (must be defined in the local/project iam.yaml)"
+              }
             },
             "additionalProperties": false
+          }
         }
+      },
+      "additionalProperties": false
     }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "rule": {
+      "type": "object",
+      "required": [
+        "id",
+        "severity",
+        "category",
+        "title",
+        "event_types",
+        "patterns",
+        "action"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique rule identifier (e.g., destructive-command)",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW"
+          ],
+          "description": "Finding severity when this rule matches"
+        },
+        "category": {
+          "type": "string",
+          "description": "Finding category for grouping and feed correlation"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title shown in findings"
+        },
+        "event_types": {
+          "type": "array",
+          "description": "Event types this rule applies to (shell, file_read, file_write, network, prompt, tool_result)",
+          "items": {
+            "type": "string",
+            "enum": [
+              "shell",
+              "file_read",
+              "file_write",
+              "network",
+              "prompt",
+              "tool_result"
+            ]
+          },
+          "minItems": 1
+        },
+        "fields": {
+          "type": "array",
+          "description": "Event fields to match against. Defaults to the canonical field for the event type (command for shell, path for file_*, url for network, combined_text for prompt/tool_result).",
+          "items": {
+            "type": "string",
+            "enum": [
+              "command",
+              "path",
+              "url",
+              "combined_text"
+            ]
+          }
+        },
+        "patterns": {
+          "type": "array",
+          "description": "Regex patterns (Python re syntax). A match on ANY pattern triggers the rule.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "block",
+            "warn",
+            "log"
+          ],
+          "description": "Legacy/decorative classification. Observe vs enforce is now controlled by `mode`/`default_mode`, not this field."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "observe",
+            "enforce"
+          ],
+          "description": "Per-rule observe/enforce override. observe = detect + log only; enforce = block on a pre-action event. Omit to inherit settings.default_mode (default observe)."
+        },
+        "add_patterns": {
+          "type": "array",
+          "description": "Extra regex patterns to add to this rule on top of its defaults. Custom org-specific detections \u2014 strengthen-only.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disable_patterns": {
+          "type": "array",
+          "description": "Default regex patterns to disable for this rule, referenced by their exact regex string. Not allowed on core protections. A no-match entry is ignored (drift fails toward more detection).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this rule is active. Defaults to true.",
+          "default": true
+        },
+        "severity_on_write": {
+          "type": "string",
+          "enum": [
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW"
+          ],
+          "description": "Override severity when the matched event_type is file_write"
+        },
+        "severity_on_manifest": {
+          "type": "string",
+          "enum": [
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW"
+          ],
+          "description": "Override severity when the matched path is a dependency manifest file"
+        }
+      },
+      "additionalProperties": false
+    },
+    "allowlist_entry": {
+      "type": "object",
+      "required": [
+        "id",
+        "rule_ids",
+        "patterns"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique allowlist entry identifier",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "rule_ids": {
+          "type": "array",
+          "description": "Rule IDs this allowlist applies to. Use ['*'] for all rules.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "patterns": {
+          "type": "array",
+          "description": "Regex patterns that, when matched, suppress the finding.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason for this allowlist entry"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/warden/policy_schema.json
+++ b/warden/policy_schema.json
@@ -189,6 +189,44 @@
             },
             "additionalProperties": false
           }
+        },
+        "rule_exemptions": {
+          "type": "array",
+          "description": "Admin-granted per-event rule exemptions, matched at eval time against the current user/device/session. 'allow' drops the finding; 'flag' downgrades it to a non-blocking warning. Core/floor rules can never be exempted.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "ruleId": {
+                "type": "string"
+              },
+              "scope": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "device",
+                  "session"
+                ]
+              },
+              "scopeId": {
+                "type": "string"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "allow",
+                  "flag"
+                ]
+              },
+              "expires": {
+                "type": "string",
+                "description": "ISO-8601 expiry; absent = permanent until revoked"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/warden/runtime.py
+++ b/warden/runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -41,6 +42,73 @@ class Decision:
     # Engine kept so callers that need post-decision config (e.g. the Claude
     # sandbox rewrite path) don't have to re-instantiate it.
     engine: Optional[PolicyEngine] = None
+
+
+def _apply_rule_exemptions(
+    findings: List[Dict[str, Any]],
+    rule_exemptions: Optional[List[Dict[str, Any]]],
+    *,
+    session_id: str,
+    subject: Optional[Subject],
+) -> List[Dict[str, Any]]:
+    """Relax or downgrade findings per admin-granted, signed rule exemptions.
+
+    Each exemption is ``{ruleId, scope (user|device|session), scopeId, action
+    (allow|flag), expires?}``, matched at eval time against the current context.
+    ``allow`` drops the matched finding (the call proceeds, nothing recorded);
+    ``flag`` downgrades it to observe (reported as a warning, but non-blocking).
+
+    Core protections are never exemptable: a floor rule id / core block category
+    (and the agent kill-switch) is left untouched regardless of any exemption.
+    """
+    if not rule_exemptions:
+        return findings
+    from warden.policy_engine import _NON_OVERRIDABLE_RULE_IDS, _CORE_BLOCK_CATEGORIES
+
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    user_id = subject.user_id if subject else None
+    device_id = None
+    try:
+        from warden.enterprise import identity as _identity
+        ident = _identity.load_identity()
+        device_id = ident.get("device_id") if ident else None
+    except Exception:
+        device_id = None
+
+    def _matches(ex: Dict[str, Any], rule_id: str) -> bool:
+        if str(ex.get("ruleId") or "") != rule_id:
+            return False
+        exp = ex.get("expires")
+        if exp and str(exp) < now_iso:
+            return False
+        scope, scope_id = ex.get("scope"), ex.get("scopeId")
+        if scope == "user":
+            return bool(user_id) and scope_id == user_id
+        if scope == "device":
+            return bool(device_id) and scope_id == device_id
+        if scope == "session":
+            return bool(session_id) and scope_id == session_id
+        return False
+
+    out: List[Dict[str, Any]] = []
+    for f in findings:
+        rule_id = str(f.get("ruleId") or "")
+        category = f.get("category")
+        # Floor + admin kill-switch are never relaxable.
+        if (rule_id in _NON_OVERRIDABLE_RULE_IDS
+                or category in _CORE_BLOCK_CATEGORIES
+                or category == "agent-control"):
+            out.append(f)
+            continue
+        match = next((ex for ex in rule_exemptions if isinstance(ex, dict) and _matches(ex, rule_id)), None)
+        if match is None:
+            out.append(f)
+        elif str(match.get("action") or "allow") == "flag":
+            # Keep the finding (auditable warning), but strip its ability to block.
+            downgraded = {**f, "mode": "observe", "exempted": "flag"}
+            out.append(downgraded)
+        # action == "allow": drop the finding entirely.
+    return out
 
 
 def _block_reason(finding: Dict[str, Any]) -> str:
@@ -190,6 +258,18 @@ def evaluate_tool_call(
                     findings.extend(extra)
             except Exception as exc:
                 sys.stderr.write(f"[warden] {fn_name} error: {exc}\n")
+
+    # Per-event rule exemptions (admin-granted, signed): relax ("allow", drop the
+    # finding) or downgrade ("flag", warn but don't block) a rule for the current
+    # user / device / session. Applied after ALL findings are gathered, so it can
+    # also relax scoped-agent denials — but never a core/floor protection.
+    try:
+        findings = _apply_rule_exemptions(
+            findings, getattr(engine, "rule_exemptions", None),
+            session_id=session_id, subject=subject,
+        )
+    except Exception as exc:
+        sys.stderr.write(f"[warden] rule-exemption error: {exc}\n")
 
     _dispatch_telemetry(
         engine=engine,

--- a/warden/runtime.py
+++ b/warden/runtime.py
@@ -199,7 +199,11 @@ def evaluate_tool_call(
     if getattr(engine, "workspace_managed", False):
         try:
             from warden.enterprise import heartbeat
-            heartbeat.record_call(agent=agent, session_id=session_id)
+            heartbeat.record_call(
+                agent=agent,
+                agent_name=_agent_name if _agent_name != agent else "",
+                session_id=session_id,
+            )
             heartbeat.maybe_flush()
         except Exception:
             pass

--- a/warden/runtime.py
+++ b/warden/runtime.py
@@ -95,19 +95,6 @@ def evaluate_tool_call(
         meta["subject"] = subject.as_dict()
     meta.setdefault("agent_name", _agent_name)
 
-    # Resolve per-agent control (kill-switch, mode override, IAM profile).
-    _control = None
-    try:
-        from warden.agents import resolve_agent_control, record_seen, make_disabled_finding
-        _control = resolve_agent_control(_agent_name, workspace)
-        # Throttled auto-registration — once per agent per process.
-        record_seen(_agent_name, framework=agent, workspace=workspace)
-        # Per-agent mode override: takes precedence over the caller's mode.
-        if _control.mode:
-            mode = _control.mode
-    except Exception as _exc:
-        sys.stderr.write(f"[warden] agent control error: {_exc}\n")
-
     if persist:
         append_session_event(workspace, session_id, event)
         events = read_session_events(workspace, session_id)
@@ -132,6 +119,26 @@ def evaluate_tool_call(
         events = [event]
 
     engine = PolicyEngine(workspace=workspace)
+
+    # Resolve per-agent control (kill-switch, mode override, IAM profile).
+    # Runs AFTER engine construction so the org's remote controls — carried in
+    # the verified signed policy's settings.agent_controls, managed workspaces
+    # only — merge with the local agents.yaml (tighten-only: see agents.py).
+    _control = None
+    try:
+        from warden.agents import resolve_agent_control, record_seen, make_disabled_finding
+        _control = resolve_agent_control(
+            _agent_name, workspace,
+            remote_controls=getattr(engine, "agent_controls", None),
+        )
+        # Throttled auto-registration — once per agent per process.
+        record_seen(_agent_name, framework=agent, workspace=workspace)
+        # Per-agent mode override: takes precedence over the caller's mode.
+        if _control.mode:
+            mode = _control.mode
+    except Exception as _exc:
+        sys.stderr.write(f"[warden] agent control error: {_exc}\n")
+
     # Only the current event drives the real-time decision (stale prior findings
     # must not block an unrelated event — see cli.py hook-dispatch rationale).
     findings = engine.evaluate(event, len(events) - 1, session_id=session_id, subject=subject)
@@ -152,7 +159,8 @@ def evaluate_tool_call(
     if _control is not None and not _control.enabled:
         try:
             from warden.agents import make_disabled_finding
-            findings.insert(0, make_disabled_finding(_agent_name, session_id))
+            findings.insert(0, make_disabled_finding(
+                _agent_name, session_id, disabled_by=_control.disabled_by))
         except Exception as exc:
             sys.stderr.write(f"[warden] kill-switch error: {exc}\n")
 


### PR DESCRIPTION
Runtime side of agent fleet management (Phase 1 + 2). Server half: prismor-web #41 (Phase 1) + the Phase 2 web PR.

## Phase 1 — per-instance heartbeat + registration

- **Heartbeat** (`warden/enterprise/heartbeat.py`): counters keyed `<framework>|<name>` (v2 file; v1 migrates on read); one `agent_activity` record per instance per flush; 64-key cap folds overflow into the framework key.
- **Registration** (`warden/agents.py` `record_seen`): POSTs `/api/agents/register` on first sight (enrolled + managed-workspace only; daemon thread + 1h on-disk debounce) so deployed-but-quiet agents appear in the fleet before their first finding.

## Phase 2 — central control over the signed policy channel

The org's kill-switch / forced mode / IAM profile per named agent now reach every enrolled device:

- `policy_engine._load` lifts `settings.agent_controls` off the **verified signed policy** into `engine.agent_controls` (managed workspaces only; added to `policy_schema.json`).
- `resolve_agent_control` merges local + remote **tighten-only**: `enabled = local AND remote` (an org pause can't be locally re-enabled, and vice versa), `mode` remote-wins, `iam_profile` remote-wins (selecting among locally-defined profiles). `disabled_by` records the layer, and the kill-switch finding tells the developer whether it was the org or their own config.
- The control block moved **after** engine construction so remote controls are available (safe: nothing before it depended on `_control`).
- `remote_policy.check_and_refresh` re-pulls on a new **`agentControlsSig`** (same pattern as `managedReposSig`) — no profile-version bump, so a dashboard pause propagates within one debounce interval regardless of profile scope.
- `prismor agents list` gains a SOURCE column (org / local / both).

## Testing

- Focused suites: heartbeat keying/migration/cap; registration guards/debounce; **control merge precedence matrix** (remote-disable vs local-enable both directions, mode/IAM precedence, remote-only agents) + end-to-end `evaluate_tool_call` kill-switch (managed blocks, unmanaged ignores); `agentControlsSig` round-trip vs the server format.
- Full suite: **683 passed**.
- e2e against the local control plane covered separately in the web PR (kill-switch flip on both the coding-agent hook path and the framework SDK path).