### PR TITLE
feat(vercel-ai): useSubject() ambient attribution + fail-closed enforce mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 🧠 [Semantic Guard](docs/semantic-guard.md): opt-in hybrid layer that adds an LLM-assisted intent check for paraphrased prompt-injection attempts the regex rules cannot catch
 - 🪤 [Canary](docs/canary.md) plants honeytoken credential files that trip a CRITICAL finding the moment an agent reads them, catching recon behavior
 - 🪪 [IAM](docs/iam.md) gives each agent a named identity and least-privilege permission profile when several agents share a workspace
-- 🧩 [Framework Agents](docs/frameworks-overview.md) guards production agents (OpenAI Agents SDK, LangChain, CrewAI, browser-use, Vercel AI SDK) with one call — wrap each request in `use_subject("user:alice")` and a multi-tenant agent gets per-user attribution, per-user IAM profiles, and per-user suspension
+- 🧩 [Framework Agents](docs/frameworks-overview.md) guards production agents (OpenAI Agents SDK, LangChain/LangGraph in Python and JS, CrewAI, browser-use, Vercel AI SDK) with one call — wrap each request in `use_subject("user:alice")` and a multi-tenant agent gets per-user attribution, per-user IAM profiles, and per-user suspension
 - 🎯 [Scoped Agent](docs/scoped-agent.md) synthesizes minimal, task-specific rules per session so an injected pivot off-task gets blocked
 - 🧬 [Learning](docs/learning.md) mines session history to propose new rules, flag false positives, and detect evasion
 - ⚖️ [Layered Policy & Exemptions](docs/policy-layers-and-exemptions.md) covers per-rule observe/enforce, the non-overridable floor, and admin-granted, time-boxed exemptions across org / project / repo layers

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 🧠 [Semantic Guard](docs/semantic-guard.md): opt-in hybrid layer that adds an LLM-assisted intent check for paraphrased prompt-injection attempts the regex rules cannot catch
 - 🪤 [Canary](docs/canary.md) plants honeytoken credential files that trip a CRITICAL finding the moment an agent reads them, catching recon behavior
 - 🪪 [IAM](docs/iam.md) gives each agent a named identity and least-privilege permission profile when several agents share a workspace
+- 🧩 [Framework Agents](docs/frameworks-overview.md) guards production agents (OpenAI Agents SDK, LangChain, CrewAI, browser-use, Vercel AI SDK) with one call — wrap each request in `use_subject("user:alice")` and a multi-tenant agent gets per-user attribution, per-user IAM profiles, and per-user suspension
 - 🎯 [Scoped Agent](docs/scoped-agent.md) synthesizes minimal, task-specific rules per session so an injected pivot off-task gets blocked
 - 🧬 [Learning](docs/learning.md) mines session history to propose new rules, flag false positives, and detect evasion
 - ⚖️ [Layered Policy & Exemptions](docs/policy-layers-and-exemptions.md) covers per-rule observe/enforce, the non-overridable floor, and admin-granted, time-boxed exemptions across org / project / repo layers

--- a/adapters/vercel-ai/README.md
+++ b/adapters/vercel-ai/README.md
@@ -63,23 +63,45 @@ try {
 
 ## Per-user (multi-tenant)
 
-Pass `subject` per request — no need to rebuild tool objects:
+Guard the tools once at module scope, then wrap each request handler in
+`useSubject()` — every guarded tool call inside is attributed to that user,
+matching the Python adapters' `use_subject()`:
 
 ```typescript
+import { prismorTools, useSubject } from "prismor-warden";
+
+const tools = prismorTools(myTools); // once, at module scope
+
 // Next.js API route
 export async function POST(req: Request) {
   const { prompt } = await req.json();
   const session = await getSession(req);
 
-  const tools = prismorTools(myTools, {
-    subject: `user:${session.userId}`,
-    mode: "enforce",
-  });
-
-  const result = await generateText({ model, tools, prompt });
+  const result = await useSubject(`user:${session.userId}`, () =>
+    generateText({ model, tools, prompt }));
   return Response.json({ text: result.text });
 }
 ```
+
+The subject propagates via `AsyncLocalStorage`, so concurrent requests with
+different users cannot bleed into each other. Per-call resolution priority:
+the `subject` option, then the ambient `useSubject()` context, then the
+`PRISMOR_SUBJECT` environment variable. (Passing `subject` per
+`prismorTools()` call still works and takes precedence.)
+
+## Fail mode
+
+If the eval-server cannot answer (not running, crashed, timeout), the adapter
+follows `failMode`:
+
+- `mode: "enforce"` (default) **fails closed** — the tool call is blocked with
+  `PrismorBlocked`. An enforced policy (e.g. a suspended user) holds even when
+  the sidecar is down.
+- `mode: "observe"` fails open — monitoring never breaks the app.
+- Set `failMode: "open"` or `"closed"` explicitly to override either default.
+
+> **Changed in 0.3.0:** enforce mode previously failed open. Pass
+> `failMode: "open"` to restore the old behavior.
 
 ## Options
 
@@ -88,6 +110,9 @@ export async function POST(req: Request) {
 | `evalUrl` | `string` | `http://127.0.0.1:7071` | Eval-server URL |
 | `subject` | `string` | `""` | End-user: `"user:alice"` or `"user=alice;team=data"` |
 | `mode` | `"enforce"\|"observe"` | `"enforce"` | Enforce blocks; observe logs only |
+| `failMode` | `"open"\|"closed"` | `"closed"` in enforce, `"open"` in observe | Behavior when the eval-server is unavailable |
+| `timeoutMs` | `number` | `10000` | Max wait for the eval-server per call |
 | `workspace` | `string` | `process.cwd()` | Project path for policy/IAM lookup |
 | `agent` | `string` | `"vercel-ai"` | Agent identifier in telemetry |
+| `agentName` | `string` | same as `agent` | Per-instance name for kill-switch / per-agent controls |
 | `eventType` | `string` | `"shell"` | Event type: `shell`, `network`, `file_write`, … |

--- a/adapters/vercel-ai/README.md
+++ b/adapters/vercel-ai/README.md
@@ -89,6 +89,29 @@ the `subject` option, then the ambient `useSubject()` context, then the
 `PRISMOR_SUBJECT` environment variable. (Passing `subject` per
 `prismorTools()` call still works and takes precedence.)
 
+## LangChain JS / LangGraph JS
+
+The same package guards LangChain JS tools — and therefore LangGraph agents
+(`ToolNode`, `createReactAgent`), which execute those tools. Guard the tool
+objects once; graphs already holding a reference are covered because `invoke`
+is wrapped in place:
+
+```typescript
+import { tool } from "@langchain/core/tools";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { prismorLangChainTools, useSubject } from "prismor-warden";
+
+const tools = prismorLangChainTools([run_shell, fetch_url]);
+const agent = createReactAgent({ llm, tools });
+
+await useSubject(`user:${userId}`, () => agent.invoke({ messages }));
+```
+
+A denied call throws `PrismorBlocked`; LangGraph's `ToolNode` catches tool
+errors by default and returns the message to the model as a `ToolMessage`, so
+the run recovers gracefully. All options (`failMode`, `timeoutMs`, `subject`,
+`eventType`, …) work identically.
+
 ## Fail mode
 
 If the eval-server cannot answer (not running, crashed, timeout), the adapter

--- a/adapters/vercel-ai/package.json
+++ b/adapters/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismor-warden",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Prismor for JS/TS agents \u2014 policy-controlled tool calls for the Vercel AI SDK via the Prismor eval-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/adapters/vercel-ai/src/index.ts
+++ b/adapters/vercel-ai/src/index.ts
@@ -268,3 +268,74 @@ export function prismorTools<
     Object.entries(tools).map(([name, t]) => [name, prismorTool(name, t, opts)]),
   ) as T;
 }
