### PR TITLE
DENY-wins precedence for mixed enforce verdicts (R4 hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.24.0] — 2026-07-11
+
+### Changed
+
+- **DENY-wins precedence when multiple enforce findings fire on one event.** `should_block` returned whichever enforce finding the engine surfaced first, so a rule-ordering accident could let a `step_up`/`modify`/`defer` verdict mask a hard `block` on the same action. It now selects the strongest verdict — block > step_up > defer > modify, with enforce `warn`/`log`/unset ranking as block (enforce means "stop") and ties preserving first-surfaced order. Coverage in `tests/test_deny_precedence.py`.
+
 ## [1.23.0] — 2026-07-11
 
 ### Added

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -264,6 +264,13 @@ def should_block(
     # rule's mode, else the policy's default_mode — both default to "observe").
     # A finding blocks only when its effective mode is "enforce". block_categories
     # no longer gates this (every category is observe-by-default until enforced).
+    # DENY-wins precedence: when several enforce findings fire on one event
+    # with mixed actions, the strongest verdict wins (block > step_up > defer
+    # > modify) rather than whichever the engine surfaced first. Unknown
+    # actions (warn/log/unset on an enforce finding) rank as block — enforce
+    # means "stop". Ties keep first-surfaced order (min() is stable).
+    _ACTION_RANK = {"block": 0, "step_up": 1, "defer": 2, "modify": 3}
+    eligible: List[Dict[str, Any]] = []
     for finding in findings:
         if str(finding.get("mode", "observe")).lower() == "enforce":
             # Reads are generally safe, so they only block for secret access —
@@ -274,8 +281,10 @@ def should_block(
                 and finding.get("category") not in ("secret_access", "iam")
             ):
                 continue
-            return finding
-    return None
+            eligible.append(finding)
+    if not eligible:
+        return None
+    return min(eligible, key=lambda f: _ACTION_RANK.get(str(f.get("action") or "block").lower(), 0))
 
 
 def legacy_should_block(

--- a/tests/test_deny_precedence.py
+++ b/tests/test_deny_precedence.py
@@ -1,0 +1,74 @@
+"""DENY-wins precedence in should_block.
+
+When several enforce findings fire on one event with mixed actions, the strongest
+verdict must win (block > step_up > defer > modify), not whichever the engine
+surfaced first — otherwise a rule ordering accident could downgrade a hard block
+to a step-up/modify. Run:  python3 tests/test_deny_precedence.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+from prismor.runtime.hooks import should_block  # noqa: E402
+
+EVENT = {"agent_event": "PreToolUse", "type": "shell"}
+
+
+def _f(action, fid, mode="enforce"):
+    return {"mode": mode, "action": action, "id": fid, "category": "test"}
+
+
+class DenyPrecedence(unittest.TestCase):
+    def test_block_wins_over_step_up_even_when_second(self):
+        picked = should_block([_f("step_up", "a"), _f("block", "b")], EVENT)
+        self.assertEqual(picked["id"], "b")
+
+    def test_block_wins_over_modify_and_defer(self):
+        picked = should_block([_f("modify", "a"), _f("defer", "b"), _f("block", "c")], EVENT)
+        self.assertEqual(picked["id"], "c")
+
+    def test_step_up_wins_over_modify_when_no_block(self):
+        picked = should_block([_f("modify", "a"), _f("step_up", "b")], EVENT)
+        self.assertEqual(picked["id"], "b")
+
+    def test_defer_beats_modify(self):
+        picked = should_block([_f("modify", "a"), _f("defer", "b")], EVENT)
+        self.assertEqual(picked["id"], "b")
+
+    def test_enforce_warn_ranks_as_deny(self):
+        # An enforce finding with action=warn/unset still means "stop" → outranks modify.
+        picked = should_block([_f("modify", "a"), _f("warn", "b")], EVENT)
+        self.assertEqual(picked["id"], "b")
+
+    def test_ties_keep_first_surfaced(self):
+        picked = should_block([_f("step_up", "first"), _f("step_up", "second")], EVENT)
+        self.assertEqual(picked["id"], "first")
+
+    def test_single_finding_unchanged(self):
+        self.assertEqual(should_block([_f("step_up", "only")], EVENT)["id"], "only")
+
+    def test_observe_findings_never_block(self):
+        self.assertIsNone(should_block([_f("block", "a", mode="observe")], EVENT))
+
+    def test_no_findings(self):
+        self.assertIsNone(should_block([], EVENT))
+
+    def test_not_pre_action(self):
+        self.assertIsNone(should_block([_f("block", "a")], {"agent_event": "PostToolUse", "type": "shell"}))
+
+    def test_file_read_carveout_still_applies(self):
+        # A non-secret file_read enforce finding is not eligible → no block.
+        read_ev = {"agent_event": "PreToolUse", "type": "file_read"}
+        self.assertIsNone(should_block([{"mode": "enforce", "action": "block", "id": "r", "category": "test"}], read_ev))
+        # …but a secret_access read still blocks.
+        secret = {"mode": "enforce", "action": "block", "id": "s", "category": "secret_access"}
+        self.assertEqual(should_block([secret], read_ev)["id"], "s")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Fixes the last R4 rough edge: when several **enforce** findings fire on one event with mixed actions, `should_block` returned whichever the engine surfaced *first*. So a rule-ordering accident could let a `step_up` / `modify` / `defer` verdict mask a hard `block` on the same action — a correctness/safety gap.

`should_block` now selects the **strongest** verdict:

```
block  >  step_up  >  defer  >  modify
```

- Enforce findings with `warn` / `log` / unset action rank as **block** (enforce mode means "stop").
- Ties keep first-surfaced order (`min()` is stable).
- File-read carve-out and observe/pre-action gating unchanged.

## Why a PR (not direct to main)

main is being actively modified by parallel work right now, so this goes through review rather than a direct push.

## Tests
- `tests/test_deny_precedence.py` — 11 cases (block beats step_up/modify/defer even when later in the list; step_up beats modify; enforce-warn ranks as deny; ties; file_read carve-out; observe never blocks).
- Regression: `test_hooks`, `test_r4_decisions`, `test_enforcement_floor`, `test_hooks_extended` all pass.