### PR TITLE
Fix repo-local Prismor runtime shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Repo-local CLI entry points can no longer be shadowed by an unrelated installed `prismor` package.** The source checkout previously relied on a PEP 420 namespace package at the top-level `prismor/` directory. On hosts that already had another `prismor` distribution on `sys.path`, `bin/prismor` could import that foreign package first and then fail with `ModuleNotFoundError: prismor.runtime`, leaving operators testing the wrong runtime or no runtime at all. The checkout now ships a real top-level `prismor/__init__.py`, and `tests/test_cli.py` covers the shadowing case directly. This was reproduced during a live runtime-enforcement benchmark on July 6, 2026. (#150)
+
 ## [1.16.0] — 2026-07-04
 
 Batches five PRs of fixes found during an extended feature-by-feature security

--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ git clone https://github.com/PrismorSec/prismor.git ~/.prismor
 PRISMOR_MODE=enforce PRISMOR_CLOAK=1 bash ~/.prismor/scripts/init.sh .
 ```
 
+If you are testing from a source checkout on a machine that already has a
+different `prismor` install, use the repo shim for health checks:
+
+```bash
+python3 ~/.prismor/bin/prismor --version
+python3 ~/.prismor/bin/prismor status
+```
+
+That path forces imports to resolve to the checked-out runtime instead of a
+stale package earlier on `sys.path`.
+
 > On externally-managed Pythons (PEP 668 — Ubuntu 23.04+, Homebrew) `pip3 install` refuses to run; install PyYAML from your system package manager instead (`sudo apt install python3-yaml`, `brew install pyyaml`, …). `init.sh` will tell you if it's missing.
 
 This installs enforce-mode Prismor hooks and the Cloak prevention layer. To register a secret, run `prismor cloak add stripe_key` and enter the value when prompted. Reference it in tool calls as `@@SECRET:stripe_key@@` and the hook handles the rest.

--- a/prismor/__init__.py
+++ b/prismor/__init__.py
@@ -1,0 +1,11 @@
+"""Top-level Prismor package.
+
+This file makes the source checkout a real package instead of a pure namespace
+package so repo-local entry points (for example ``bin/prismor``) cannot be
+shadowed by an unrelated installed ``prismor`` distribution earlier on the
+import path.
+"""
+
+from prismor.runtime import __version__
+
+__all__ = ["__version__"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -231,6 +232,29 @@ class TestImmunityUmbrella(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
         for action in ("install", "uninstall", "add", "list", "remove", "status"):
             self.assertIn(action, r.stdout)
+
+    def test_repo_shim_beats_shadowing_prismor_package(self):
+        # Simulate an unrelated installed `prismor` package ahead of site-packages.
+        # The repo shim must still import THIS checkout.
+        with tempfile.TemporaryDirectory() as td:
+            shadow_root = Path(td)
+            shadow_pkg = shadow_root / "prismor"
+            shadow_pkg.mkdir()
+            (shadow_pkg / "__init__.py").write_text("__version__ = 'shadowed'\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(shadow_root)
+            r = subprocess.run(
+                [sys.executable, IMMUNITY_CLI, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("prismor ", r.stdout)
+        self.assertNotIn("shadowed", r.stdout)
 
 
 class TestSkillInstall(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add a real top-level `prismor` package so repo-local entrypoints cannot be shadowed by an unrelated installed `prismor` package
- add a CLI regression test that simulates package shadowing and proves `bin/immunity` still resolves to this checkout
- document the repo-shim health-check path for source-checkout operators and record the fix in the changelog

## Validation
- python3 -m pytest tests/test_cli.py -q
- python3 scripts/check_oss_safe.py
- bash scripts/run_security_tests.sh