### PR TITLE
pip install prismor[framework] — bundle adapters into the main wheel (v1.14.1)

### DIFF
--- a/docs/frameworks-browser-use.md
+++ b/docs/frameworks-browser-use.md
@@ -12,14 +12,12 @@ Playwright touches the browser.
 
 ## Install
 
-> The adapter packages are not on PyPI yet — until they publish, install from
-> source (the import paths below are identical either way).
-
 ```bash
-pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                        # Warden runtime
-pip install "prismor-warden-browser-use @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/browser-use"
-pip install browser-use                              # + browser-use itself, if not present
+pip install "prismor[browser-use]"
 ```
+
+> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> works from source: `pip install "prismor[browser-use] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard a controller (easy path)
 

--- a/docs/frameworks-crewai.md
+++ b/docs/frameworks-crewai.md
@@ -7,14 +7,12 @@ Registry entry: `id: crewai` in
 
 ## Install
 
-> The adapter packages are not on PyPI yet — until they publish, install from
-> source (the import paths below are identical either way).
-
 ```bash
-pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                  # Warden runtime
-pip install "prismor-warden-crewai @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/crewai"
-pip install crewai                             # + crewai itself, if not present
+pip install "prismor[crewai]"
 ```
+
+> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> works from source: `pip install "prismor[crewai] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard tools (easy path)
 

--- a/docs/frameworks-langchain.md
+++ b/docs/frameworks-langchain.md
@@ -7,14 +7,12 @@ Registry entry: `id: langchain` in
 
 ## Install
 
-> The adapter packages are not on PyPI yet — until they publish, install from
-> source (the import paths below are identical either way).
-
 ```bash
-pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"                     # Warden runtime
-pip install "prismor-warden-langchain @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/langchain"
-pip install langchain-core                        # + langchain itself, if not present
+pip install "prismor[langchain]"
 ```
+
+> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> works from source: `pip install "prismor[langchain] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard tools (easy path)
 

--- a/docs/frameworks-openai-agents.md
+++ b/docs/frameworks-openai-agents.md
@@ -14,14 +14,12 @@ The OpenAI Agents SDK adapter ships from
 
 ## Install
 
-> The adapter packages are not on PyPI yet — until they publish, install from
-> source (the import paths below are identical either way).
-
 ```bash
-pip install "prismor @ git+https://github.com/PrismorSec/prismor.git@main"              # Warden runtime
-pip install "prismor-warden-openai @ git+https://github.com/PrismorSec/prismor.git@main#subdirectory=adapters/openai-agents"
-pip install openai-agents                  # + the SDK itself, if not present
+pip install "prismor[openai-agents]"
 ```
+
+> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> works from source: `pip install "prismor[openai-agents] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard an agent (easy path)
 

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -6,16 +6,17 @@ on your existing agent or controller object, with no changes to your tool logic.
 
 ## UX at a glance
 
-| Framework | Language | Package | Guard | Multi-tenant |
+| Framework | Language | Install | Guard | Multi-tenant |
 |---|---|---|---|---|
-| OpenAI Agents SDK | Python | `prismor-warden-openai` | `guard_agent(agent)` | `use_subject("user:alice")` |
-| LangChain / LangGraph | Python | `prismor-warden-langchain` | `guard_tools([...])` | `use_subject("user:alice")` |
-| CrewAI | Python | `prismor-warden-crewai` | `guard_tools([...])` | `use_subject("user:alice")` |
-| browser-use | Python | `prismor-warden-browser-use` | `guard_controller(controller)` | `use_subject("user:alice")` |
-| Vercel AI SDK | TypeScript | `prismor-warden-vercel` | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
+| OpenAI Agents SDK | Python | `pip install "prismor[openai-agents]"` | `guard_agent(agent)` | `use_subject("user:alice")` |
+| LangChain / LangGraph | Python | `pip install "prismor[langchain]"` | `guard_tools([...])` | `use_subject("user:alice")` |
+| CrewAI | Python | `pip install "prismor[crewai]"` | `guard_tools([...])` | `use_subject("user:alice")` |
+| browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
+| Vercel AI SDK | TypeScript | `prismor-warden-vercel` (npm, from source until published) | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
 
