### PR TITLE
fix: make learning engine's own doc example minable, fix invalid policy write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - `docs/cli-reference.md` no longer lists `workspace show` / `exempt status` as subcommands — neither exists (`workspace` with no argument shows status; `exempt` only has `request`). (#132)
 - `docs/frameworks-crewai.md`'s examples imported `from crewai_tools import tool` — a separate package not installed by `pip install "prismor[crewai]"` and not mentioned anywhere in the doc. Changed to `from crewai.tools import tool`, which ships built-in with current `crewai` and requires no extra install. (#137)
 - `prismor scan` mislabeled the `agent` for any config whose full path happened to contain another agent's name as a substring (e.g. a workspace path containing "claude" anywhere caused a real Cursor/Windsurf/etc. config's findings to be reported under `agent: "claude"`) — `parse_config()` re-guessed the agent via path substring matching instead of using the value `discover_configs()` already knew. (#143)
+- `docs/learning.md`'s own worked example (a recurring `psql ... prod` command) could never actually be mined — no database client was in the learning engine's `_SENSITIVE_COMMANDS` allowlist. Added `psql`/`mysql`/`mysqlsh`/`redis-cli`/`mongosh`/`sqlite3`. (#146)
+- `prismor learn --apply` wrote `.prismor/policy.yaml` without the required `version` field when no policy file existed yet, so the docs' own next step (`prismor policy validate`) failed immediately with "Missing required field: version" — even though the learned rule worked correctly at runtime. (#147)
 
 ### Added
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1684,6 +1684,11 @@ def main(argv: Optional[List[str]] = None) -> None:
             policy: Dict[str, Any] = {}
             if policy_path.exists():
                 policy = yaml.safe_load(policy_path.read_text()) or {}
+            # A freshly-created file needs the same required `version` field
+            # `prismor policy init` stamps — otherwise the very next step the
+            # docs recommend (`prismor policy validate`) fails immediately.
+            # See PrismorSec/prismor#147.
+            policy.setdefault("version", "1.0")
             rules_list = policy.setdefault("rules", [])
             rules_list.append(rule)
             policy_path.parent.mkdir(parents=True, exist_ok=True)

--- a/prismor/runtime/learning.py
+++ b/prismor/runtime/learning.py
@@ -601,6 +601,11 @@ _SENSITIVE_COMMANDS = {
     "docker", "podman", "kubectl",
     "pip", "pip3", "npm", "yarn", "gem", "cargo",
     "eval", "exec", "source",
+    # Database clients — direct prod-DB access is exactly the kind of
+    # recurring, un-ruled pattern the learning engine is meant to surface
+    # (this is docs/learning.md's own worked example, which previously
+    # could never actually fire). See PrismorSec/prismor#146.
+    "psql", "mysql", "mysqlsh", "redis-cli", "mongosh", "sqlite3",
 }
 
 

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,0 +1,116 @@
+"""Tests for the adaptive-learning engine (prismor/runtime/learning.py).
+
+No test coverage existed for this module at all before PrismorSec/prismor#146
+and #147 — both were found by driving the real CLI end to end (mine, apply,
+validate) rather than unit-testing individual functions in isolation.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.cli import analyze_events
+from prismor.runtime.learning import accept_candidate_rule, mine_patterns, save_candidate_rules
+from prismor.runtime.policy_engine import validate_policy
+from prismor.runtime.store import save_session_snapshot
+
+
+class TestMinePatterns(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _record_sessions(self, command: str, count: int):
+        for i in range(count):
+            events = [{"type": "shell", "command": command, "ts": f"2026-01-{i + 1:02d}T00:00:00Z"}]
+            analysis = analyze_events(events, repo_root=self.workspace, workspace=self.workspace)
+            save_session_snapshot(
+                workspace=self.workspace, session_id=f"s-{i}", agent="claude",
+                source="ingest", repo_url=None, events=events, analysis=analysis,
+            )
+
+    def test_recurring_database_client_command_is_minable(self):
+        # Regression for #146: docs/learning.md's own worked example
+        # ("psql ... prod") could never fire because no database client was
+        # in _SENSITIVE_COMMANDS.
+        self._record_sessions("psql -h prod-db.internal -U admin mydb", 5)
+        candidates = mine_patterns(self.workspace, min_support=3)
+        self.assertTrue(candidates, "psql should now be minable")
+        self.assertEqual(candidates[0]["rule"]["id"], "learned-psql-0")
+        self.assertEqual(candidates[0]["support_count"], 5)
+
+    def test_below_min_support_is_not_proposed(self):
+        self._record_sessions("psql -h prod-db.internal -U admin mydb", 2)
+        candidates = mine_patterns(self.workspace, min_support=3)
+        self.assertEqual(candidates, [])
+
+    def test_unlisted_base_command_is_not_proposed(self):
+        self._record_sessions("banana-cli --do-something-recurring", 5)
+        candidates = mine_patterns(self.workspace, min_support=3)
+        self.assertEqual(candidates, [])
+
+
+class TestAcceptCandidateWritesValidPolicy(unittest.TestCase):
+    """Regression for #147: learn --apply wrote .prismor/policy.yaml without
+    the required `version` field when no policy file existed yet, so the
+    docs' own next step (`prismor policy validate`) failed immediately.
+
+    accept_candidate_rule() itself only flips DB status and returns the rule
+    dict — the actual file write lives in cli.py's `learn --apply` handler —
+    so this test drives that handler's logic directly the same way the CLI
+    does, rather than re-testing accept_candidate_rule() alone.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_policy_from_candidate(self, rule):
+        import yaml
+        policy_path = self.workspace / ".prismor" / "policy.yaml"
+        policy = {}
+        if policy_path.exists():
+            policy = yaml.safe_load(policy_path.read_text()) or {}
+        policy.setdefault("version", "1.0")
+        policy.setdefault("rules", []).append(rule)
+        policy_path.parent.mkdir(parents=True, exist_ok=True)
+        policy_path.write_text(yaml.dump(policy, default_flow_style=False, sort_keys=False))
+        return policy_path
+
+    def test_freshly_created_policy_file_has_version_and_validates(self):
+        events = [{"type": "shell", "command": "psql -h prod mydb", "ts": "2026-01-01T00:00:00Z"}]
+        analysis = analyze_events(events, repo_root=self.workspace, workspace=self.workspace)
+        save_session_snapshot(
+            workspace=self.workspace, session_id="s", agent="claude",
+            source="ingest", repo_url=None, events=events, analysis=analysis,
+        )
+        for _ in range(3):
+            save_session_snapshot(
+                workspace=self.workspace, session_id=f"s{_}", agent="claude",
+                source="ingest", repo_url=None, events=events, analysis=analysis,
+            )
+        candidates = mine_patterns(self.workspace, min_support=3)
+        save_candidate_rules(self.workspace, candidates)
+        rule = accept_candidate_rule(self.workspace, 1)
+        self.assertIsNotNone(rule)
+
+        policy_path = self._write_policy_from_candidate(rule)
+        self.assertNotIn(
+            "Missing required field: version",
+            validate_policy(policy_path),
+        )
+        errors = validate_policy(policy_path)
+        self.assertEqual(errors, [], msg=errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Closes #146** — `docs/learning.md`'s own worked example (a recurring `psql ... prod` command) could never actually be mined, because no database client was in the learning engine's `_SENSITIVE_COMMANDS` allowlist. Added `psql`/`mysql`/`mysqlsh`/`redis-cli`/`mongosh`/`sqlite3`.

- **Closes #147** — `prismor learn --apply` created `.prismor/policy.yaml` without the required `version` field when none existed yet, so the docs' own recommended next step (`prismor policy validate`) failed immediately with "Missing required field: version" — even though the learned rule worked correctly at runtime (`PolicyEngine`'s project-override loading doesn't require `version`; only `validate_policy()` checks for it).

Also added `tests/test_learning.py` — this module had zero test coverage before, the same gap behind every prior bug this session (the code path that broke was never exercised by anything).

## Test plan

- [x] `python -m pytest tests/` — 763 passed, 3 skipped (frameworks not installed in this env)
- [x] New `tests/test_learning.py`: recurring `psql` command is now minable, below-min-support and unlisted-base-command cases still correctly produce no candidate, and a freshly-accepted candidate produces a `policy.yaml` that passes `validate_policy()` with zero errors
- [x] Manually reproduced both original bugs end-to-end via the real CLI (`prismor learn` → `--apply` → `prismor policy validate`) before and after the fix