+
+// ── LangChain JS / LangGraph JS ──────────────────────────────────────────────
+
+/** A LangChain JS StructuredTool-like object (also what LangGraph's ToolNode calls). */
+interface LangChainToolLike {
+  name?: string;
+  invoke: (input: any, config?: any) => any;
+}
+
+/** Extract the argument record from a ToolNode-style ToolCall or raw args input. */
+function langChainArgs(input: any): Record<string, unknown> {
+  if (input && typeof input === "object") {
+    // LangGraph's ToolNode invokes tools with the full ToolCall object
+    // ({ name, args, id, type: "tool_call" }); direct callers pass raw args.
+    if (input.type === "tool_call" && typeof input.args === "object" && input.args !== null) {
+      return input.args as Record<string, unknown>;
+    }
+    return input as Record<string, unknown>;
+  }
+  return { input };
+}
+
+/**
+ * Guard a LangChain JS / LangGraph JS tool so every `invoke()` is evaluated by
+ * Prismor first. Works on anything StructuredTool-shaped — `tool(fn, {...})`
+ * from `@langchain/core/tools`, and therefore the tools LangGraph's
+ * `createReactAgent` / `ToolNode` execute. The same tool object is returned
+ * with its `invoke` wrapped in place, so graphs already holding a reference
+ * are covered too.
+ *
+ * A denied call throws PrismorBlocked. LangGraph's ToolNode catches tool
+ * errors by default (`handleToolErrors: true`) and feeds the message back to
+ * the model as a ToolMessage, so the run recovers gracefully.
+ */
+export function prismorLangChainTool<T extends LangChainToolLike>(
+  tool: T,
+  opts: PrismorOptions = {},
+): T {
+  if ((tool as any).__prismor_guarded__) return tool;
+  const resolved = resolveOpts(opts);
+  const sid = sessionId();
+  const toolName = tool.name || "tool";
+  const original = tool.invoke.bind(tool);
+
+  (tool as any).invoke = async (input: any, config?: any) => {
+    const decision = await evaluate(toolName, langChainArgs(input), resolved, sid);
+    if (!decision.allow) {  // honor the runtime decision (incl. org kill-switch), not the app-passed mode
+      throw new PrismorBlocked(decision.reason ?? "policy violation", decision);
+    }
+    return original(input, config);
+  };
+  (tool as any).__prismor_guarded__ = true;
+  return tool;
+}
+
+/**
+ * Guard a list of LangChain JS / LangGraph JS tools in one call — mirrors the
+ * Python adapters' `guard_tools([...])`. Returns the same array.
+ *
+ * @example
+ * import { prismorLangChainTools, useSubject } from "prismor-warden";
+ * const tools = prismorLangChainTools([run_shell, fetch_url]);
+ * const agent = createReactAgent({ llm, tools });
+ * await useSubject(`user:${userId}`, () => agent.invoke({ messages }));
+ */
+export function prismorLangChainTools<T extends LangChainToolLike>(
+  tools: T[],
+  opts: PrismorOptions = {},
+): T[] {
+  return tools.map((t) => prismorLangChainTool(t, opts));
+}

--- a/adapters/vercel-ai/src/index.ts
+++ b/adapters/vercel-ai/src/index.ts
@@ -6,17 +6,34 @@
  * throws PrismorBlocked (enforce mode) or logs and proceeds (observe mode).
  *
  * Quick start:
