### PR TITLE
npm: final name prismor-warden

### DIFF
--- a/.github/workflows/release-adapters.yml
+++ b/.github/workflows/release-adapters.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Build and publish @prismorsec/prismor
+      - name: Build and publish prismor-warden
         if: env.NPM_TOKEN != ''
         working-directory: adapters/vercel-ai
         run: |

--- a/adapters/LICENSE
+++ b/adapters/LICENSE
@@ -4,7 +4,7 @@ Copyright (c) 2026 Prismor
 
 The framework adapters in this directory (prismor-warden-langchain,
 prismor-warden-crewai, prismor-warden-openai, prismor-warden-browser-use,
-and the npm package `@prismorsec/prismor`) are licensed under MIT — the most permissive terms — so
+and the npm package `prismor-warden`) are licensed under MIT — the most permissive terms — so
 the ecosystem can integrate and vendor them with zero friction. The Warden
 runtime they call into is licensed separately at the repository root.
 

--- a/adapters/vercel-ai/README.md
+++ b/adapters/vercel-ai/README.md
@@ -1,4 +1,4 @@
-# @prismorsec/prismor
+# prismor-warden
 
 Prismor Warden adapter for the [Vercel AI SDK](https://sdk.vercel.ai).
 
@@ -17,7 +17,7 @@ immunity eval-server --port 7071 --workspace /path/to/project
 ## Install
 
 ```bash
-npm install @prismorsec/prismor
+npm install prismor-warden
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ npm install @prismorsec/prismor
 import { generateText, tool } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
-import { wardenTools } from "@prismorsec/prismor";
+import { wardenTools } from "prismor-warden";
 
 const run_shell = tool({
   description: "Run a shell command",
@@ -49,7 +49,7 @@ const result = await generateText({
 A blocked call throws `WardenBlocked`. In a Next.js API route:
 
 ```typescript
-import { WardenBlocked } from "@prismorsec/prismor";
+import { WardenBlocked } from "prismor-warden";
 
 try {
   const result = await generateText({ model, tools, prompt });

--- a/adapters/vercel-ai/package-lock.json
+++ b/adapters/vercel-ai/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "prismor",
+  "name": "prismor-warden",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prismor",
+      "name": "prismor-warden",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/adapters/vercel-ai/package.json
+++ b/adapters/vercel-ai/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prismorsec/prismor",
+  "name": "prismor-warden",
   "version": "0.1.0",
   "description": "Prismor Warden for JS/TS agents \u2014 policy-controlled tool calls for the Vercel AI SDK via the Prismor eval-server",
   "main": "dist/index.js",

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -12,11 +12,11 @@ on your existing agent or controller object, with no changes to your tool logic.
 | LangChain / LangGraph | Python | `pip install "prismor[langchain]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | CrewAI | Python | `pip install "prismor[crewai]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
-| Vercel AI SDK | TypeScript | `npm install @prismorsec/prismor` | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
+| Vercel AI SDK | TypeScript | `npm install prismor-warden` | `wardenTools(tools, opts)` | `{ subject: "user:alice" }` |
 
 > The Python adapters ship inside the `prismor` package (needs `>= 1.14.2`) —
 > the extra just pulls the framework itself. `prismor[frameworks]` installs all
-> four. On npm it is `@prismorsec/prismor` (the registry blocks the bare name as too similar to `prisma`).
+> four. On npm it is `prismor-warden` (the registry blocks bare `prismor` as too similar to `prisma`).
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Warden-Subject` header |
 
 The Python multi-tenant pattern: guard once at startup with no bound subject,
@@ -80,7 +80,7 @@ Validated live on an Ubuntu EC2 instance with real OpenAI function calls:
 
 | Language | Adapter size | Dependencies |
 |---|---|---|
-| TypeScript (Vercel AI SDK) | ~80 lines | `npm install @prismorsec/prismor` |
+| TypeScript (Vercel AI SDK) | ~80 lines | `npm install prismor-warden` |
 | Node.js (raw) | ~25 lines | built-in `fetch` |
 | Ruby | ~20 lines | stdlib `Net::HTTP` |
 | Java 21 | ~25 lines | stdlib `java.net.http` |

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -38,7 +38,7 @@ The server exposes:
 ## Install
 
 ```bash
-npm install @prismorsec/prismor
+npm install prismor-warden
 ```
 
 ## Quick start
@@ -47,7 +47,7 @@ npm install @prismorsec/prismor
 import { generateText, tool } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
-import { wardenTools } from "@prismorsec/prismor";
+import { wardenTools } from "prismor-warden";
 
 const run_shell = tool({
   description: "Execute a shell command",
@@ -75,7 +75,7 @@ const result = await generateText({ model: openai("gpt-4o-mini"), tools, prompt 
 A denied call in enforce mode throws `WardenBlocked`:
 
 ```typescript
-import { WardenBlocked, wardenTools } from "@prismorsec/prismor";
+import { WardenBlocked, wardenTools } from "prismor-warden";
 
 // In a Next.js API route:
 export async function POST(req: Request) {

--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -104,7 +104,7 @@ with use_subject("user:alice"):
 ### Vercel AI SDK / any language (HTTP)
 Run the sidecar: `prismor eval-server --port 7071 --workspace .`
 ```ts
-import { wardenTools } from "@prismorsec/prismor";
+import { wardenTools } from "prismor-warden";
 const tools = wardenTools({ run_shell, search_web }, { subject: `user:${userId}` });
 await generateText({ model, tools, prompt });
 ```


### PR DESCRIPTION
`npm install prismor-warden` — reads as the product (Prismor Warden), unscoped, and the registry accepts it. `@prismorsec/prismor@0.1.0` is deprecated with a rename pointer (automation tokens can't unpublish — delete it from the npm website if you want it gone entirely). All docs/workflow/README references updated.