### PR TITLE
fix(packaging): include adapters/ in sdist — v1.14.2

### DIFF
--- a/docs/frameworks-browser-use.md
+++ b/docs/frameworks-browser-use.md
@@ -16,7 +16,7 @@ Playwright touches the browser.
 pip install "prismor[browser-use]"
 ```
 
-> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> Needs `prismor >= 1.14.2`. Until that version is on PyPI, the same one-liner
 > works from source: `pip install "prismor[browser-use] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard a controller (easy path)

--- a/docs/frameworks-crewai.md
+++ b/docs/frameworks-crewai.md
@@ -11,7 +11,7 @@ Registry entry: `id: crewai` in
 pip install "prismor[crewai]"
 ```
 
-> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> Needs `prismor >= 1.14.2`. Until that version is on PyPI, the same one-liner
 > works from source: `pip install "prismor[crewai] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard tools (easy path)

--- a/docs/frameworks-langchain.md
+++ b/docs/frameworks-langchain.md
@@ -11,7 +11,7 @@ Registry entry: `id: langchain` in
 pip install "prismor[langchain]"
 ```
 
-> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> Needs `prismor >= 1.14.2`. Until that version is on PyPI, the same one-liner
 > works from source: `pip install "prismor[langchain] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard tools (easy path)

--- a/docs/frameworks-openai-agents.md
+++ b/docs/frameworks-openai-agents.md
@@ -18,7 +18,7 @@ The OpenAI Agents SDK adapter ships from
 pip install "prismor[openai-agents]"
 ```
 
-> Needs `prismor >= 1.14.1`. Until that version is on PyPI, the same one-liner
+> Needs `prismor >= 1.14.2`. Until that version is on PyPI, the same one-liner
 > works from source: `pip install "prismor[openai-agents] @ git+https://github.com/PrismorSec/prismor.git@main"`.
 
 ## Guard an agent (easy path)

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -14,7 +14,7 @@ on your existing agent or controller object, with no changes to your tool logic.
 | browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
 | Vercel AI SDK | TypeScript | `prismor-warden-vercel` (npm, from source until published) | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
 
-> The Python adapters ship inside the `prismor` package (needs `>= 1.14.1`) —
+> The Python adapters ship inside the `prismor` package (needs `>= 1.14.2`) —
 > the extra just pulls the framework itself. `prismor[frameworks]` installs all
 > four. The npm package publishes separately.
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Warden-Subject` header |

--- a/packaging/immunity-agent-shim/immunity_agent/__init__.py
+++ b/packaging/immunity-agent-shim/immunity_agent/__init__.py
@@ -12,4 +12,4 @@ then use the ``prismor`` command. See https://prismor.dev for details.
 """
 
 __all__ = ["__version__"]
-__version__ = "1.14.1"
+__version__ = "1.14.2"

--- a/packaging/immunity-agent-shim/pyproject.toml
+++ b/packaging/immunity-agent-shim/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # `warden/__init__.py` on every release.
 [project]
 name = "immunity-agent"
-version = "1.14.1"
+version = "1.14.2"
 description = "Deprecated — renamed to 'prismor'. Installs prismor for you. Run: pip install prismor"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "prismor>=1.14.1",
+    "prismor>=1.14.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ packages = [
 include = [
     "warden/",
     "supplychain/",
+    # The wheel is built FROM the sdist in CI — the bundled framework adapters
+    # (impl modules + namespace shims) must ride along or the published wheel
+    # ships shims that import nothing (the 1.14.1 bug).
+    "adapters/",
     "immunity-agent.pth",
     "advisories/immunity-feed.json",
     "advisories/immunity-feed.json.sig",

--- a/warden/__init__.py
+++ b/warden/__init__.py
@@ -1,6 +1,6 @@
 """Prismor Warden local session-security utility."""
 
-__version__ = "1.14.1"
+__version__ = "1.14.2"
 
 from warden.semantic_guard import SemanticGuard, SemanticRisk
 from warden.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
The 1.14.1 wheel published broken: CI builds wheel-from-sdist, and `adapters/` wasn't in the sdist include list — so the wheel had the `prismor.warden.<fw>` shims (hatchling auto-includes force-include sources in sdists) but not the `prismor_warden_*` impl modules they import. `pip install "prismor[langchain]"` from PyPI → ModuleNotFoundError.

Fix: add `adapters/` to sdist includes; bump 1.14.2; docs min-version notes updated. Verified with the exact CI build path (`python -m build` sdist→wheel): all four impl modules + shims present in the wheel.