- *   const tools = prismorTools({ run_shell, search_web }, { subject: `user:${userId}` });
- *   const result = await generateText({ model, tools, prompt });
+ *   const tools = prismorTools({ run_shell, search_web });
+ *   // in your request handler — attribute every tool call to the caller:
+ *   await useSubject(`user:${userId}`, () =>
+ *     generateText({ model, tools, prompt }));
  */
 
 export interface PrismorOptions {
   /** URL of the running eval-server. Default: http://127.0.0.1:7071 */
   evalUrl?: string;
-  /** Subject for per-user attribution: "user:alice" or "user=alice;team=data" */
+  /**
+   * Subject for per-user attribution: "user:alice" or "user=alice;team=data".
+   * Resolved per call, in priority order: this option, then the ambient
+   * useSubject() context, then the PRISMOR_SUBJECT environment variable —
+   * mirroring the Python runtime's resolve_subject().
+   */
   subject?: string;
   /** "enforce" blocks denied calls; "observe" logs only. Default: "enforce" */
   mode?: "enforce" | "observe";
+  /**
+   * What to do when the eval-server cannot answer (unreachable, non-2xx,
+   * timeout). "closed" blocks the tool call; "open" allows it with a warning.
+   * Default: "closed" in enforce mode, "open" in observe mode — an enforced
+   * suspension must hold even when the sidecar is down, while observe-mode
+   * monitoring must never break the app.
+   */
+  failMode?: "open" | "closed";
+  /** Max milliseconds to wait for the eval-server. Default: 10000 */
+  timeoutMs?: number;
   /** Workspace path forwarded to the policy engine. Default: process.cwd() */
   workspace?: string;
   /** Framework identifier (e.g. "vercel-ai"). Default: "vercel-ai" */
@@ -56,19 +73,110 @@ const FAIL_OPEN_DECISION: PrismorDecision = {
   allow: true, reason: null, findings: [], blocking: null, subject: null,
 };
 
+// ── Ambient subject context ──────────────────────────────────────────────────
+
+interface SubjectStorage {
+  run<T>(subject: string, fn: () => T): T;
+  getStore(): string | undefined;
+}
+
+// AsyncLocalStorage exists on Node and on the major edge runtimes (Vercel Edge,
+// Cloudflare with nodejs_compat). Loaded lazily so merely importing this module
+// never fails on a runtime without it — only useSubject() itself requires it.
+let _subjectStorage: SubjectStorage | null | undefined;
+
+function subjectStorage(): SubjectStorage | null {
+  if (_subjectStorage !== undefined) return _subjectStorage;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { AsyncLocalStorage } = require("node:async_hooks");
+    _subjectStorage = new AsyncLocalStorage() as SubjectStorage;
+  } catch {
+    _subjectStorage = null;
+  }
+  return _subjectStorage;
+}
+
+/**
+ * Attribute every Prismor-guarded tool call inside `fn` to `subject` — the
+ * multi-tenant path for one deployed agent serving many users. Wrap the body
+ * of your request handler:
+ *
+ *   const tools = prismorTools({ run_shell });          // guard once, at module scope
+ *   await useSubject(`user:${userId}`, () =>            // per request
+ *     generateText({ model, tools, prompt }));
+ *
+ * The subject propagates through async calls (AsyncLocalStorage), so parallel
+ * requests with different users cannot bleed into each other. An explicit
+ * `subject` option on prismorTools() takes precedence over this context.
+ *
+ * Throws when the runtime has no AsyncLocalStorage: silently dropping the
+ * subject would let a user's calls escape their per-user policy. Pass the
+ * `subject` option per request instead on such runtimes.
+ */
+export function useSubject<T>(subject: string, fn: () => T): T {
+  const storage = subjectStorage();
+  if (!storage) {
+    throw new Error(
+      "[prismor] useSubject() requires AsyncLocalStorage, which this runtime does not provide. " +
+      "Pass prismorTools(tools, { subject }) per request instead.",
+    );
+  }
+  return storage.run(subject, fn);
+}
+
+function resolveSubject(explicit: string): string {
+  if (explicit) return explicit;
+  const ambient = subjectStorage()?.getStore();
+  if (ambient) return ambient;
+  if (typeof process !== "undefined" && process.env && process.env.PRISMOR_SUBJECT) {
+    return process.env.PRISMOR_SUBJECT;
+  }
+  return "";
+}
+
+// ── Evaluation ───────────────────────────────────────────────────────────────
+
+/** Resolve an eval-server failure according to failMode. */
+function onEvalFailure(
+  detail: string,
+  opts: Required<PrismorOptions>,
+): PrismorDecision {
+  if (opts.failMode === "closed") {
+    console.error(`[prismor] eval-server unavailable (${detail}) — failing closed`);
+    return {
+      allow: false,
+      reason: `eval-server unavailable (${detail}) — failing closed`,
+      findings: [],
+      blocking: null,
+      subject: null,
+    };
+  }
+  console.warn(`[prismor] eval-server unavailable (${detail}) — failing open`);
+  return FAIL_OPEN_DECISION;
+}
+
+function timeoutSignal(ms: number): AbortSignal | undefined {
+  if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(ms);
+  }
+  return undefined;
+}
+
 async function evaluate(
   toolName: string,
   args: Record<string, unknown>,
   opts: Required<PrismorOptions>,
   sessionId: string,
 ): Promise<PrismorDecision> {
+  const subject = resolveSubject(opts.subject);
   let res: Response;
   try {
     res = await fetch(`${opts.evalUrl}/v1/evaluate`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(opts.subject ? { "X-Prismor-Subject": opts.subject } : {}),
+        ...(subject ? { "X-Prismor-Subject": subject } : {}),
         ...(opts.agentName ? { "X-Prismor-Agent-Name": opts.agentName } : {}),
       },
       body: JSON.stringify({
@@ -79,33 +187,33 @@ async function evaluate(
         agent_name: opts.agentName,
         mode: opts.mode,
         session_id: sessionId,
-        subject: opts.subject,
+        subject,
         workspace: opts.workspace,
       }),
+      signal: timeoutSignal(opts.timeoutMs),
     });
   } catch (err) {
-    // eval-server unreachable (not started, crashed, network error) — this is
-    // the documented fail-open case. `fetch` throws for connection failures
-    // rather than resolving with a bad status, so it needs its own catch
-    // alongside the !res.ok branch below. See PrismorSec/prismor#136.
-    console.warn(`[prismor] eval-server unreachable (${(err as Error).message}) — failing open`);
-    return FAIL_OPEN_DECISION;
+    // eval-server unreachable (not started, crashed, network error, timeout) —
+    // `fetch` throws for connection failures rather than resolving with a bad
+    // status, so it needs its own catch alongside the !res.ok branch below.
+    return onEvalFailure((err as Error).message, opts);
   }
 
   if (!res.ok) {
-    // Server error — fail open (don't break the agent on infrastructure issues)
-    console.warn(`[prismor] eval-server returned ${res.status} — failing open`);
-    return FAIL_OPEN_DECISION;
+    return onEvalFailure(`HTTP ${res.status}`, opts);
   }
   return res.json() as Promise<PrismorDecision>;
 }
 
 function resolveOpts(opts: PrismorOptions): Required<PrismorOptions> {
   const agent = opts.agent ?? "vercel-ai";
+  const mode = opts.mode ?? "enforce";
   return {
     evalUrl: opts.evalUrl ?? "http://127.0.0.1:7071",
     subject: opts.subject ?? "",
-    mode: opts.mode ?? "enforce",
+    mode,
+    failMode: opts.failMode ?? (mode === "enforce" ? "closed" : "open"),
+    timeoutMs: opts.timeoutMs ?? 10_000,
     workspace: opts.workspace ?? process.cwd(),
     agent,
     agentName: opts.agentName ?? agent,
@@ -124,7 +232,7 @@ function sessionId(): string {
  *
  * @param toolName  The key name under which this tool is registered (used in telemetry).
  * @param tool      The tool object returned by the `tool()` helper.
- * @param opts      Prismor options (evalUrl, subject, mode, …).
+ * @param opts      Prismor options (evalUrl, subject, mode, failMode, …).
  */
 export function prismorTool<
   T extends { execute?: (...args: any[]) => any },
@@ -149,8 +257,9 @@ export function prismorTool<
  * Wrap every tool in a record — the idiomatic Vercel AI SDK pattern.
  *
  * @example
- * const tools = prismorTools({ run_shell, search_web }, { subject: `user:${userId}` });
- * const result = await generateText({ model, tools, prompt });
+ * const tools = prismorTools({ run_shell, search_web });
+ * await useSubject(`user:${userId}`, () =>
+ *   generateText({ model, tools, prompt }));
  */
 export function prismorTools<
   T extends Record<string, { execute?: (...args: any[]) => any }>,

--- a/adapters/vercel-ai/test/index.test.js
+++ b/adapters/vercel-ai/test/index.test.js
@@ -248,3 +248,69 @@ test("a tool with no execute() is returned unchanged", () => {
   const wrapped = prismorTool("noop", noop);
   assert.equal(wrapped, noop);
 });
+
+// ── LangChain JS / LangGraph JS ─────────────────────────────────────────────
+
+const { prismorLangChainTool, prismorLangChainTools } = require("../dist/index.js");
+
+function fakeLcTool(name) {
+  return {
+    name,
+    async invoke(input, _config) {
+      const args = input && input.type === "tool_call" ? input.args : input;
+      return `ran ${name}: ${JSON.stringify(args)}`;
+    },
+  };
+}
+
+test("langchain: guarded invoke() sends tool name and args to the eval-server", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const [tool] = prismorLangChainTools([fakeLcTool("fetch_url")]);
+    const out = await tool.invoke({ url: "https://example.com" });
+    assert.equal(out, 'ran fetch_url: {"url":"https://example.com"}');
+    assert.equal(requests[0].body.tool_name, "fetch_url");
+    assert.deepEqual(requests[0].body.arguments, { url: "https://example.com" });
+  });
+});
+
+test("langchain: ToolCall-shaped input (LangGraph ToolNode) unwraps args for evaluation", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const tool = prismorLangChainTool(fakeLcTool("run_shell"));
+    const call = { name: "run_shell", args: { command: "echo hi" }, id: "1", type: "tool_call" };
+    await tool.invoke(call);
+    assert.deepEqual(requests[0].body.arguments, { command: "echo hi" });
+  });
+});
+
+test("langchain: denied invoke() throws PrismorBlocked and never runs the tool", async () => {
+  await withMockFetch(
+    async () => ({ ok: true, json: async () => ({ allow: false, reason: "nope", findings: [], blocking: null, subject: null }) }),
+    async () => {
+      let ran = false;
+      const tool = prismorLangChainTool({ name: "run_shell", invoke: async () => { ran = true; } });
+      await assert.rejects(() => tool.invoke({ command: "rm -rf /" }), PrismorBlocked);
+      assert.equal(ran, false);
+    },
+  );
+});
+
+test("langchain: useSubject() attributes guarded invoke() calls", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const tool = prismorLangChainTool(fakeLcTool("fetch_url"));
+    await useSubject("user:alice", () => tool.invoke({ url: "https://a.com" }));
+    await useSubject("user:bob", () => tool.invoke({ url: "https://b.com" }));
+    assert.deepEqual(requests.map((r) => r.body.subject), ["user:alice", "user:bob"]);
+  });
+});
+
+test("langchain: guarding twice is a no-op", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const tool = prismorLangChainTool(prismorLangChainTool(fakeLcTool("fetch_url")));
+    await tool.invoke({ url: "https://a.com" });
+    assert.equal(requests.length, 1);
+  });
+});

