### PR TITLE
release: v1.14.0

### DIFF
--- a/packaging/immunity-agent-shim/immunity_agent/__init__.py
+++ b/packaging/immunity-agent-shim/immunity_agent/__init__.py
@@ -12,4 +12,4 @@ then use the ``prismor`` command. See https://prismor.dev for details.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/packaging/immunity-agent-shim/pyproject.toml
+++ b/packaging/immunity-agent-shim/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # `warden/__init__.py` on every release.
 [project]
 name = "immunity-agent"
-version = "1.13.0"
+version = "1.14.0"
 description = "Deprecated — renamed to 'prismor'. Installs prismor for you. Run: pip install prismor"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "prismor>=1.13.0",
+    "prismor>=1.14.0",
 ]
 
 [project.urls]

--- a/warden/__init__.py
+++ b/warden/__init__.py
@@ -1,6 +1,6 @@
 """Prismor Warden local session-security utility."""
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"
 
 from warden.semantic_guard import SemanticGuard, SemanticRisk
 from warden.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
Version bump for the v1.14.0 release (runtime + immunity-agent shim, shim pin moves to prismor>=1.14.0). Tag `v1.14.0` follows the merge — the Release workflow builds, publishes both packages to PyPI via trusted publishing, and creates the GitHub Release.

Ships the 37 commits since the (untagged) 1.13.0 upload: `prismor.warden.*` namespace imports, `warden.principal` + eval-server (unblocks the framework adapters), curl installer + sandbox fixes, agent-name telemetry, per-instance heartbeat, instance registration, org-pushed per-agent controls, eval-time rule exemptions, and the www API base fix.