### PR TITLE
ci: adapter release workflow (PyPI trusted publishing + npm)

### DIFF
--- a/.github/workflows/release-adapters.yml
+++ b/.github/workflows/release-adapters.yml
@@ -1,0 +1,76 @@
+name: Release Adapters
+
+# Publishes the framework adapter packages. Separate from the main Release
+# workflow so an unconfigured publisher can never block a runtime release.
+#
+# PyPI side (trusted publishing, no tokens): each package needs a (pending)
+# publisher on pypi.org pointing at this repo + this workflow file + the
+# `pypi` environment: prismor-warden-langchain, prismor-warden-crewai,
+# prismor-warden-openai, prismor-warden-browser-use.
+#
+# npm side: set an automation token as the NPM_TOKEN repo secret; the job
+# skips cleanly when it's absent.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "adapters-v*"
+
+permissions:
+  contents: read
+  id-token: write # OIDC for PyPI trusted publishing
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    environment: pypi
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter: [langchain, crewai, openai-agents, browser-use]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build ${{ matrix.adapter }} adapter
+        run: |
+          pip install build
+          python -m build "adapters/${{ matrix.adapter }}" --outdir dist-adapter
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-adapter
+          skip-existing: true
+
+  npm:
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when NPM_TOKEN is not configured
+        if: env.NPM_TOKEN == ''
+        run: echo "NPM_TOKEN secret not set — skipping npm publish." && exit 0
+
+      - uses: actions/setup-node@v4
+        if: env.NPM_TOKEN != ''
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Build and publish prismor-warden-vercel
+        if: env.NPM_TOKEN != ''
+        working-directory: adapters/vercel-ai
+        run: |
+          npm install
+          npm run build
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/release-adapters.yml`: on `workflow_dispatch` or an `adapters-v*` tag, builds each of the four Python adapters (matrix, `skip-existing`) and publishes via PyPI trusted publishing, plus `prismor-warden-vercel` to npm when an `NPM_TOKEN` secret exists (skips cleanly otherwise). Local test-build of an adapter sdist+wheel passes.

**Requires one-time setup on pypi.org** (org owner): add pending publishers for `prismor-warden-langchain`, `-crewai`, `-openai`, `-browser-use` → repo `PrismorSec/prismor`, workflow `release-adapters.yml`, environment `pypi`.