### PR TITLE
fix(cloak): scrub secrets from all Bash output + guard Read of secret files

### DIFF
--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -1,0 +1,194 @@
+"""Tests for the cloaking output-scrub layer.
+
+Covers the leak path where a secret enters context without ever passing
+through an ``@@SECRET@@`` placeholder:
+
+  A. scrub-stream.sh — masks registered secret values on a stdin stream.
+  B. decloak.sh      — wraps *every* Bash command so its output is scrubbed,
+                       not only commands that reference a placeholder; still
+                       substitutes placeholders and preserves exit codes.
+  C. read-guard.sh   — denies a Read of a file that holds a registered secret.
+
+Each test runs against an isolated $PRISMOR_HOME so the developer's real vault
+is never touched. Run:  python3 tests/test_cloak_output_scrub.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+_HOME = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+_SECRETS = _HOME / "secrets"
+_SECRETS.mkdir(parents=True)
+os.environ["PRISMOR_HOME"] = str(_HOME)
+os.environ["PRISMOR_SECRETS_DIR"] = str(_SECRETS)
+
+_HOOKS = _REPO / "warden" / "cloaking" / "hooks"
+_DECLOAK = _HOOKS / "decloak.sh"
+_SCRUB = _HOOKS / "scrub-stream.sh"
+_READ_GUARD = _HOOKS / "read-guard.sh"
+
+# A high-entropy canary registered as a secret named CANARY.
+_CANARY = "sk-live-CANARY-0123456789abcdef0123456789abcdef"
+(_SECRETS / "CANARY").write_text(_CANARY)
+_PLACEHOLDER = "@@SECRET:CANARY@@"
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if ok:
+        _passed += 1
+        print(f"  PASS  {name}")
+    else:
+        _failed += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def run_hook(script: Path, payload: dict) -> dict | None:
+    proc = subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+def run_scrub(stdin_text: str) -> str:
+    proc = subprocess.run(
+        ["bash", str(_SCRUB)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    return proc.stdout
+
+
+def bash_payload(command: str) -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "session_id": "test",
+    }
+
+
+def execute_wrapped(command: str) -> tuple[str, int]:
+    """Run a command through decloak's wrapper and return (output, exit_code),
+    exactly as Claude Code would after applying updatedInput."""
+    res = run_hook(_DECLOAK, bash_payload(command))
+    wrapped = res["hookSpecificOutput"]["updatedInput"]["command"] if res else command
+    proc = subprocess.run(["bash", "-c", wrapped], capture_output=True, text=True, env=os.environ)
+    return proc.stdout, proc.returncode
+
+
+# ── A. scrub-stream.sh ────────────────────────────────────────────────────
+def test_scrub_masks_secret():
+    out = run_scrub(f"the key is {_CANARY} ok\n")
+    check("scrub masks a registered secret value",
+          _CANARY not in out and _PLACEHOLDER in out, out.strip())
+
+
+def test_scrub_passthrough_no_secret():
+    out = run_scrub("nothing sensitive here\n")
+    check("scrub leaves non-secret text unchanged", out == "nothing sensitive here\n", out)
+
+
+# ── B. decloak.sh output scrubbing (no placeholder) ───────────────────────
+def test_grep_output_scrubbed():
+    # Model reads the secret out of a file via grep — never uses a placeholder.
+    env_file = _HOME / "app.env"
+    env_file.write_text(f"CANARY_API_KEY={_CANARY}\n")
+    out, _ = execute_wrapped(f"grep CANARY {env_file}")
+    check("grep output is scrubbed (no placeholder used)",
+          _CANARY not in out and _PLACEHOLDER in out, out.strip())
+
+
+def test_source_echo_scrubbed():
+    env_file = _HOME / "creds.env"
+    env_file.write_text(f"CANARY_API_KEY={_CANARY}\n")
+    out, _ = execute_wrapped(f'set -a; . {env_file}; set +a; echo "$CANARY_API_KEY"')
+    check("sourced env var echo is scrubbed",
+          _CANARY not in out and _PLACEHOLDER in out, out.strip())
+
+
+def test_no_secret_in_wrapped_command():
+    # The wrapped command string must never contain the raw secret value —
+    # it would otherwise land in the transcript via tool_input.command.
+    env_file = _HOME / "app2.env"
+    env_file.write_text(f"K={_CANARY}\n")
+    res = run_hook(_DECLOAK, bash_payload(f"cat {env_file}"))
+    wrapped = res["hookSpecificOutput"]["updatedInput"]["command"]
+    check("wrapped command contains no raw secret", _CANARY not in wrapped, wrapped)
+
+
+def test_exit_code_preserved():
+    _, code_true = execute_wrapped("true")
+    _, code_false = execute_wrapped("bash -c 'exit 7'")
+    check("exit code preserved through the scrub pipe", code_true == 0 and code_false == 7,
+          f"true={code_true} false={code_false}")
+
+
+# ── B'. decloak.sh placeholder substitution still works ───────────────────
+def test_placeholder_substituted_and_output_scrubbed():
+    out, _ = execute_wrapped(f'echo "using {_PLACEHOLDER}"')
+    check("placeholder use runs with real value but output is re-masked",
+          _CANARY not in out and _PLACEHOLDER in out, out.strip())
+
+
+def test_unregistered_placeholder_denied():
+    res = run_hook(_DECLOAK, bash_payload("echo @@SECRET:NOPE@@"))
+    dec = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+    check("unknown placeholder is denied (fail closed)", dec == "deny", str(res))
+
+
+# ── C. read-guard.sh ──────────────────────────────────────────────────────
+def read_payload(fp: str) -> dict:
+    return {"hook_event_name": "PreToolUse", "tool_name": "Read",
+            "tool_input": {"file_path": fp}, "session_id": "test"}
+
+
+def test_read_of_secret_file_denied():
+    secret_file = _HOME / "prod.env"
+    secret_file.write_text(f"CANARY_API_KEY={_CANARY}\n")
+    res = run_hook(_READ_GUARD, read_payload(str(secret_file)))
+    dec = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+    check("Read of a secret-bearing file is denied", dec == "deny", str(res))
+
+
+def test_read_of_clean_file_allowed():
+    clean = _HOME / "readme.txt"
+    clean.write_text("no secrets here\n")
+    res = run_hook(_READ_GUARD, read_payload(str(clean)))
+    check("Read of a clean file is allowed (no-op)", res is None, str(res))
+
+
+def main() -> int:
+    for fn in [
+        test_scrub_masks_secret, test_scrub_passthrough_no_secret,
+        test_grep_output_scrubbed, test_source_echo_scrubbed,
+        test_no_secret_in_wrapped_command, test_exit_code_preserved,
+        test_placeholder_substituted_and_output_scrubbed,
+        test_unregistered_placeholder_denied,
+        test_read_of_secret_file_denied, test_read_of_clean_file_allowed,
+    ]:
+        fn()
+    print(f"\n{_passed} passed, {_failed} failed")
+    return 1 if _failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1328,6 +1328,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     scope=args.scope,
                     enable_userprompt_guard=not args.no_userprompt_guard,
                     enable_secret_guard=not args.no_secret_guard,
+                    enable_read_guard=not args.no_read_guard,
                     enable_sweep_on_stop=args.sweep_on_stop,
                 )
                 print(f"Installed Claude Code cloaking hooks at {result['configPath']}")
@@ -2014,6 +2015,8 @@ def build_parser() -> argparse.ArgumentParser:
                            help="Skip the UserPromptSubmit soft-block hook (use a clipboard filter instead)")
     t_install.add_argument("--no-secret-guard", action="store_true",
                            help="Skip the PreToolUse detect-and-block hook for raw secrets in tool calls")
+    t_install.add_argument("--no-read-guard", action="store_true",
+                           help="Skip the PreToolUse hook that denies reading files containing a registered secret")
     t_install.add_argument("--sweep-on-stop", action="store_true",
                            help="Also wire a Stop-hook dry-run sweep for residue detection")
 

--- a/warden/cloaking/README.md
+++ b/warden/cloaking/README.md
@@ -17,7 +17,9 @@ prismor cloak add stripe_key    # value read from stdin, never argv
 From that point on, the model refers to the secret as `@@SECRET:stripe_key@@`. When the agent emits a tool call containing that placeholder, Warden's `PreToolUse` hook:
 
 1. Substitutes the placeholder with the real value in the command that is actually executed locally.
-2. Wraps the command so its captured stdout/stderr passes through a `sed` filter that scrubs the real value *back* to the placeholder before Claude Code records it.
+2. Wraps the command so its captured stdout/stderr passes through `scrub-stream.sh`, which masks the real value *back* to the placeholder before Claude Code records it.
+
+The wrap in step 2 is applied to **every** `Bash` command once any secret is registered — not only commands that referenced a placeholder. So a value a command reads out of a file (`grep KEY .env`, `source .env; echo $KEY`, `cat config`, an HTTP response body) is masked too, closing the leak path where a raw secret enters context without ever passing through a placeholder. The scrubber reads the vault itself at runtime, so no secret value is embedded in the wrapped command string.
 
 Result: the real secret is resident only inside the hook process and the local subprocess. The model, the JSONL transcript (`~/.claude/projects/<cwd>/*.jsonl`), and every upstream API request see only the placeholder.
 
@@ -52,7 +54,8 @@ This merges four hook entries into `.claude/settings.json` (preserving any Warde
 | Event | Matcher | Script | Purpose |
 |---|---|---|---|
 | `PreToolUse` | `Bash\|Write\|Edit\|MultiEdit\|mcp__.*` | `secret-guard.sh` | Detect raw secrets in tool input, vault + deny |
-| `PreToolUse` | `Bash` | `decloak.sh` | Substitute placeholders, wrap with `sed` |
+| `PreToolUse` | `Read` | `read-guard.sh` | Deny a Read of a file that holds a registered secret |
+| `PreToolUse` | `Bash` | `decloak.sh` | Substitute placeholders, wrap output through `scrub-stream.sh` |
 | `PostToolUse` | `mcp__.*` | `recloak-mcp.sh` | Scrub real values from MCP responses |
 | `UserPromptSubmit` | — | `userprompt-guard.sh` | Soft-block + auto-cloak pasted secrets |
 | `Stop` (opt) | — | `sweep-on-stop.sh` | Dry-run sweep for residue (off by default) |
@@ -184,7 +187,7 @@ Enumerated honestly so you know what to layer on top:
 1. **Hand-typed secrets shorter than ~16 chars.** No prefix, too short for entropy heuristics, indistinguishable from benign text.
 2. **Secrets generated mid-turn** (`openssl rand`, `aws iam create-access-key`, `ssh-keygen`). The `sed`-wrap scrubber only knows about values already in `$PRISMOR_SECRETS_DIR`, so a freshly minted value flows through the *generating* command's output unscrubbed. `secret-guard.sh` does catch it on the *next* tool call if the value matches a known pattern (e.g. a generated `AKIA…` reused in a later command) — but a value with no recognizable shape still slips through.
 3. **The secrets directory itself**, if committed, synced, or backed up without exclusion. Treat it as a single point of failure.
-4. **Built-in `Read` of secret-bearing files.** `PostToolUse` can only rewrite MCP tool output, not built-in Read. Add a `permissions.deny` rule under `Read(./secrets/**)` in your Claude settings to close this gap, and route secret access through the placeholder syntax instead.
+4. **Built-in `Read` of secret-bearing files.** `PostToolUse` can only rewrite MCP tool output, not built-in Read, so a Read cannot be scrubbed after the fact. `read-guard.sh` (a `PreToolUse:Read` hook, on by default) closes this by *denying* a Read whose target file contains a registered secret and directing the model to the `@@SECRET:name@@` placeholder instead. Disable with `prismor cloak install --no-read-guard` if a deny is too strict for your workflow.
 5. **Assistant-side narration.** If the model already saw a real value (through paste, Read, or a command that bypassed the wrapper), it can echo the value in prose. Hooks cannot filter assistant text. Use `/clear` immediately after any suspected leak.
 
 For residue that slips through despite all of the above, run:
@@ -224,7 +227,9 @@ warden/cloaking/
 ├── builtin_patterns.txt    # single source of truth for detection regexes
 ├── hooks/
 │   ├── _patterns.sh        # shared bash loader (sourced by the guards)
-│   ├── decloak.sh          # PreToolUse:Bash — placeholder substitution
+│   ├── decloak.sh          # PreToolUse:Bash — placeholder substitution + output scrub
+│   ├── scrub-stream.sh     # stdin filter — masks registered secrets in command output
+│   ├── read-guard.sh       # PreToolUse:Read — deny reads of secret-bearing files
 │   ├── secret-guard.sh     # PreToolUse — detect raw secrets, vault + deny
 │   ├── recloak-mcp.sh      # PostToolUse:mcp__.*
 │   ├── userprompt-guard.sh # UserPromptSubmit soft-block

--- a/warden/cloaking/hooks/decloak.sh
+++ b/warden/cloaking/hooks/decloak.sh
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
 # Prismor Warden — cloaking PreToolUse hook (Claude Code, Bash matcher).
 #
-# Substitutes `@@SECRET:name@@` placeholders in the model's bash command with
-# the real value from $PRISMOR_SECRETS_DIR/<name>, then wraps the command so
-# that its captured stdout/stderr is piped through `sed` to scrub the real
-# value back to the placeholder before Claude Code records it.
+# Two jobs, both aimed at keeping a real secret out of the model's context,
+# the JSONL transcript, and any upstream API request:
 #
-# Result: the real secret is resident only inside this hook's process and the
-# local bash subprocess — never in the model's context, the JSONL transcript,
-# or any API request to the upstream provider.
+#   1. DECLOAK — substitute each `@@SECRET:name@@` placeholder in the command
+#      with the real value from $PRISMOR_SECRETS_DIR/<name> so the command
+#      actually works when it runs locally.
 #
-# Stdin:  Claude Code PreToolUse JSON payload
-# Stdout: JSON with hookSpecificOutput.updatedInput (if substitution occurred)
-#         or hookSpecificOutput.permissionDecision=deny (if secret not found).
-#         Empty stdout = no-op (command contained no placeholder).
+#   2. SCRUB — wrap the command so its combined stdout/stderr is piped through
+#      `scrub-stream.sh`, which masks every registered secret value back to its
+#      placeholder before Claude Code records the output. This happens for
+#      EVERY Bash command, not only ones that used a placeholder — so a secret
+#      a command reads out of a file (`grep KEY .env`, `source .env; echo $KEY`,
+#      `cat config`, an HTTP response body, ...) is masked too. That closes the
+#      leak path where the raw value enters context without ever passing
+#      through an `@@SECRET@@` placeholder.
+#
+# The scrubber reads the vault itself at runtime, so no secret value is ever
+# embedded in the wrapped command string (which Claude Code records verbatim).
+#
+# Stdin:  Claude Code PreToolUse JSON payload.
+# Stdout: JSON with hookSpecificOutput.updatedInput (command rewritten), or
+#         permissionDecision=deny (a referenced secret is not registered).
+#         Empty stdout = no-op (no secrets registered and no placeholder).
 set -uo pipefail
 
-SECRETS_DIR="${PRISMOR_SECRETS_DIR:-$HOME/.prismor/secrets}"
+_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRETS_DIR="${PRISMOR_SECRETS_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/secrets}"
+SCRUBBER="$_HOOK_DIR/scrub-stream.sh"
 
-# Require jq — the rest of Warden already depends on Python, but hook scripts
-# are shell-only for speed. If jq is missing we fail closed with a clear msg.
+# Require jq — hook scripts are shell-only for speed. Fail closed if missing.
 if ! command -v jq >/dev/null 2>&1; then
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Prismor cloaking requires jq (brew install jq)"}}\n'
   exit 0
@@ -32,41 +43,48 @@ tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
 [[ -n "$cmd" ]] || exit 0
 
-# Enumerate unique placeholders in the command.
-placeholders="$(printf '%s' "$cmd" | grep -oE '@@SECRET:[a-zA-Z0-9_-]+@@' | sort -u || true)"
-[[ -n "$placeholders" ]] || exit 0
-
+# ── 1. Decloak: substitute any @@SECRET:name@@ placeholders ────────────────
 new_cmd="$cmd"
-sed_filter=""
-while IFS= read -r placeholder; do
-  [[ -z "$placeholder" ]] && continue
-  name="${placeholder#@@SECRET:}"
-  name="${name%@@}"
-  secret_file="$SECRETS_DIR/$name"
+placeholders="$(printf '%s' "$cmd" | grep -oE '@@SECRET:[a-zA-Z0-9_-]+@@' | sort -u || true)"
+if [[ -n "$placeholders" ]]; then
+  while IFS= read -r placeholder; do
+    [[ -z "$placeholder" ]] && continue
+    name="${placeholder#@@SECRET:}"
+    name="${name%@@}"
+    secret_file="$SECRETS_DIR/$name"
+    if [[ ! -f "$secret_file" ]]; then
+      # Fail closed: deny rather than leaving a dangling placeholder that would
+      # confuse the downstream command.
+      jq -n --arg reason "Prismor cloaking: secret '$name' not registered. Run: prismor cloak add $name" \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+      exit 0
+    fi
+    real="$(cat "$secret_file")"
+    new_cmd="${new_cmd//"$placeholder"/$real}"
+  done <<< "$placeholders"
+fi
 
-  if [[ ! -f "$secret_file" ]]; then
-    # Fail closed: deny the tool call rather than silently leaving the
-    # placeholder in, which would confuse downstream commands.
-    jq -n --arg reason "Prismor cloaking: secret '$name' not registered. Run: prismor cloak add $name" \
-      '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
-    exit 0
-  fi
+# ── 2. Decide whether to wrap the command for output scrubbing ──────────────
+# Scrub whenever there is at least one registered secret to protect, OR a
+# placeholder substitution injected a real value into the command. If the
+# vault is empty and no substitution happened, stay a no-op (preserves the
+# original behavior for users who have not registered any secret).
+have_secrets=0
+shopt -s nullglob
+for _f in "$SECRETS_DIR"/*; do
+  [[ -f "$_f" ]] && { have_secrets=1; break; }
+done
 
-  real="$(cat "$secret_file")"
-  # Substitute placeholder → real in the command string.
-  new_cmd="${new_cmd//"$placeholder"/$real}"
+if [[ "$have_secrets" -eq 0 && "$new_cmd" == "$cmd" ]]; then
+  exit 0
+fi
 
-  # Build the sed scrubber: real → placeholder. Escape sed metacharacters.
-  esc_real="$(printf '%s' "$real" | sed 's/[\/&|]/\\&/g')"
-  sed_filter+="s|$esc_real|$placeholder|g;"
-done <<< "$placeholders"
+# Wrap: run the command in a brace group, merge stderr into stdout, pipe
+# through the scrubber, and re-raise the command's own exit status (not sed's)
+# so callers that branch on exit codes still behave correctly. Only the
+# scrubber path and the secrets-dir path are embedded — never a secret value.
+wrapped="{ $new_cmd ; } 2>&1 | PRISMOR_SECRETS_DIR=$(printf '%q' "$SECRETS_DIR") $(printf '%q' "$SCRUBBER"); exit \${PIPESTATUS[0]}"
 
-# Wrap the command in a subshell whose combined stdout/stderr is scrubbed.
-# The model only ever sees the output of `sed`, never the raw output.
-wrapped="( $new_cmd ) 2>&1 | sed -E '$sed_filter'"
-
-# Preserve any other fields of tool_input (e.g., description) and overwrite
-# only .command.
 new_input="$(printf '%s' "$input" | jq --arg c "$wrapped" '.tool_input | .command = $c')"
 jq -n --argjson ni "$new_input" \
   '{hookSpecificOutput:{hookEventName:"PreToolUse",updatedInput:$ni}}'

--- a/warden/cloaking/hooks/read-guard.sh
+++ b/warden/cloaking/hooks/read-guard.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Prismor Warden — cloaking PreToolUse hook (Claude Code, Read matcher).
+#
+# The built-in Read tool has no post-hoc output-rewrite channel (unlike Bash,
+# whose output decloak.sh scrubs, and MCP tools, whose output recloak-mcp.sh
+# scrubs). So a secret read through the Read tool cannot be masked after the
+# fact — the only way to keep it out of context is to stop the read.
+#
+# This hook denies a Read whose target file contains a registered secret value,
+# and tells the model to reference the `@@SECRET:name@@` placeholder instead
+# (which decloak.sh will substitute at execution time). Files that hold no
+# registered secret are unaffected.
+#
+# Stdin:  Claude Code PreToolUse JSON payload (Read).
+# Stdout: JSON permissionDecision=deny (target holds a secret), else empty.
+set -uo pipefail
+
+SECRETS_DIR="${PRISMOR_SECRETS_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/secrets}"
+
+command -v jq >/dev/null 2>&1 || exit 0   # no jq → silent no-op; decloak fails loud
+
+input="$(cat)"
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[[ "$tool_name" == "Read" ]] || exit 0
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+[[ -n "$file_path" && -f "$file_path" ]] || exit 0
+[[ -d "$SECRETS_DIR" ]] || exit 0
+
+# Does the target file contain any registered secret value verbatim?
+shopt -s nullglob
+for secret_file in "$SECRETS_DIR"/*; do
+  [[ -f "$secret_file" ]] || continue
+  name="$(basename "$secret_file")"
+  real="$(cat "$secret_file")"
+  [[ ${#real} -ge 4 ]] || continue
+  if grep -qF -- "$real" "$file_path" 2>/dev/null; then
+    reason="Prismor cloaking: '$file_path' contains the registered secret '$name'. Reading it would place the raw value in context. Reference it as @@SECRET:${name}@@ in a Bash command instead — Warden substitutes the real value at execution time and scrubs it from the output."
+    jq -n --arg r "$reason" \
+      '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+    exit 0
+  fi
+done
+
+exit 0

--- a/warden/cloaking/hooks/scrub-stream.sh
+++ b/warden/cloaking/hooks/scrub-stream.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Prismor Warden — cloaking output scrubber (stdin filter).
+#
+# Reads every registered secret from $PRISMOR_SECRETS_DIR and rewrites any
+# occurrence of a real value on stdin to its `@@SECRET:name@@` placeholder,
+# streaming the result to stdout. Used by decloak.sh to sanitize the combined
+# stdout/stderr of *every* Bash command the model runs — so a secret that a
+# command reads out of a file (grep, cat, source+echo, an HTTP response body,
+# etc.) is masked before Claude Code records the output, even when the model
+# never referenced an `@@SECRET@@` placeholder.
+#
+# Why a separate script instead of an inline `sed` in the wrapped command:
+# the real secret values must NOT appear in the command string, or they would
+# land in `tool_input.command` (and thus the transcript). This helper reads
+# the vault itself at runtime, so only its path — never a secret — is embedded
+# in the command Claude Code records.
+#
+# Stdin:  arbitrary command output.
+# Stdout: same output with registered secret values replaced by placeholders.
+# On any error (missing vault, no jq/sed) it passes stdin through unchanged:
+# a scrub is best-effort defense-in-depth and must never swallow command
+# output the agent depends on.
+set -uo pipefail
+
+SECRETS_DIR="${PRISMOR_SECRETS_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/secrets}"
+
+# No vault, or no secrets registered → nothing to scrub, pass through.
+if [[ ! -d "$SECRETS_DIR" ]]; then
+  exec cat
+fi
+
+# Build a single sed program: real value → placeholder, for each secret.
+# Escape sed's `s|...|...|` delimiters and metacharacters in the real value.
+sed_filter=""
+shopt -s nullglob
+for secret_file in "$SECRETS_DIR"/*; do
+  [[ -f "$secret_file" ]] || continue
+  name="$(basename "$secret_file")"
+  real="$(cat "$secret_file")"
+  # Skip empty or trivially short values: masking a 1-2 char string would
+  # corrupt ordinary output far more than it protects anything.
+  [[ ${#real} -ge 4 ]] || continue
+  esc_real="$(printf '%s' "$real" | sed 's/[\/&|]/\\&/g')"
+  sed_filter+="s|$esc_real|@@SECRET:${name}@@|g;"
+done
+
+if [[ -z "$sed_filter" ]]; then
+  exec cat
+fi
+
+# `sed -E` over the stream. If sed is somehow unavailable, fall back to cat.
+if command -v sed >/dev/null 2>&1; then
+  exec sed -E "$sed_filter"
+else
+  exec cat
+fi

--- a/warden/cloaking/installer.py
+++ b/warden/cloaking/installer.py
@@ -24,6 +24,7 @@ _HOOKS_SUBDIR = Path(__file__).resolve().parent / "hooks"
 
 _DECLOAK = _HOOKS_SUBDIR / "decloak.sh"
 _SECRET_GUARD = _HOOKS_SUBDIR / "secret-guard.sh"
+_READ_GUARD = _HOOKS_SUBDIR / "read-guard.sh"
 _RECLOAK_MCP = _HOOKS_SUBDIR / "recloak-mcp.sh"
 _USERPROMPT_GUARD = _HOOKS_SUBDIR / "userprompt-guard.sh"
 _SWEEP_ON_STOP = _HOOKS_SUBDIR / "sweep-on-stop.sh"
@@ -109,6 +110,7 @@ def install(
     scope: str = "project",
     enable_userprompt_guard: bool = True,
     enable_secret_guard: bool = True,
+    enable_read_guard: bool = True,
     enable_sweep_on_stop: bool = False,
 ) -> Dict[str, Any]:
     """Install the cloaking hooks into ``settings.json``.
