### PR TITLE
docs: honest adapter installs — from source until packages publish

### DIFF
--- a/docs/frameworks-browser-use.md
+++ b/docs/frameworks-browser-use.md
@@ -12,9 +12,13 @@ Playwright touches the browser.
 
 ## Install
 
+> The adapter packages are not on PyPI yet — until they publish, install from
+> source (the import paths below are identical either way).
+
 ```bash
-pip install prismor-warden-browser-use
-pip install "prismor-warden-browser-use[browser]"   # + browser-use itself
+pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                        # Warden runtime
+pip install "prismor-warden-browser-use @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/browser-use"
+pip install browser-use                              # + browser-use itself, if not present
 ```
 
 ## Guard a controller (easy path)

--- a/docs/frameworks-crewai.md
+++ b/docs/frameworks-crewai.md
@@ -7,9 +7,13 @@ Registry entry: `id: crewai` in
 
 ## Install
 
+> The adapter packages are not on PyPI yet — until they publish, install from
+> source (the import paths below are identical either way).
+
 ```bash
-pip install prismor-warden-crewai
-pip install "prismor-warden-crewai[crewai]"   # + crewai itself
+pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                  # Warden runtime
+pip install "prismor-warden-crewai @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/crewai"
+pip install crewai                             # + crewai itself, if not present
 ```
 
 ## Guard tools (easy path)

--- a/docs/frameworks-langchain.md
+++ b/docs/frameworks-langchain.md
@@ -7,9 +7,13 @@ Registry entry: `id: langchain` in
 
 ## Install
 
+> The adapter packages are not on PyPI yet — until they publish, install from
+> source (the import paths below are identical either way).
+
 ```bash
-pip install prismor-warden-langchain
-pip install "prismor-warden-langchain[langchain]"  # + langchain-core itself
+pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                     # Warden runtime
+pip install "prismor-warden-langchain @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/langchain"
+pip install langchain-core                        # + langchain itself, if not present
 ```
 
 ## Guard tools (easy path)

--- a/docs/frameworks-openai-agents.md
+++ b/docs/frameworks-openai-agents.md
@@ -14,9 +14,13 @@ The OpenAI Agents SDK adapter ships from
 
 ## Install
 
+> The adapter packages are not on PyPI yet — until they publish, install from
+> source (the import paths below are identical either way).
+
 ```bash
-pip install prismor-warden-openai          # + the Warden runtime (prismor)
-pip install "prismor-warden-openai[sdk]"   # + the openai-agents SDK itself
+pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"              # Warden runtime
+pip install "prismor-warden-openai @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/openai-agents"
+pip install openai-agents                  # + the SDK itself, if not present
 ```
 
 ## Guard an agent (easy path)

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -6,13 +6,16 @@ on your existing agent or controller object, with no changes to your tool logic.
 
 ## UX at a glance
 
-| Framework | Language | Install | Guard | Multi-tenant |
+| Framework | Language | Package | Guard | Multi-tenant |
 |---|---|---|---|---|
-| OpenAI Agents SDK | Python | `pip install prismor-warden-openai` | `guard_agent(agent)` | `use_subject("user:alice")` |
-| LangChain / LangGraph | Python | `pip install prismor-warden-langchain` | `guard_tools([...])` | `use_subject("user:alice")` |
-| CrewAI | Python | `pip install prismor-warden-crewai` | `guard_tools([...])` | `use_subject("user:alice")` |
-| browser-use | Python | `pip install prismor-warden-browser-use` | `guard_controller(controller)` | `use_subject("user:alice")` |
-| Vercel AI SDK | TypeScript | `npm install prismor-warden-vercel` | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
+| OpenAI Agents SDK | Python | `prismor-warden-openai` | `guard_agent(agent)` | `use_subject("user:alice")` |
+| LangChain / LangGraph | Python | `prismor-warden-langchain` | `guard_tools([...])` | `use_subject("user:alice")` |
+| CrewAI | Python | `prismor-warden-crewai` | `guard_tools([...])` | `use_subject("user:alice")` |
+| browser-use | Python | `prismor-warden-browser-use` | `guard_controller(controller)` | `use_subject("user:alice")` |
+| Vercel AI SDK | TypeScript | `prismor-warden-vercel` | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
+
+> The adapter packages are not on PyPI/npm yet — each framework doc shows the
+> verified install-from-source command until they publish.
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Warden-Subject` header |
 
 The Python multi-tenant pattern: guard once at startup with no bound subject,
@@ -76,7 +79,7 @@ Validated live on an Ubuntu EC2 instance with real OpenAI function calls:
 
 | Language | Adapter size | Dependencies |
 |---|---|---|
-| TypeScript (Vercel AI SDK) | ~80 lines | `npm install prismor-warden-vercel` |
+| TypeScript (Vercel AI SDK) | ~80 lines | `prismor-warden-vercel` (from source until published — see [frameworks-vercel-ai](frameworks-vercel-ai.md)) |
 | Node.js (raw) | ~25 lines | built-in `fetch` |
 | Ruby | ~20 lines | stdlib `Net::HTTP` |
 | Java 21 | ~25 lines | stdlib `java.net.http` |

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -37,8 +37,12 @@ The server exposes:
 
 ## Install
 
+> The npm package is not published yet — until it is, install the adapter from
+> a checkout of the repo (it has no runtime npm dependencies).
+
 ```bash
-npm install prismor-warden-vercel
+git clone https://github.com/PrismorSec/prismor.git
+npm install ./prismor/adapters/vercel-ai
 ```
 
 ## Quick start


### PR DESCRIPTION
## Problem
The framework docs tell people to `pip install prismor-warden-langchain` (etc.) and `npm install prismor-warden-vercel` — **none of the five adapter packages are published** (all 404 on PyPI/npm). Worse, the adapters import `warden.principal`, which postdates the released `prismor` 1.13.0, so they can't run against the PyPI runtime at all.

## Fix
Every install section now shows the **verified** from-source commands:
- Python: `pip install "prismor @ git+…"` + `pip install "prismor-warden-<x> @ git+…#subdirectory=adapters/<x>"`
- Vercel: clone + `npm install ./prismor/adapters/vercel-ai`
- Overview table: Install column → Package names, with a not-yet-published note

Validated in a clean venv: install both → `from prismor.warden.langchain import guard_tools, use_subject` imports exactly as documented.

## Real fix (separate)
Cut prismor v1.14.0 and publish the five adapter packages — then these sections revert to plain `pip install` / `npm install`.