### PR TITLE
harden(adapters): shims refuse to load under a top-level name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.21.1] — 2026-07-10
+
+### Fixed
+
+- **Framework-adapter namespace shims now refuse to load under a top-level name.** Each `prismor.<framework>` shim (`prismor/openai`, `prismor/crewai`, `prismor/langchain`, `prismor/browser_use`) aliases its implementation into `sys.modules`. That alias now fires only when the shim is imported under its intended dotted name; if the `prismor` package directory ever leaks onto `sys.path` and Python resolves the shim as a bare top-level module (e.g. `openai`), it raises a clear `ImportError` pointing at the sys.path pollution instead of silently replacing the real SDK with the adapter. Defense in depth complementing the sys.path fix (#173).
+
 ## [1.21.0] — 2026-07-10
 
 ### Added

--- a/adapters/browser-use/prismor/browser_use/__init__.py
+++ b/adapters/browser-use/prismor/browser_use/__init__.py
@@ -9,6 +9,19 @@ paths resolve to the same module object.
 """
 import sys as _sys
 
+# This shim must only ever be imported as ``prismor.browser_use``. If the
+# ``prismor`` package directory leaks onto sys.path, Python can resolve it as a
+# *top-level* ``browser_use`` module; blindly aliasing sys.modules would then
+# replace the real browser-use package with this adapter and break every
+# downstream ``import browser_use``. Fail loudly instead. (The sys.path leak was
+# fixed in PrismorSec/prismor#173 — this guard is defense in depth.)
+if __name__ != "prismor.browser_use":
+    raise ImportError(
+        f"prismor.browser_use was imported as {__name__!r}, not 'prismor.browser_use' "
+        "— the 'prismor' package directory is on sys.path and is shadowing the real "
+        "'browser_use' package. Remove it from sys.path (see PrismorSec/prismor#173)."
+    )
+
 import prismor_browser_use as _impl
 
 _sys.modules[__name__] = _impl

--- a/adapters/crewai/prismor/crewai/__init__.py
+++ b/adapters/crewai/prismor/crewai/__init__.py
@@ -9,6 +9,19 @@ paths resolve to the same module object.
 """
 import sys as _sys
 
+# This shim must only ever be imported as ``prismor.crewai``. If the ``prismor``
+# package directory leaks onto sys.path, Python can resolve it as a *top-level*
+# ``crewai`` module; blindly aliasing sys.modules would then replace the real
+# CrewAI SDK with this adapter and break every downstream ``import crewai``.
+# Fail loudly instead. (The sys.path leak was fixed in PrismorSec/prismor#173 —
+# this guard is defense in depth so the two can never combine again.)
+if __name__ != "prismor.crewai":
+    raise ImportError(
+        f"prismor.crewai was imported as {__name__!r}, not 'prismor.crewai' — the "
+        "'prismor' package directory is on sys.path and is shadowing the real "
+        "'crewai' SDK. Remove it from sys.path (see PrismorSec/prismor#173)."
+    )
+
 import prismor_crewai as _impl
 
 _sys.modules[__name__] = _impl

--- a/adapters/langchain/prismor/langchain/__init__.py
+++ b/adapters/langchain/prismor/langchain/__init__.py
@@ -9,6 +9,19 @@ paths resolve to the same module object.
 """
 import sys as _sys
 
+# This shim must only ever be imported as ``prismor.langchain``. If the
+# ``prismor`` package directory leaks onto sys.path, Python can resolve it as a
+# *top-level* ``langchain`` module; blindly aliasing sys.modules would then
+# replace the real LangChain package with this adapter and break every
+# downstream ``import langchain``. Fail loudly instead. (The sys.path leak was
+# fixed in PrismorSec/prismor#173 — this guard is defense in depth.)
+if __name__ != "prismor.langchain":
+    raise ImportError(
+        f"prismor.langchain was imported as {__name__!r}, not 'prismor.langchain' — "
+        "the 'prismor' package directory is on sys.path and is shadowing the real "
+        "'langchain' package. Remove it from sys.path (see PrismorSec/prismor#173)."
+    )
+
 import prismor_langchain as _impl
 
 _sys.modules[__name__] = _impl

--- a/adapters/openai-agents/prismor/openai/__init__.py
+++ b/adapters/openai-agents/prismor/openai/__init__.py
@@ -9,6 +9,19 @@ paths resolve to the same module object.
 """
 import sys as _sys
 
+# This shim must only ever be imported as ``prismor.openai``. If the ``prismor``
+# package directory leaks onto sys.path, Python can resolve it as a *top-level*
+# ``openai`` module; blindly aliasing sys.modules would then replace the real
+# OpenAI SDK with this adapter and break every downstream ``import openai``.
+# Fail loudly instead. (The sys.path leak was fixed in PrismorSec/prismor#173 —
+# this guard is defense in depth so the two can never combine again.)
+if __name__ != "prismor.openai":
+    raise ImportError(
+        f"prismor.openai was imported as {__name__!r}, not 'prismor.openai' — the "
+        "'prismor' package directory is on sys.path and is shadowing the real "
+        "'openai' SDK. Remove it from sys.path (see PrismorSec/prismor#173)."
+    )
+
 import prismor_openai as _impl
 
 _sys.modules[__name__] = _impl

--- a/tests/test_adapter_shim_guard.py
+++ b/tests/test_adapter_shim_guard.py
@@ -1,0 +1,32 @@
+"""Adapter shim import guard.
+
+Each ``prismor.<framework>`` shim aliases its implementation module into
+``sys.modules``. That alias must fire ONLY when the shim is imported under its
+intended dotted name. If the ``prismor`` package directory ever leaks onto
+``sys.path`` (the root cause fixed in PrismorSec/prismor#173), Python can resolve
+e.g. ``prismor/openai`` as a *top-level* ``openai`` module — and a blind alias
+would then replace the real SDK with the adapter, breaking every downstream
+``import openai``. The shim must fail loudly instead. This is defense in depth.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+SHIMS = {
+    "openai": _ROOT / "adapters/openai-agents/prismor/openai/__init__.py",
+    "crewai": _ROOT / "adapters/crewai/prismor/crewai/__init__.py",
+    "langchain": _ROOT / "adapters/langchain/prismor/langchain/__init__.py",
+    "browser_use": _ROOT / "adapters/browser-use/prismor/browser_use/__init__.py",
+}
+
+
+@pytest.mark.parametrize("toplevel,path", list(SHIMS.items()))
+def test_shim_refuses_toplevel_import(toplevel, path):
+    # Load the shim under the bare top-level name it would receive if the prismor
+    # package dir were on sys.path. It must raise before aliasing sys.modules.
+    spec = importlib.util.spec_from_file_location(toplevel, str(path))
+    module = importlib.util.module_from_spec(spec)
+    with pytest.raises(ImportError, match="sys.path"):
+        spec.loader.exec_module(module)


### PR DESCRIPTION
Defense-in-depth follow-up to #173 (the sys.path leak in `semantic_guard_v2.py`, now merged).

## Why

#173 removed the `sys.path.insert` that let the `prismor` package directory leak onto `sys.path`. That leak was only *half* the shadowing bug. The other half is here: each `prismor.<framework>` shim does

```python
_sys.modules[__name__] = _impl
```

with **no guard on `__name__`**. If the package dir is ever on `sys.path` again — from any future regression, not just the one #173 fixed — Python resolves the shim as a bare top-level module (`openai`, `crewai`, `langchain`, `browser_use`) and that unconditional alias silently replaces the **real SDK** with the adapter. That's what produced:

```
ImportError: cannot import name 'AsyncOpenAI' from 'prismor_openai'
```

## Change

Guard each shim's alias so it only fires under the intended dotted name; otherwise raise a clear, actionable `ImportError`:

```python
if __name__ != "prismor.openai":
    raise ImportError(
        "... the 'prismor' package directory is on sys.path and is shadowing "
        "the real 'openai' SDK. Remove it from sys.path (see #173)."
    )
```

Applied to all four shims (`openai`, `crewai`, `langchain`, `browser_use`). The legitimate `from prismor.openai import guard_agent` path is unaffected (`__name__ == "prismor.openai"`).

With #173 **and** this in place, the leak and the alias can never combine to hijack a real SDK again — one is enough to prevent it, and now both are covered.

## Test

`tests/test_adapter_shim_guard.py` loads each shim file under its bare top-level name and asserts it raises rather than aliasing `sys.modules`. Passes on this branch.

## Note

The shims are the single source of truth: the main wheel force-includes them (`[tool.hatch.build.targets.wheel.force-include]`), so this one edit fixes both the standalone adapter packages and the shims shipped inside the base `prismor` wheel.
