### PR TITLE
ci: gate cloaking + policy tests as a security regression suite

### DIFF
--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -1,0 +1,25 @@
+name: Security regression
+
+# Runs the cloaking + policy test suite on every push and PR, so a change to a
+# hook script or a policy rule cannot silently reopen a scrubbed/blocked path.
+# This is the CI gate behind the secret-cloaking and policy-enforcement layers.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install jq (cloaking hooks are shell)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+      - name: Install pytest
+        run: python3 -m pip install --quiet pytest
+      - name: Run security regression suite
+        run: bash scripts/run_security_tests.sh

--- a/scripts/run_security_tests.sh
+++ b/scripts/run_security_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Prismor Warden — security regression suite.
+#
+# Single entrypoint for the cloaking + policy tests, run identically in CI
+# (.github/workflows/security-regression.yml) and locally. These lock the
+# adversarial scenarios the live benchmark exercises — secret scrubbing, the
+# Read / @file guards, and the destructive/remote-exec/exfil/injection policy
+# rules — so a change to a hook or a rule can never silently regress them.
+#
+# Usage:  bash scripts/run_security_tests.sh
+# Exits non-zero on the first failure. Requires jq (the cloak hooks are shell).
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq is required (the cloaking hooks are shell-only)." >&2
+  exit 1
+fi
+
+fail=0
+
+# ── Cloaking hook regression (script-style tests, exit 1 on failure) ───────
+# Each file guards its own $PRISMOR_HOME, so they are safe to run anywhere.
+for t in \
+  tests/test_cloak_output_scrub.py \
+  tests/test_cloak_atfile_guard.py \
+  ; do
+  if [[ -f "$t" ]]; then
+    echo "── $t ──"
+    python3 "$t" || fail=1
+  fi
+done
+
+# ── Policy + detect-and-block regression (pytest) ──────────────────────────
+pytest_targets=()
+for t in \
+  tests/test_policies.py \
+  tests/test_cloak_secret_guard.py \
+  ; do
+  [[ -f "$t" ]] && pytest_targets+=("$t")
+done
+
+if [[ ${#pytest_targets[@]} -gt 0 ]]; then
+  echo "── pytest: ${pytest_targets[*]} ──"
+  python3 -m pytest "${pytest_targets[@]}" -q || fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo ""
+  echo "SECURITY REGRESSION FAILED — a cloaking/policy guarantee regressed." >&2
+  exit 1
+fi
+echo ""
+echo "All security regression checks passed."


### PR DESCRIPTION
## Why

The secret-cloaking hooks and the policy rules have tests, but **nothing runs them in CI**. `oss-guard.yml` only runs the open-core leak guard; the cloaking/policy tests run only when someone remembers to. So a change to a hook script or a rule pattern can silently reopen a scrubbed or blocked path — which is precisely the failure mode the live benchmark keeps surfacing. This wires the gate.

## What

- **`scripts/run_security_tests.sh`** — one entrypoint (used by CI and locally) that runs:
  - the cloaking hook regression: output scrub, Read guard, and the `@file` guard when present (`test_cloak_output_scrub.py`, `test_cloak_atfile_guard.py`)
  - the policy + detect-and-block suite (`pytest test_policies.py test_cloak_secret_guard.py`)
  - Exits non-zero on the first failure; **gracefully skips test files not yet on the branch**, so it composes cleanly with in-flight PRs and picks up new scenario locks as they merge.
- **`.github/workflows/security-regression.yml`** — runs that suite on every push and PR (installs `jq`, since the hooks are shell-only), matching the repo's existing workflow conventions.

## Verified

Locally on a clean checkout: **10** cloak-scrub checks + **134** policy/secret-guard tests pass. Once the `@file` guard (#115) and world-writable `chmod` (#116) PRs merge, their tests are gated automatically with no further wiring.

## Context

This is the highest-leverage follow-up from the benchmark work: the individual fixes (#114 merged, #115, #116) each ship their own tests — this makes sure they, and every future hook/rule change, are actually enforced on every commit.