### PR TITLE
Release v1.18.0

### DIFF
--- a/packaging/immunity-agent-shim/pyproject.toml
+++ b/packaging/immunity-agent-shim/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 # `prismor/runtime/__init__.py` on every release.
 [project]
 name = "immunity-agent"
-version = "1.17.11"
+version = "1.18.0"
 description = "Deprecated — renamed to 'prismor'. Installs prismor for you. Run: pip install prismor"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "prismor>=1.17.11",
+    "prismor>=1.18.0",
 ]
 
 [project.urls]

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.17.15"
+__version__ = "1.18.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
Bumps runtime + immunity-agent shim to **1.18.0**. Ships the T1-T15 coverage gap-fill work merged in #162, #163, #166, #167, #168. Tag `v1.18.0` after merge to trigger the PyPI + GitHub release.