--- a/adapters/vercel-ai/test/index.test.js
+++ b/adapters/vercel-ai/test/index.test.js
@@ -1,13 +1,17 @@
 "use strict";
 /**
  * Tests for the Vercel AI SDK adapter. No live eval-server — global fetch is
- * stubbed so these run standalone. Covers the fail-open regression from
- * PrismorSec/prismor#136: a network error from fetch() itself (eval-server
- * unreachable) must fail open, not throw.
+ * stubbed so these run standalone. Covers:
+ *  - failMode semantics: enforce fails CLOSED by default when the eval-server
+ *    is unavailable (a suspended user must stay suspended), observe fails open,
+ *    and failMode overrides either default. Supersedes the fail-open contract
+ *    from PrismorSec/prismor#136, which observe mode keeps.
+ *  - useSubject(): ambient per-request attribution, explicit-option precedence,
+ *    PRISMOR_SUBJECT fallback, and no bleed across concurrent requests.
  */
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { prismorTools, prismorTool, PrismorBlocked } = require("../dist/index.js");
+const { prismorTools, prismorTool, useSubject, PrismorBlocked } = require("../dist/index.js");
 
 function withMockFetch(impl, fn) {
   const original = globalThis.fetch;
@@ -17,9 +21,19 @@ function withMockFetch(impl, fn) {
   });
 }
 