@@ -122,6 +124,10 @@ def install(
         enable_secret_guard: Wire the PreToolUse detect-and-block hook that
             catches raw secrets the model emits directly (not via a
             placeholder) and denies the call after vaulting the value.
+        enable_read_guard: Wire the PreToolUse hook that denies a Read of a
+            file containing a registered secret. The built-in Read tool has no
+            output-rewrite channel, so the read is blocked rather than scrubbed;
+            the model is told to use the ``@@SECRET:name@@`` placeholder instead.
         enable_sweep_on_stop: Wire the Stop-hook dry-run sweep. Off by
             default because it runs ``prismor sweep`` against ``~/.claude``
             on every session end, which is noisy for quick sessions.
@@ -155,12 +161,23 @@ def install(
         )
         installed.append(f"PreToolUse:{_SECRET_GUARD_MATCHER} (secret-guard)")
 
-    # PreToolUse: decloak on Bash matcher.
+    # PreToolUse: deny reads of files that hold a registered secret. Built-in
+    # Read has no post-hoc output scrub, so containment means blocking the read.
+    if enable_read_guard:
+        hooks["PreToolUse"] = _merge_claude_entries(
+            hooks.get("PreToolUse", []),
+            {"matcher": "Read", "hooks": [_hook_entry(_READ_GUARD)]},
+        )
+        installed.append("PreToolUse:Read (read-guard)")
+
+    # PreToolUse: decloak on Bash matcher. Substitutes @@SECRET@@ placeholders
+    # and wraps every Bash command so its output is scrubbed of registered
+    # secret values (not only placeholder-mediated ones).
     hooks["PreToolUse"] = _merge_claude_entries(
         hooks.get("PreToolUse", []),
         {"matcher": "Bash", "hooks": [_hook_entry(_DECLOAK)]},
     )
-    installed.append("PreToolUse:Bash (decloak)")
+    installed.append("PreToolUse:Bash (decloak + output scrub)")
 
     # PostToolUse: recloak MCP responses.
     hooks["PostToolUse"] = _merge_claude_entries(


### PR DESCRIPTION
## Problem

Cloaking's output scrub only engaged for `@@SECRET@@`-**placeholder** flows. `decloak.sh` returned early (`exit 0`) unless the model's command literally contained a placeholder, so a secret that a command reads **out of a file at runtime** reached model context completely unscrubbed:

- `grep KEY .env` → matched line with the raw value
- `source .env; echo $KEY` → raw value on stdout
- `curl ... ` whose response body echoes the secret
- the built-in **Read** tool → no scrub path at all

The raw value then lands in the model context, the JSONL transcript, and every upstream API request — which is exactly what cloaking is meant to prevent. This surfaced as file-read leaks in a live end-to-end leak test (secrets pulled in via `grep`/`source`/Read leaked under Warden at roughly the unprotected rate).

## Fix

**Make the Bash output scrub unconditional, and close the Read path.**

- **`decloak.sh`** now wraps *every* `Bash` command (once any secret is registered), piping its combined stdout/stderr through the scrubber — not only commands that used a placeholder. Placeholder substitution and the fail-closed deny for unregistered placeholders are unchanged. Exit codes are preserved via `PIPESTATUS` so callers that branch on status still work.
- **`scrub-stream.sh`** (new) is a stdin filter that reads the vault at runtime and masks each registered secret value back to its placeholder. Crucially it reads the vault *itself*, so **no secret value is ever embedded in the wrapped command string** (which Claude Code records verbatim in `tool_input.command`). Short (<4 char) values are skipped to avoid corrupting ordinary output; it fails open (pass-through) so it can never swallow output the agent depends on.
- **`read-guard.sh`** (new, `PreToolUse:Read`, on by default). Built-in Read has no post-hoc output-rewrite channel, so containment means *blocking* the read: a Read of a file that contains a registered secret is denied with a message pointing the model at the `@@SECRET:name@@` placeholder. Opt out with `prismor cloak install --no-read-guard`.
- Installer + CLI wiring (`--no-read-guard`), README, and file-tree updates.

## Tests

`tests/test_cloak_output_scrub.py` — 10 cases, all green, plus the existing `test_cloak_secret_guard.py` (23) still passes:

- scrub masks a registered value / passes clean text through
- `grep` and `source; echo` output scrubbed **with no placeholder used**
- wrapped command string contains **no** raw secret
- exit code preserved through the scrub pipe
- placeholder still substitutes-and-re-masks; unregistered placeholder denied
- Read of a secret-bearing file denied; Read of a clean file allowed

## Live verification

Re-ran the previously-leaking `grep KEY secrets.env` vector through the real `claude` CLI with these hooks in an isolated config. Before: the raw canary reached context and the model's reply. **After: the model sees only `CANARY_API_KEY=@@SECRET:CANARY_API_KEY@@`** — the grep output was masked by the wrapper.

## Out of scope (follow-ups)

- **Egress rule** for a secret *file* streamed to the network by reference (`curl --data-binary @secrets.env`): the bytes leave the box before any content match applies — needs a path-based sink rule, not output scrubbing.
- **On-disk copies** (`cp secrets.env config.txt`): the copy is a filesystem op with no secret in the command text.
- Extending the scrub/guard to the built-in **Grep** tool.