-> The adapter packages are not on PyPI/npm yet — each framework doc shows the
-> verified install-from-source command until they publish.
+> The Python adapters ship inside the `prismor` package (needs `>= 1.14.1`) —
+> the extra just pulls the framework itself. `prismor[frameworks]` installs all
+> four. The npm package publishes separately.
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Warden-Subject` header |
 
 The Python multi-tenant pattern: guard once at startup with no bound subject,

--- a/packaging/immunity-agent-shim/immunity_agent/__init__.py
+++ b/packaging/immunity-agent-shim/immunity_agent/__init__.py
@@ -12,4 +12,4 @@ then use the ``prismor`` command. See https://prismor.dev for details.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.14.0"
+__version__ = "1.14.1"

--- a/packaging/immunity-agent-shim/pyproject.toml
+++ b/packaging/immunity-agent-shim/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # `warden/__init__.py` on every release.
 [project]
 name = "immunity-agent"
-version = "1.14.0"
+version = "1.14.1"
 description = "Deprecated — renamed to 'prismor'. Installs prismor for you. Run: pip install prismor"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "prismor>=1.14.0",
+    "prismor>=1.14.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,19 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["build", "pytest"]
+# Framework adapters ship inside this package (prismor.warden.<framework>);
+# the extras just pull the framework itself so `pip install "prismor[langchain]"`
+# is a one-liner. See adapters/ for the sources and docs/frameworks-*.
+langchain = ["langchain-core>=0.2"]
+crewai = ["crewai>=0.30"]
+openai-agents = ["openai-agents>=0.0.1"]
+browser-use = ["browser-use>=0.1.0"]
+frameworks = [
+    "langchain-core>=0.2",
+    "crewai>=0.30",
+    "openai-agents>=0.0.1",
+    "browser-use>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://prismor.dev"
@@ -54,10 +67,25 @@ prismor-warden-cloak = "warden.cloaking.hermes_plugin_entry:register"
 path = "warden/__init__.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["warden", "supplychain"]
+packages = [
+    "warden",
+    "supplychain",
+    # Framework adapter implementations — bundled so the extras above work
+    # without separate adapter packages on PyPI.
+    "adapters/langchain/prismor_warden_langchain",
+    "adapters/crewai/prismor_warden_crewai",
+    "adapters/openai-agents/prismor_warden_openai",
+    "adapters/browser-use/prismor_warden_browser_use",
+]
 
 # Bundle runtime data into the wheel under warden/data/
 [tool.hatch.build.targets.wheel.force-include]
+# prismor.warden.<framework> namespace shims (PEP 420 — no __init__.py above
+# the leaf, so the prismor/ and prismor/warden/ levels stay namespaces).
+"adapters/langchain/prismor/warden/langchain/__init__.py" = "prismor/warden/langchain/__init__.py"
+"adapters/crewai/prismor/warden/crewai/__init__.py" = "prismor/warden/crewai/__init__.py"
+"adapters/openai-agents/prismor/warden/openai/__init__.py" = "prismor/warden/openai/__init__.py"
+"adapters/browser-use/prismor/warden/browser_use/__init__.py" = "prismor/warden/browser_use/__init__.py"
 "immunity-agent.pth" = "immunity-agent.pth"
 "advisories/immunity-feed.json" = "warden/data/advisories/immunity-feed.json"
 "advisories/immunity-feed.json.sig" = "warden/data/advisories/immunity-feed.json.sig"

--- a/warden/__init__.py
+++ b/warden/__init__.py
@@ -1,6 +1,6 @@
 """Prismor Warden local session-security utility."""
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"
 
 from warden.semantic_guard import SemanticGuard, SemanticRisk
 from warden.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
## What
`pip install "prismor[langchain]"` (or `crewai`, `openai-agents`, `browser-use`, `frameworks` for all) now gives a working adapter with one command:

- The four `prismor_warden_*` impl modules + their `prismor.warden.<fw>` PEP 420 namespace shims are bundled into the main wheel (hatch `packages` + `force-include`; no stray `__init__.py` above the leaves)
- Extras pull the framework itself; the adapters import frameworks lazily so the base install stays dependency-light
- Framework docs switched to the extras one-liners (git fallback noted until 1.14.1 hits PyPI); overview table updated
- Version → **1.14.1**

## Why
Kills the five-package publishing problem: no pending publishers, no separate adapter releases — fixing the single `prismor` trusted publisher on PyPI unblocks everything Python-side. (`adapters/` stay as standalone-publishable sources; the npm Vercel adapter is unchanged.)

## Verified
Clean venv, built wheel: `pip install "prismor[langchain] @ file://…whl"` → `from prismor.warden.langchain import guard_tools, use_subject` and `prismor.warden.openai.guard_agent` import; `langchain-core` resolved via the extra. Wheel contents audited for all 8 bundled paths.