+const ALLOW = { allow: true, reason: null, findings: [], blocking: null, subject: null };
+
+/** Mock fetch that records each request body and allows everything. */
+function recordingFetch(requests) {
+  return async (_url, init) => {
+    requests.push({ body: JSON.parse(init.body), headers: init.headers });
+    return { ok: true, json: async () => ALLOW };
+  };
+}
+
 test("allows the call when the eval-server returns allow: true", async () => {
   await withMockFetch(
-    async () => ({ ok: true, json: async () => ({ allow: true, reason: null, findings: [], blocking: null, subject: null }) }),
+    async () => ({ ok: true, json: async () => ALLOW }),
     async () => {
       const run_shell = { execute: async ({ command }) => `ran: ${command}` };
       const tools = prismorTools({ run_shell });
@@ -43,29 +57,188 @@ test("throws PrismorBlocked when the eval-server denies the call", async () => {
   );
 });
 
-test("fails open (does not throw) on a non-2xx response", async () => {
+// ── failMode ────────────────────────────────────────────────────────────────
+
+test("enforce mode fails CLOSED on a non-2xx response by default", async () => {
   await withMockFetch(
     async () => ({ ok: false, status: 503 }),
     async () => {
-      const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+      const run_shell = { execute: async () => "should not run" };
       const tools = prismorTools({ run_shell });
-      const result = await tools.run_shell.execute({ command: "rm -rf /" });
-      assert.equal(result, "ran: rm -rf /");
+      await assert.rejects(
+        () => tools.run_shell.execute({ command: "rm -rf /" }),
+        PrismorBlocked,
+      );
     },
   );
 });
 
-test("fails open (does not throw) when fetch itself rejects — #136 regression", async () => {
+test("enforce mode fails CLOSED when fetch itself rejects by default", async () => {
+  await withMockFetch(
+    async () => {
+      throw new TypeError("fetch failed");
+    },
+    async () => {
+      const run_shell = { execute: async () => "should not run" };
+      const tools = prismorTools({ run_shell });
+      await assert.rejects(
+        () => tools.run_shell.execute({ command: "rm -rf /" }),
+        PrismorBlocked,
+      );
+    },
+  );
+});
+
+test("observe mode fails open when the eval-server is unreachable — #136 contract", async () => {
   await withMockFetch(
     async () => {
       throw new TypeError("fetch failed");
     },
     async () => {
       const run_shell = { execute: async ({ command }) => `ran: ${command}` };
-      const tools = prismorTools({ run_shell });
-      // Before the fix, this threw the raw fetch error instead of failing open.
+      const tools = prismorTools({ run_shell }, { mode: "observe" });
       const result = await tools.run_shell.execute({ command: "rm -rf /" });
       assert.equal(result, "ran: rm -rf /");
+    },
+  );
+});
+
+test("failMode: 'open' overrides the enforce-mode default", async () => {
+  await withMockFetch(
+    async () => {
+      throw new TypeError("fetch failed");
+    },
+    async () => {
+      const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+      const tools = prismorTools({ run_shell }, { failMode: "open" });
+      const result = await tools.run_shell.execute({ command: "echo hi" });
+      assert.equal(result, "ran: echo hi");
+    },
+  );
+});
+
+test("failMode: 'closed' overrides the observe-mode default", async () => {
+  await withMockFetch(
+    async () => {
+      throw new TypeError("fetch failed");
+    },
+    async () => {
+      const run_shell = { execute: async () => "should not run" };
+      const tools = prismorTools({ run_shell }, { mode: "observe", failMode: "closed" });
+      await assert.rejects(
+        () => tools.run_shell.execute({ command: "echo hi" }),
+        PrismorBlocked,
+      );
+    },
+  );
+});
+
+test("a hung eval-server times out and follows failMode", async () => {
+  await withMockFetch(
+    (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(init.signal.reason));
+      }),
+    async () => {
+      const run_shell = { execute: async () => "should not run" };
+      const tools = prismorTools({ run_shell }, { timeoutMs: 30 });
+      await assert.rejects(
+        () => tools.run_shell.execute({ command: "echo hi" }),
+        PrismorBlocked,
+      );
+    },
+  );
+});
+
+// ── useSubject / subject resolution ─────────────────────────────────────────
+
+test("useSubject() attributes calls made inside its scope", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async ({ command }) => `ran: ${command}` };
+    const tools = prismorTools({ run_shell });
+    await useSubject("user:alice", () => tools.run_shell.execute({ command: "echo hi" }));
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].body.subject, "user:alice");
+    assert.equal(requests[0].headers["X-Prismor-Subject"], "user:alice");
+  });
+});
+
+test("subject is resolved per call, not at wrap time", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async () => "ok" };
+    const tools = prismorTools({ run_shell }); // wrapped once, outside any subject
+    await useSubject("user:alice", () => tools.run_shell.execute({ command: "a" }));
+    await useSubject("user:bob", () => tools.run_shell.execute({ command: "b" }));
+    assert.deepEqual(
+      requests.map((r) => r.body.subject),
+      ["user:alice", "user:bob"],
+    );
+  });
+});
+
+test("explicit subject option takes precedence over useSubject()", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async () => "ok" };
+    const tools = prismorTools({ run_shell }, { subject: "user:pinned" });
+    await useSubject("user:alice", () => tools.run_shell.execute({ command: "a" }));
+    assert.equal(requests[0].body.subject, "user:pinned");
+  });
+});
+
+test("PRISMOR_SUBJECT env is the fallback when no option or context is set", async () => {
+  const requests = [];
+  process.env.PRISMOR_SUBJECT = "user:envuser";
+  try {
+    await withMockFetch(recordingFetch(requests), async () => {
+      const run_shell = { execute: async () => "ok" };
+      const tools = prismorTools({ run_shell });
+      await tools.run_shell.execute({ command: "a" });
+      assert.equal(requests[0].body.subject, "user:envuser");
+    });
+  } finally {
+    delete process.env.PRISMOR_SUBJECT;
+  }
+});
+
+test("no subject → no subject field or header sent", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async () => "ok" };
+    const tools = prismorTools({ run_shell });
+    await tools.run_shell.execute({ command: "a" });
+    assert.equal(requests[0].body.subject, "");
+    assert.equal("X-Prismor-Subject" in requests[0].headers, false);
+  });
+});
+
+test("concurrent requests with different subjects do not bleed", async () => {
+  const requests = [];
+  await withMockFetch(
+    async (_url, init) => {
+      requests.push(JSON.parse(init.body));
+      await new Promise((r) => setTimeout(r, 5)); // force interleaving
+      return { ok: true, json: async () => ALLOW };
+    },
+    async () => {
+      const run_shell = { execute: async ({ command }) => command };
+      const tools = prismorTools({ run_shell });
+      const users = ["alice", "bob", "carol", "dave"];
+      await Promise.all(
+        users.map((u) =>
+          useSubject(`user:${u}`, async () => {
+            for (let i = 0; i < 5; i++) {
+              await tools.run_shell.execute({ command: u });
+            }
+          }),
+        ),
+      );
+      for (const req of requests) {
+        assert.equal(req.subject, `user:${req.arguments.command}`);
+      }
+      assert.equal(requests.length, 20);
     },
   );
 });

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -12,18 +12,20 @@ on your existing agent or controller object, with no changes to your tool logic.
 | LangChain / LangGraph | Python | `pip install "prismor[langchain]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | CrewAI | Python | `pip install "prismor[crewai]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
