### PR TITLE
Memory-poisoning scan (#155) uses live session cwd, not install-time workspace

### DIFF
--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -1101,7 +1101,18 @@ def _normalize_claude(payload: Dict[str, Any], session_id: str, workspace: Path)
         "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
     }
     if hook_event == "SessionStart":
-        memory = _read_project_memory(workspace)
+        # payload["cwd"] is the live directory of *this* session, sent by
+        # Claude on every hook call. `workspace` is whatever was configured
+        # at `install-hooks` time (often a fixed dir for --scope user
+        # installs) — falling back to it when cwd is absent, but preferring
+        # cwd means the scan actually covers the project the agent is
+        # running in, not wherever hooks happened to be installed from. See
+        # PrismorSec/prismor#155 follow-up: a user-scope install pointed at
+        # $HOME meant every session's memory scan silently read $HOME's
+        # CLAUDE.md instead of the real project's, regardless of cwd.
+        raw_cwd = payload.get("cwd")
+        memory_root = Path(raw_cwd) if raw_cwd else workspace
+        memory = _read_project_memory(memory_root)
         base["metadata"]["memory_files"] = memory["files"]
         return {**base, "type": "memory", "content": memory["content"]}
     if hook_event == "UserPromptSubmit":


### PR DESCRIPTION
## Summary
Found while re-verifying #153/#155 with a live benchmark re-run (transcript + telemetry inspection, not just the aggregate CSV).

The SessionStart memory scan added in #155 resolves CLAUDE.md/AGENTS.md relative to the `workspace` argument the hook was installed with, not the actual session's live cwd. For a `--scope user` (global) install — a normal, common configuration, and what our benchmark box uses — that workspace is one fixed directory set at `install-hooks` time. Every session anywhere on the machine silently scanned that one directory's memory files, regardless of which project the agent was actually running in that session. Net effect: #155's fix had no observable effect outside a project-scoped install.

## Repro
1. `install-hooks --agent claude --scope user --workspace /home/ubuntu --mode enforce`
2. Run a session with `cwd=/tmp/some-other-project` containing a poisoned `CLAUDE.md`.
3. `memory-embedded-directive` never fires — the scan looked at `/home/ubuntu/CLAUDE.md` instead, which doesn't exist.
4. Confirmed via `~/.prismor/telemetry-spool.jsonl`: zero `memory_poisoning` findings across repeated attempts, despite the poisoned file being read and its directive followed.

## Fix
`payload["cwd"]` is already sent by Claude on every hook call and already used elsewhere in `_normalize_claude` for metadata — this just also uses it (falling back to `workspace` when absent) to resolve which memory files to scan.

Evidence: re-run of the ASI06 attack from PrismorSec/prismor#153 after the fix and after re-running `install-hooks` to pick up the new SessionStart hook — confirms the SessionStart hook itself was correctly installed and firing; the memory event just resolved the wrong directory.

https://claude.ai/code/session_01UAyyix7rsRnSzrHEv8Qw1u