### PR TITLE
Default control-plane base to https://www.prismor.dev

### DIFF
--- a/warden/enterprise/identity.py
+++ b/warden/enterprise/identity.py
@@ -24,7 +24,9 @@ from typing import Any, Dict, Optional
 
 # Default control-plane base URL. Overridable via $PRISMOR_API_BASE so
 # self-hosted / staging deployments can repoint without a rebuild.
-DEFAULT_API_BASE = "https://prismor.dev"
+# www is canonical: the apex is subject to host-level redirects that urllib
+# will not follow for POSTs (a domain-level 308 once broke enrollment).
+DEFAULT_API_BASE = "https://www.prismor.dev"
 
 _SCHEMA = "warden.identity.v1"
 

--- a/warden/store.py
+++ b/warden/store.py
@@ -1751,7 +1751,7 @@ def get_enrollment() -> Optional[Dict[str, Any]]:
             "enrolled": True,
             "org_id": data.get("org_id"),
             "device_id": data.get("device_id"),
-            "api_base": data.get("api_base", "https://prismor.dev"),
+            "api_base": data.get("api_base", "https://www.prismor.dev"),
         }
     except Exception:
         return None


### PR DESCRIPTION
## Why
`prismor enroll` failed with `enrollment rejected (308): Redirecting...` — the apex `prismor.dev` sat behind a Vercel **host-level 308 → www** that applied to `/api/*` too, and urllib won't resend a POST body across a redirect. That broke enrollment, telemetry ingest, and policy POSTs for every default install.

## What
- `DEFAULT_API_BASE` → `https://www.prismor.dev` (canonical host, immune to apex redirect config)
- Same default in `store.py`'s enrollment-status fallback
- `PRISMOR_API_BASE` env and `--api-base` still override

The web side has also been fixed (apex now serves `/api` directly; the www canonicalization moved into middleware for page routes only — Ar9av/prismor-web-preview#46), so existing 1.13.0 installs work again today. This makes the client robust regardless of apex routing. Ships with v1.14.0.