-| Vercel AI SDK | TypeScript | `npm install prismor-warden` | `prismorTools(tools, opts)` | `{ subject: "user:alice" }` |
+| Vercel AI SDK | TypeScript | `npm install prismor-warden` | `prismorTools(tools)` | `useSubject("user:alice", fn)` |
+| Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Prismor-Subject` header |
 
 > The Python adapters ship inside the `prismor` package (needs `>= 1.14.2`) —
 > the extra just pulls the framework itself. `prismor[frameworks]` installs all
-> four. On npm it is `prismor` (the registry blocks bare `prismor` as too similar to `prisma`).
-| Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Prismor-Subject` header |
+> four. On npm the package is `prismor-warden`.
 
-The Python multi-tenant pattern: guard once at startup with no bound subject,
-then wrap each request with `use_subject`. A context var threads the subject
-through the evaluation pipeline — thread-safe and async-safe.
+The multi-tenant pattern is the same in every language: guard once at startup
+with no bound subject, then wrap each request with `use_subject` (Python) or
+`useSubject` (TypeScript). A context variable (`ContextVar` / `AsyncLocalStorage`)
+threads the subject through the evaluation pipeline — thread-safe and
+async-safe, so concurrent requests for different users cannot bleed.
 
-For non-Python languages: pass `subject` per call in the request body or
+For raw HTTP callers: pass `subject` per call in the request body or
 `X-Prismor-Subject` header. The eval-server resolves it identically.
 
 ## What "guard" does
@@ -73,8 +75,10 @@ POST /v1/evaluate
 
 The Python policy engine, IAM, and telemetry run inside the sidecar. Adapters
 in other languages are ~25 lines of HTTP client code with no Python dependency.
-The adapter **fails open** if the eval-server is down — agents are never broken
-by infrastructure issues.
+If the eval-server is down, the shipped TypeScript adapter **fails closed in
+enforce mode** (a suspension or deny keeps holding) and **open in observe mode**
+(monitoring never breaks the agent), overridable via `failMode`. Raw HTTP
+callers choose their own failure behavior — match these defaults.
 
 Validated live on an Ubuntu EC2 instance with real OpenAI function calls:
 
@@ -138,15 +142,26 @@ Add `user:<id>` or `team:<id>` keys to `.prismor/iam.yaml`:
 
 ```yaml
 agents:
+  # bob keeps every tool except shell + network
   user:bob:
+    allowed_tools: ["*"]
     deny_tools: [Bash]
+    deny_network: true
+    allowed_paths: ["**"]
+
+  # suspend a user entirely: empty allowlist blocks every tool call
+  user:mallory:
+    allowed_tools: []
+    deny_tools: []
     deny_network: true
     allowed_paths: ["**"]
 ```
 
 When a request runs under `use_subject("user:bob")`, bob's profile is selected
