### PR TITLE
[codex] fix cloak run env placeholder assignments

### DIFF
--- a/prismor/runtime/cloaking/runtime.py
+++ b/prismor/runtime/cloaking/runtime.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from prismor.runtime.cloaking.secrets_store import secrets_dir
 
 _PLACEHOLDER_RE = re.compile(r"@@SECRET:([a-zA-Z0-9_-]{1,64})@@")
+_ENV_ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 
 _READER_UTILS = frozenset({
     "cat", "bat", "less", "more", "head", "tail", "grep", "egrep", "fgrep",
@@ -78,6 +79,19 @@ def scrub_text(text: str, *, secrets: Optional[Dict[str, str]] = None) -> str:
         if len(value) >= 4:
             out = out.replace(value, f"@@SECRET:{name}@@")
     return out
+
+
+def _split_env_assignments(args: List[str]) -> tuple[Dict[str, str], List[str]]:
+    """Split leading shell-style env assignments from the command argv."""
+    env_updates: Dict[str, str] = {}
+    index = 0
+    for arg in args:
+        match = _ENV_ASSIGNMENT_RE.fullmatch(arg)
+        if not match:
+            break
+        env_updates[match.group(1)] = match.group(2)
+        index += 1
+    return env_updates, args[index:]
 
 
 def codex_cloak_finding(event: Dict[str, Any], session_id: str) -> Optional[Dict[str, Any]]:
@@ -181,8 +195,14 @@ def run_decloaked_command(argv: Iterable[str]) -> int:
     if not args:
         raise ValueError("Usage: prismor cloak run -- <command> [args...]")
     secrets = _read_secret_map()
+    env_updates, command_args = _split_env_assignments(args)
+    if not command_args:
+        raise ValueError("Usage: prismor cloak run -- <command> [args...]")
     try:
-        resolved = [decloak_text(arg, secrets=secrets) for arg in args]
+        resolved_env = {
+            name: decloak_text(value, secrets=secrets) for name, value in env_updates.items()
+        }
+        resolved = [decloak_text(arg, secrets=secrets) for arg in command_args]
     except KeyError as exc:
         name = str(exc).strip("'")
         raise ValueError(
@@ -190,10 +210,18 @@ def run_decloaked_command(argv: Iterable[str]) -> int:
             f"Run: prismor cloak add {name}"
         ) from exc
 
-    proc = subprocess.run(resolved, capture_output=True, text=True, errors="replace", check=False)
+    env = os.environ.copy()
+    env.update(resolved_env)
+    proc = subprocess.run(
+        resolved,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        check=False,
+        env=env,
+    )
     if proc.stdout:
         sys.stdout.write(scrub_text(proc.stdout, secrets=secrets))
     if proc.stderr:
         sys.stderr.write(scrub_text(proc.stderr, secrets=secrets))
     return int(proc.returncode)
-

--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -149,6 +149,17 @@ def test_placeholder_substituted_and_output_scrubbed():
           _CANARY not in out and _PLACEHOLDER in out, out.strip())
 
 
+def test_leading_env_assignment_decloaked_and_scrubbed():
+    out, code = execute_wrapped(
+        f"OPENAI_API_KEY={_PLACEHOLDER} python3 -c 'import os; print(os.environ[\"OPENAI_API_KEY\"])'"
+    )
+    check(
+        "leading env assignment is decloaked and output is re-masked",
+        code == 0 and _CANARY not in out and _PLACEHOLDER in out,
+        out.strip(),
+    )
+
+
 def test_unregistered_placeholder_denied():
     res = run_hook(_DECLOAK, bash_payload("echo @@SECRET:NOPE@@"))
     dec = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
@@ -182,6 +193,7 @@ def main() -> int:
         test_grep_output_scrubbed, test_source_echo_scrubbed,
         test_no_secret_in_wrapped_command, test_exit_code_preserved,
         test_placeholder_substituted_and_output_scrubbed,
+        test_leading_env_assignment_decloaked_and_scrubbed,
         test_unregistered_placeholder_denied,
         test_read_of_secret_file_denied, test_read_of_clean_file_allowed,
     ]:

--- a/tests/test_codex_cloak_runtime.py
+++ b/tests/test_codex_cloak_runtime.py
@@ -74,6 +74,22 @@ class TestCodexCloakRuntime(unittest.TestCase):
         self.assertIn("@@SECRET:OPENAI_API_KEY@@", combined)
         self.assertNotIn("sk-test-1234567890", combined)
 
+    def test_cloak_run_decloaks_leading_env_assignments(self):
+        stdout = StringIO()
+        stderr = StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            code = run_decloaked_command([
+                "OPENAI_API_KEY=@@SECRET:OPENAI_API_KEY@@",
+                sys.executable,
+                "-c",
+                "import os; print(os.environ['OPENAI_API_KEY'])",
+            ])
+
+        self.assertEqual(code, 0)
+        combined = stdout.getvalue() + stderr.getvalue()
+        self.assertIn("@@SECRET:OPENAI_API_KEY@@", combined)
+        self.assertNotIn("sk-test-1234567890", combined)
+
     def test_codex_hook_dispatch_blocks_and_records_placeholder(self):
         payload = {
             "hook_event_name": "PreToolUse",


### PR DESCRIPTION
## What changed

This fixes `prismor cloak run -- ...` for commands that pass cloaked placeholders through leading shell-style environment assignments such as `OPENAI_API_KEY=@@SECRET:OPENAI_API_KEY@@`.

Previously, the Codex-owned cloak runner only decloaked positional argv entries. That meant a command like:

```bash
OPENAI_API_KEY=@@SECRET:OPENAI_API_KEY@@ prismor cloak run -- sh -lc '... $OPENAI_API_KEY ...'
```

would pass the literal placeholder string into the child shell environment, and downstream API calls would fail with `invalid_api_key`.

The runner now splits leading `NAME=value` assignments, decloaks those values into the child process environment, and continues to scrub any matching secret values from stdout/stderr.

## Why

Codex is block-only for cloak hooks, so `prismor cloak run` is the supported execution path for placeholder-backed shell commands. That path needs to handle normal shell invocation patterns, including leading environment assignments.

## Impact

- Codex users can now use `prismor cloak run` with leading env assignments safely.
- Claude coverage is regression-tested for the equivalent command-text form.
- Output redaction behavior remains unchanged.

## Validation

- `python3 -m pytest tests/test_codex_cloak_runtime.py`
- `python3 tests/test_cloak_output_scrub.py`
- `python3 -m py_compile prismor/runtime/cloaking/runtime.py tests/test_codex_cloak_runtime.py tests/test_cloak_output_scrub.py`
