### PR TITLE
fix(runtime): stop semantic_guard_v2 from shadowing framework SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.18.4] — 2026-07-10
+
+### Fixed
+
+- **Framework SDK adapters no longer shadow the real SDK they wrap.** `prismor/runtime/semantic_guard_v2.py` prepended the `prismor` package directory to `sys.path` (a v1 relic), which made the PEP-420 namespace shims `prismor/openai`, `prismor/crewai`, `prismor/langchain`, and `prismor/browser_use` importable as top-level modules — so a plain `import openai` (or `crewai`/`langchain`/`browser_use`) resolved to the adapter shim and hijacked `sys.modules`, breaking the genuine SDK for every in-process adapter. The stray `sys.path.insert` is removed; the sibling heuristic import resolves through the installed `prismor` namespace without it. Regression test added.
+
 ## [1.18.3] — 2026-07-10
 
 ### Fixed

--- a/prismor/runtime/semantic_guard_v2.py
+++ b/prismor/runtime/semantic_guard_v2.py
@@ -25,10 +25,11 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
-# Import heuristic engine from v1
-_HERE = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.dirname(_HERE))
-
+# Import heuristic engine from v1. This is an absolute import that resolves via
+# the installed `prismor` namespace package — it must NOT prepend the package
+# directory to sys.path, or `prismor/<subdir>` namespace packages (e.g. the
+# framework-adapter shims prismor/openai, prismor/crewai) become importable as
+# top-level modules and shadow the real SDKs they wrap.
 from prismor.runtime.semantic_guard import SemanticRisk, _heuristic_analyze
 
 # ── Thresholds for LLM escalation ──────────────────────────────────────────

--- a/tests/test_semantic_guard_syspath.py
+++ b/tests/test_semantic_guard_syspath.py
@@ -1,0 +1,42 @@
+"""Regression: importing the Prismor runtime must not put the ``prismor``
+package directory on ``sys.path``.
+
+If it does, the PEP-420 namespace subpackages that ship the framework-adapter
+shims (``prismor/openai``, ``prismor/crewai``, ``prismor/langchain``,
+``prismor/browser_use``) become importable as TOP-LEVEL modules — so a plain
+``import openai`` resolves to ``prismor/openai`` and its alias shim hijacks
+``sys.modules['openai']``, shadowing the real SDK the adapter is meant to wrap.
+That broke every in-process framework adapter.
+
+The root cause was a stray ``sys.path.insert(0, os.path.dirname(_HERE))`` at the
+top of ``prismor/runtime/semantic_guard_v2.py`` (a v1 relic — the sibling import
+resolves through the installed ``prismor`` namespace without it).
+"""
+import subprocess
+import sys
+import textwrap
+
+
+def test_runtime_import_does_not_pollute_syspath():
+    # Use a fresh interpreter so module-level side effects actually run
+    # (an already-imported module would not re-execute its top-level code).
+    code = textwrap.dedent(
+        """
+        import os, sys
+        import prismor
+        pkg_dirs = {os.path.realpath(p) for p in prismor.__path__}
+        # Importing the runtime pulls in semantic_guard_v2 at module load.
+        import prismor.runtime.semantic_guard_v2  # noqa: F401
+        leaked = sorted(pkg_dirs & {os.path.realpath(p) for p in sys.path if p})
+        if leaked:
+            print("LEAKED:" + ";".join(leaked))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        "prismor package dir leaked onto sys.path — prismor/<subdir> namespace "
+        "packages would shadow real top-level SDKs.\n"
+        + result.stdout
+        + result.stderr
+    )


### PR DESCRIPTION
## Problem

Installing any in-process framework adapter alongside prismor breaks the real SDK it is meant to guard. In a venv with prismor + the OpenAI adapter, `import openai` returns the Prismor shim instead of the OpenAI client:

```
ImportError: cannot import name 'AsyncOpenAI' from 'prismor_openai'
```

This affects **all four** in-process adapters — `openai`, `crewai`, `langchain`, `browser_use` — because their top-level imports all resolve to the Prismor namespace shim.

## Root cause

`prismor/runtime/semantic_guard_v2.py` did:

```python
_HERE = os.path.dirname(os.path.abspath(__file__))
sys.path.insert(0, os.path.dirname(_HERE))   # -> site-packages/prismor
```

That puts the `prismor` **package directory** onto `sys.path` (at interpreter startup, via `runtime/__init__.py` → `semantic_guard_v2`). Once it's there, the PEP-420 namespace shims `prismor/openai`, `prismor/crewai`, `prismor/langchain`, `prismor/browser_use` become importable as **top-level** modules, and each shim's `sys.modules[__name__] = _impl` alias then hijacks the real SDK (`import openai` → `prismor_openai`).

The `sys.path.insert` is a v1 relic: the very next line is an absolute import (`from prismor.runtime.semantic_guard import …`) that resolves through the installed `prismor` namespace without it.

## Fix

Remove the stray `sys.path.insert`. Add a regression test that spawns a fresh interpreter, imports `prismor.runtime.semantic_guard_v2`, and asserts no `prismor.__path__` entry has leaked onto `sys.path`.

## Verification

With this fix, `import openai`/`crewai`/`langchain`/`browser_use` all resolve to the **real** SDK (no workaround), and all five adapters pass live end-to-end (openai-agents, langchain, crewai, browser-use, and the vercel-ai eval-server path): safe tool calls allowed, `rm -rf /` and secret-exfil calls blocked before execution.

`tests/test_semantic_guard_syspath.py` passes on this branch and fails on `main`.
