### PR TITLE
fix(registry): accept http surface + client-side blocking

### DIFF
--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -21,5 +21,11 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
       - name: Install pytest
         run: python3 -m pip install --quiet pytest
+      - name: Verify integration registry
+        # Catches registry.yaml drift vs SURFACES/BLOCKING enums and matrix sync
+        # (see TODO.md: verify_registry.sh in CI). Needs PyYAML for the YAML load path.
+        run: |
+          python3 -m pip install --quiet pyyaml
+          bash scripts/verify_registry.sh
       - name: Run security regression suite
         run: bash scripts/run_security_tests.sh

--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -45,9 +45,11 @@ _Generated from `prismor/runtime/integrations/registry.yaml` — do not edit by 
 | CrewAI | framework | sdk | ✅ | `throw` |
 | LangChain / LangGraph | framework | sdk | ✅ | `throw` |
 | browser-use | framework | sdk | ✅ | `throw` |
+| Vercel AI SDK | framework | http | ✅ | `throw` |
+| HTTP Eval-Server (any language) | framework | http | ✅ | `client-side` |
 | MCP Proxy (any MCP-speaking agent) | framework | mcp | 🟡 | `proxy-deny` |
 
-Legend: ✅ shipped · 🟡 roadmap · — sweep-only / not applicable. Surfaces: `hook-config` (config-file hooks) · `sdk` (in-process adapter) · `mcp` (proxy) · `rules-only` (static guardrails).
+Legend: ✅ shipped · 🟡 roadmap · — sweep-only / not applicable. Surfaces: `hook-config` (config-file hooks) · `sdk` (in-process adapter) · `mcp` (proxy) · `http` (eval-server sidecar) · `rules-only` (static guardrails).
 
 <!-- END GENERATED: coverage-matrix -->
 

--- a/prismor/runtime/integrations/registry.py
+++ b/prismor/runtime/integrations/registry.py
@@ -23,9 +23,11 @@ _REGISTRY_PATH = Path(__file__).resolve().parent / "registry.yaml"
 
 # Allowed enum values — kept in sync with registry.schema.json.
 KINDS = frozenset({"coding-agent", "framework"})
-SURFACES = frozenset({"hook-config", "sdk", "mcp", "rules-only"})
+# http = language-agnostic eval-server / Vercel AI sidecar (POST /v1/evaluate)
+SURFACES = frozenset({"hook-config", "sdk", "mcp", "rules-only", "http"})
 STATUSES = frozenset({"shipped", "roadmap", "sweep-only"})
-BLOCKING = frozenset({"exit-2", "json-permission", "throw", "proxy-deny", "none"})
+# client-side = HTTP eval-server adapters that enforce in the caller (Node/Ruby/Java/Rust)
+BLOCKING = frozenset({"exit-2", "json-permission", "throw", "proxy-deny", "none", "client-side"})
 
 
 @dataclass(frozen=True)
@@ -85,7 +87,7 @@ def get(agent_id: str, path: Optional[Path] = None) -> Optional[Integration]:
 
 
 def by_surface(surface: str, path: Optional[Path] = None) -> List[Integration]:
-    """All integrations exposing ``surface`` (hook-config|sdk|mcp|rules-only)."""
+    """All integrations exposing ``surface`` (hook-config|sdk|mcp|rules-only|http)."""
     return [i for i in load_registry(path) if i.surface == surface]
 
 

--- a/prismor/runtime/integrations/registry.schema.json
+++ b/prismor/runtime/integrations/registry.schema.json
@@ -21,9 +21,9 @@
         "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "name": { "type": "string" },
         "kind": { "enum": ["coding-agent", "framework"] },
-        "surface": { "enum": ["hook-config", "sdk", "mcp", "rules-only"] },
+        "surface": { "enum": ["hook-config", "sdk", "mcp", "rules-only", "http"] },
         "status": { "enum": ["shipped", "roadmap", "sweep-only"] },
-        "blocking": { "enum": ["exit-2", "json-permission", "throw", "proxy-deny", "none"] },
+        "blocking": { "enum": ["exit-2", "json-permission", "throw", "proxy-deny", "none", "client-side"] },
         "events": { "type": "array", "items": { "type": "string" } },
         "config_paths": {
           "type": "object",

--- a/scripts/gen_integration_matrix.py
+++ b/scripts/gen_integration_matrix.py
@@ -61,7 +61,7 @@ def render_matrix() -> str:
         "",
         "Legend: ✅ shipped · 🟡 roadmap · — sweep-only / not applicable. "
         "Surfaces: `hook-config` (config-file hooks) · `sdk` (in-process adapter) · "
-        "`mcp` (proxy) · `rules-only` (static guardrails).",
+        "`mcp` (proxy) · `http` (eval-server sidecar) · `rules-only` (static guardrails).",
         "",
         _END,
     ]


### PR DESCRIPTION
## Summary

`scripts/verify_registry.sh` currently fails on main:

```
AssertionError: vercel-ai: bad surface 'http'
```

`registry.yaml` already ships **vercel-ai** and **eval-server** with:
- `surface: http`
- `blocking: client-side` (eval-server)

…but the Python enums and JSON schema still only allow the older values, so the fallback validator (and jsonschema, if installed) rejects a valid registry.

## Changes

1. Add `http` to `SURFACES` and `client-side` to `BLOCKING` in `registry.py`
2. Mirror those enums in `registry.schema.json`
3. Document `http` (eval-server sidecar) in the integration matrix legend
4. Wire `bash scripts/verify_registry.sh` into `security-regression.yml` (from TODO.md) so this can't regress

## Test plan

- [x] `bash scripts/verify_registry.sh` → OK (22 integrations)
- [ ] CI green on this PR

---

Came via your comment on the Agent Gate launch gist — happy to help more on MCP proxy / dashboard subject filter if useful.