### PR TITLE
fix(policy): flag world-writable chmod beyond literal 777

### DIFF
--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -44,6 +44,20 @@ class TestDestructiveCommandPattern(unittest.TestCase):
     def test_chmod_777(self):
         self.assertIsNotNone(DESTRUCTIVE_COMMAND_PATTERN.search("chmod 777 /var/www"))
 
+    def test_chmod_world_writable_numeric(self):
+        for cmd in ("chmod -R 777 .", "chmod 0777 x", "chmod 1777 /tmp", "chmod 666 f"):
+            self.assertIsNotNone(DESTRUCTIVE_COMMAND_PATTERN.search(cmd), cmd)
+
+    def test_chmod_world_writable_symbolic(self):
+        for cmd in ("chmod a+rwx ./shared", "chmod o+w file",
+                    "chmod a+w file", "chmod ugo+rwx dir", "chmod g+w,o+w x"):
+            self.assertIsNotNone(DESTRUCTIVE_COMMAND_PATTERN.search(cmd), cmd)
+
+    def test_chmod_safe_modes_not_flagged(self):
+        for cmd in ("chmod 644 f", "chmod 755 script.sh", "chmod +x run.sh",
+                    "chmod 600 key", "chmod 750 dir", "chmod g+w shared", "chmod u+x bin"):
+            self.assertIsNone(DESTRUCTIVE_COMMAND_PATTERN.search(cmd), cmd)
+
     def test_mkfs(self):
         self.assertIsNotNone(DESTRUCTIVE_COMMAND_PATTERN.search("mkfs /dev/sda1"))
 

--- a/warden/policies.py
+++ b/warden/policies.py
@@ -61,7 +61,11 @@ DESTRUCTIVE_COMMAND_PATTERN = re.compile(
     r"(?:"
     r"rm\s+(?:-[a-zA-Z]*f[a-zA-Z]*\s+|(?:-[a-zA-Z]+\s+)*)(?:/\s*$|/\s+)"
     r"|sudo\s+rm\b"
-    r"|chmod\s+777\b"
+    # World-writable chmod — numeric modes whose "other" digit grants write
+    # (…2/3/6/7, e.g. 777, 666, 0777, 1777), plus symbolic grants of write to
+    # other/all (o+w, a+w, a+rwx). Group-only and read-only modes are ignored.
+    r"|chmod\s+(?:-[A-Za-z]+\s+)*[0-7]?[0-7][0-7][2367]\b"
+    r"|chmod\s+(?:-[A-Za-z]+\s+)*[ugoa,+=rwxXst-]*[oa][+=][a-zX]*w"
     r"|chown\s+-R\b"
     r"|mkfs\b"
     r"|dd\s+if=.*of=/dev/"


### PR DESCRIPTION
## Problem

`DESTRUCTIVE_COMMAND_PATTERN` matched only the literal string `chmod 777`. A live benchmark of the enforce hook showed a model making a directory world-writable through two variants the rule never saw:

- **Other numeric world-writable modes** — `chmod 666`, `chmod 0777`, `chmod 1777`
- **Symbolic modes** — `chmod a+rwx`, `chmod o+w` (the form a model naturally reaches for, and the one it fell back to after the `777` form was blocked)

All of these grant write to *other*/*all* and are as dangerous as `777`, but passed straight through.

## Fix

Broaden the rule to two clauses:

```
chmod (…flags…) [0-7]?[0-7][0-7][2367]\b        # numeric: other digit is writable
chmod (…flags…) …[oa][+=]…w                     # symbolic: o+w / a+w / a+rwx
```

- Catches `777`, `666`, `0777`, `1777`, `chmod -R 777`, `a+rwx`, `o+w`, `a+w`, `ugo+rwx`, `g+w,o+w`.
- **Leaves safe modes alone:** `chmod 644`, `755`, `+x`, `600`, `750`, `640`, and group-only `chmod g+w` are not flagged — so ordinary permission fixes don't trip the rule.

## Tests

Added to `TestDestructiveCommandPattern`: numeric world-writable, symbolic world-writable, and a safe-modes-not-flagged case. Full policy suite green — **137 passed**.

## Context

This closes one of the two coverage gaps found in the policy-enforcement benchmark (the other — indirect prompt injection not blocking in enforce — is a larger change and left as a separate item).