-automatically — no env var, no code change. Users without a profile get the
-org-wide defaults.
+automatically — no env var, no code change, and no per-user re-guarding of
+tools. Users without a profile get the org-wide defaults. Tool names match
+what the framework sees (the wrapped function or tool's name, e.g.
+`fetch_url`), so one profile applies across every framework the user reaches.
 
 ## Per-framework guides
 

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -13,6 +13,7 @@ on your existing agent or controller object, with no changes to your tool logic.
 | CrewAI | Python | `pip install "prismor[crewai]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
 | Vercel AI SDK | TypeScript | `npm install prismor-warden` | `prismorTools(tools)` | `useSubject("user:alice", fn)` |
+| LangChain JS / LangGraph JS | TypeScript | `npm install prismor-warden` | `prismorLangChainTools([...])` | `useSubject("user:alice", fn)` |
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Prismor-Subject` header |
 
 > The Python adapters ship inside the `prismor` package (needs `>= 1.14.2`) —
@@ -49,6 +50,7 @@ Regardless of framework, every adapter does the same three things:
 | CrewAI | `tool.func` → `tool._run` → `tool.run` (first found) | before the tool implementation runs |
 | browser-use | `Registry.execute_action` | before Playwright executes any browser action |
 | Vercel AI SDK | `tool.execute` | before the tool body runs, after the LLM emits the tool call |
+| LangChain JS / LangGraph JS | `tool.invoke` (StructuredTool) | before the tool runs — covers LangGraph's `ToolNode` / `createReactAgent` |
 | HTTP (any language) | caller-side `POST /v1/evaluate` | before calling the tool implementation |
 
 ## Eval-server (non-Python languages)

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -61,11 +61,8 @@ const fetch_url = tool({
   execute: async ({ url }) => { /* your implementation */ },
 });
 
-// Wrap all tools — every execute() is now policy-checked before it runs
-const tools = prismorTools(
-  { run_shell, fetch_url },
-  { subject: `user:${userId}` }
-);
+// Wrap all tools once, at module scope — every execute() is now policy-checked
+const tools = prismorTools({ run_shell, fetch_url });
 
 const result = await generateText({ model: openai("gpt-4o-mini"), tools, prompt });
 ```
@@ -75,15 +72,18 @@ const result = await generateText({ model: openai("gpt-4o-mini"), tools, prompt 
 A denied call in enforce mode throws `PrismorBlocked`:
 
 ```typescript
-import { PrismorBlocked, prismorTools } from "prismor-warden";
+import { PrismorBlocked, prismorTools, useSubject } from "prismor-warden";
+
+const tools = prismorTools(myTools); // once, at module scope
 
 // In a Next.js API route:
 export async function POST(req: Request) {
-  const { prompt, userId } = await req.json();
-  const tools = prismorTools(myTools, { subject: `user:${userId}` });
+  const { prompt } = await req.json();
+  const session = await getSession(req);
 
   try {
-    const result = await generateText({ model, tools, prompt });
+    const result = await useSubject(`user:${session.userId}`, () =>
+      generateText({ model, tools, prompt }));
     return Response.json({ text: result.text });
   } catch (e) {
     if (e instanceof PrismorBlocked) {
@@ -96,17 +96,25 @@ export async function POST(req: Request) {
 
 ## Per-user (multi-tenant)
 
-Pass `subject` per request. The subject is forwarded to the eval-server where
-it is resolved to per-user IAM policies and attributed in telemetry:
+Wrap each request handler in `useSubject()` — the TypeScript equivalent of the
+Python adapters' `use_subject()`. Every guarded tool call inside the wrapped
+scope is attributed to that user, forwarded to the eval-server, resolved to
+per-user IAM policies, and recorded in telemetry:
 
 ```typescript
-// Each incoming request gets its own subject — no shared state
-const tools = prismorTools(myTools, {
-  subject: `user:${session.userId}`,
-  mode: "enforce",
-  workspace: "/path/to/project",
-});
+const tools = prismorTools(myTools); // guard once — no per-request rebuilding
+
+export async function POST(req: Request) {
+  const session = await getSession(req);
+  return useSubject(`user:${session.userId}`, () => handleAgentTurn(tools, req));
+}
 ```
+
+The subject rides on `AsyncLocalStorage`, so concurrent requests with different
+users cannot bleed into each other. Resolution per call, highest priority
+first: the `subject` option on `prismorTools()`, the ambient `useSubject()`
+context, then the `PRISMOR_SUBJECT` environment variable — the same order as
+the Python runtime's `resolve_subject()`.
 
 Subjects are `"user:<id>"` or the structured form `"user=alice;team=data"`.
 Users without an explicit IAM profile fall through to org-wide defaults.
@@ -116,10 +124,13 @@ Users without an explicit IAM profile fall through to org-wide defaults.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `evalUrl` | `string` | `http://127.0.0.1:7071` | Eval-server URL |
-| `subject` | `string` | `""` | End-user identity: `"user:alice"` |
+| `subject` | `string` | `""` | End-user identity: `"user:alice"` (overrides `useSubject()`) |
 | `mode` | `"enforce"\|"observe"` | `"enforce"` | Enforce blocks; observe logs only |
+| `failMode` | `"open"\|"closed"` | `"closed"` in enforce, `"open"` in observe | Behavior when the eval-server is unavailable |
+| `timeoutMs` | `number` | `10000` | Max wait for the eval-server per call |
 | `workspace` | `string` | `process.cwd()` | Project path for policy + IAM lookup |
 | `agent` | `string` | `"vercel-ai"` | Agent label in telemetry |
+| `agentName` | `string` | same as `agent` | Per-instance name for kill-switch / per-agent controls |
 | `eventType` | `string` | `"shell"` | `shell`, `network`, `file_write`, `file_read` |
 
 ## Event type mapping
@@ -148,18 +159,32 @@ Or set a default for all tools when using `prismorTools`:
 const tools = prismorTools(myTools, { eventType: "network" });
 ```
 
-## Fail-open design
+## Fail mode
 
-If the eval-server is unreachable (down, not yet started, crashed), the adapter
-**warns and allows** — it never breaks the agent because of infrastructure
-issues. Run `prismor eval-server` as a long-lived sidecar process or a Docker
-container to minimise downtime.
+If the eval-server cannot answer (down, not yet started, crashed, or slower
+than `timeoutMs`), the adapter follows `failMode`:
+
+- **Enforce mode fails closed** (default): the call is blocked with
+  `PrismorBlocked`. Enforcement — e.g. a suspended user or a per-user tool
+  deny — keeps holding even when the sidecar is down.
+- **Observe mode fails open** (default): monitoring never breaks the agent.
+- Override either default with `failMode: "open"` or `"closed"`.
 
 ```typescript
-// Adapter behaviour when eval-server is down:
-// console.warn("[prismor] eval-server returned 503 — failing open")
+// Enforce mode, eval-server down:
+// console.error("[prismor] eval-server unavailable (fetch failed) — failing closed")
+// → throw PrismorBlocked; tool.execute() never runs
+
+// Observe mode (or failMode: "open"), eval-server down:
+// console.warn("[prismor] eval-server unavailable (fetch failed) — failing open")
 // → tool.execute() is called normally
 ```
+
+Run `prismor eval-server` as a long-lived sidecar process or a Docker container
+to minimise downtime.
+
+> **Changed in 0.3.0:** enforce mode previously failed open. Pass
+> `failMode: "open"` to restore the old behavior.
 
 ## Modes
 

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -200,6 +200,25 @@ Start in `observe` to understand your agent's blast radius without disrupting
 users. Switch to `enforce` once confident. Policy is YAML — change it without
 redeploying TypeScript code.
 
+## LangChain JS / LangGraph JS
+
+`prismor-warden` also guards LangChain JS tools in place — and therefore
+LangGraph agents, whose `ToolNode` / `createReactAgent` execute those tools:
+
+```typescript
+import { prismorLangChainTools, useSubject } from "prismor-warden";
+
+const tools = prismorLangChainTools([run_shell, fetch_url]);
+const agent = createReactAgent({ llm, tools });
+await useSubject(`user:${userId}`, () => agent.invoke({ messages }));
+```
+
+`prismorLangChainTool(s)` wraps the tool's `invoke()` (handling both raw args
+and LangGraph's ToolCall-shaped input) and returns the same object, so
+existing references stay guarded. Denied calls throw `PrismorBlocked`;
+LangGraph's `ToolNode` feeds the error back to the model as a `ToolMessage`
+by default, so runs recover gracefully. All options in the table above apply.
+
 ## Other languages
 
 The eval-server speaks plain JSON over HTTP, so any language can act as an

--- a/prismor/runtime/iam.py
+++ b/prismor/runtime/iam.py
@@ -255,6 +255,18 @@ def check_iam(
         finding["title"] = finding["title"].replace(
             "[scoped agent]", f"[iam:{agent_id}]"
         )
+        # The shared scoped-rules copy says "for this session", which misleads
+        # for identity-keyed profiles: a user:<id> deny follows the user across
+        # every session and agent. Name the actual scope in user-facing text.
+        if agent_id.startswith("user:"):
+            scope = f"for user '{agent_id[5:]}'"
+        elif agent_id.startswith("team:"):
+            scope = f"for team '{agent_id[5:]}'"
+        else:
+            scope = f"for agent identity '{agent_id}'"
+        for key in ("title", "evidence"):
+            if isinstance(finding.get(key), str):
+                finding[key] = finding[key].replace("for this session", scope)
     return finding
 
 


### PR DESCRIPTION
## What

Two gaps in the Vercel AI SDK adapter vs the Python adapters, both blocking per-user access management for multi-tenant agents:

1. **No ambient subject context.** `subject` was a static option per `prismorTools()` call, so multi-tenant apps had to rebuild tool wrappers on every request. This adds `useSubject(subject, fn)` backed by `AsyncLocalStorage` — guard tools once at module scope, wrap each request handler, and every guarded call inside is attributed to that user. Subject resolution is now per-call with the same priority as the Python runtime's `resolve_subject()`: explicit option > ambient context > `PRISMOR_SUBJECT` env.

2. **Enforce mode failed open.** If the eval-server was down, every call was allowed — meaning a per-user suspension or tool deny silently stopped holding. Enforce mode now **fails closed** by default (observe mode keeps the #136 fail-open contract, since monitoring should never break the app). New `failMode: "open" | "closed"` overrides either default, and a new `timeoutMs` (10s default) stops a hung sidecar from hanging tool calls forever.

## Breaking change

Enforce mode previously failed open on eval-server failure; pass `failMode: "open"` to restore. Version bumped 0.2.0 → 0.3.0, README documents the change.

## Testing

- 15/15 unit tests (`node --test`, mocked fetch): failMode matrix (enforce/observe × default/override), timeout abort, subject priority, per-call resolution, env fallback, header omission, and a 4-user × 5-call concurrency test asserting zero subject bleed.
- Live integration against a real `prismor eval-server` with a `user:alice` IAM deny profile: alice blocked with `iam:user:alice` finding, bob allowed on the same module-scope tools via `useSubject`, and a dead eval-server port correctly failed closed.
- `tsc` clean.