### PR TITLE
feat(runtime): add Grok Build (xAI) coding-agent hook integration

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -2,7 +2,7 @@
 
 How Prismor integrates with each major AI coding agent — what ships today, what's planned, and what mechanism each agent exposes for runtime security monitoring.
 
-_Last updated: 2026-06-17._
+_Last updated: 2026-07-11._
 
 ---
 
@@ -28,6 +28,7 @@ _Generated from `prismor/runtime/integrations/registry.yaml` — do not edit by 
 | Hermes (NousResearch gateway) | coding-agent | hook-config | ✅ | `throw` |
 | Codex (OpenAI) | coding-agent | hook-config | ✅ | `exit-2` |
 | GitHub Copilot CLI | coding-agent | hook-config | ✅ | `json-permission` |
+| Grok Build (xAI) | coding-agent | hook-config | ✅ | `exit-2` |
 | Gemini CLI (Google) | coding-agent | hook-config | 🟡 | `exit-2` |
 | OpenCode | coding-agent | sdk | 🟡 | `throw` |
 | Kiro (AWS) | coding-agent | hook-config | 🟡 | `exit-2` |
@@ -126,6 +127,17 @@ Prismor integrates with Hermes at two complementary layers:
 - **Minimum version: `codex-cli` ≥ `0.141.0-alpha.1`.** Earlier versions, including the `0.140.0` stable release, have an upstream bug ([openai/codex#26383](https://github.com/openai/codex/issues/26383), [#26452](https://github.com/openai/codex/issues/26452)) where `codex exec` never dispatches *any* hook — not because of config shape, matcher syntax, or hook trust, but because `--dangerously-bypass-hook-trust` silently failed to propagate to the exec thread, so hooks (which require persisted trust) were dropped before dispatch even without `exec` printing an error. Fixed in [openai/codex#26434](https://github.com/openai/codex/pull/26434), merged 2026-06-16, first shipped in `rust-v0.141.0-alpha.1`. As of this writing that fix has not yet reached a stable release tag — pin to an alpha ≥ that build if you need working Codex hooks today, and watch for the next `0.141.x` (or later) stable release.
 - **Required feature flag:** Codex's hook dispatcher additionally requires `[features].hooks = true` (previously `codex_hooks`, deprecated in current stable) in the **user-level** `~/.codex/config.toml` — read from nowhere else, not even a project-scoped `.codex/config.toml`. Without it, hooks are silent no-ops: no error, no warning, every tool call passes straight through. `install_hooks()` now sets/migrates this automatically as of PrismorSec/prismor#149 (verified live against `codex-cli 0.142.5`: a destructive command that should have been blocked instead ran and deleted its target file before this fix).
 - **Code:** `prismor/runtime/hooks.py` `_merge_codex()`, `_strip_codex()`, `_normalize_codex()`, `_ensure_codex_hooks_feature_enabled()`.
+
+### Grok Build (xAI)
+
+- **Config:** `~/.grok/hooks/prismor.json` (user) or `<repo>/.grok/hooks/prismor.json` (project). Grok reads a directory of independent hook files (`~/.grok/hooks/*.json` / `<repo>/.grok/hooks/*.json`), so Prismor owns a dedicated file instead of merging into a shared one.
+- **Events hooked:** `UserPromptSubmit`, `PreToolUse`, `PostToolUse`. `PreToolUse` is Grok's only blocking event.
+- **Matchers installed:** `Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*`, following Claude Code's tool-name taxonomy — Grok Build natively reads `.claude/settings.json` and `.cursor/hooks.json` as a convenience, which strongly implies (but does not itself confirm) that its own built-in tool names match Claude Code's.
+- **Blocking:** exit 2 from hook → block; stdout `{"decision": "deny", "reason": "..."}` supplies the reason shown to the user. Exit 0 → allow. Any other exit code, a crash, or a timeout fails **open** on Grok's side (documented behavior, not a Prismor choice).
+- **Sweep target:** `~/.grok/`.
+- **Not yet verified against a live `grok` install.** This integration is built entirely from [docs.x.ai/build/features/hooks](https://docs.x.ai/build/features/hooks) and [docs.x.ai/build/overview](https://docs.x.ai/build/overview) — no `grok` binary was available to smoke-test against at implementation time. Before relying on this in `enforce` mode, run `grok inspect` to confirm the real built-in tool names, and verify a deliberately blocked command is actually denied end to end (the same live check done for Codex above).
+- **Project-hook trust:** Grok requires trust before running project-level hooks (`/hooks-trust` or `--trust` inside `grok`, recorded in `~/.grok/trusted_folders.toml`). This is a one-time manual step Prismor does not automate.
+- **Code:** `prismor/runtime/hooks.py` `_merge_grok()`, `_strip_grok()`, `_normalize_grok()`.
 
 ---
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1008,7 +1008,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                         "permissionDecisionReason": reason,
                     }) + "\n")
                     return
-                # No inline-approval surface (cursor/windsurf/codex): fail closed.
+                # No inline-approval surface (cursor/windsurf/codex/grok): fail closed.
                 sys.stderr.write(f"Prismor requires approval for this action (no approval surface — blocked): {reason}\n")
                 raise SystemExit(2)
 
@@ -1043,6 +1043,12 @@ def main(argv: Optional[List[str]] = None) -> None:
                 if args.agent == "copilot":
                     # Copilot CLI reads permissionDecision from stdout; exit 2 is ignored.
                     sys.stdout.write(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}) + "\n")
+                elif args.agent == "grok":
+                    # Grok Build reads {"decision": "deny", "reason": ...} from stdout
+                    # AND requires exit code 2 (unlike Copilot, which ignores exit code).
+                    sys.stdout.write(json.dumps({"decision": "deny", "reason": reason}) + "\n")
+                    sys.stderr.write(f"Prismor blocked this action: [{blocking['severity']}] {blocking['title']}\n")
+                    raise SystemExit(2)
                 else:
                     sys.stderr.write(f"Prismor blocked this action: [{blocking['severity']}] {blocking['title']}\n")
                     if blocking.get("evidence"):
@@ -2020,7 +2026,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── deps ──────────────────────────────────────────────────────────
@@ -2150,7 +2156,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
@@ -2164,13 +2170,13 @@ def build_parser() -> argparse.ArgumentParser:
         "`prismor cloak install`.",
     )
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -2527,6 +2533,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".codex" / "hooks.json"
     if agent == "copilot":
         return workspace / ".github" / "copilot" / "hooks.json"
+    if agent == "grok":
+        return workspace / ".grok" / "hooks" / "prismor.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -2634,7 +2642,7 @@ def _print_dashboard(days: int = 7) -> None:
         risk_color = _RED if latest_risk >= 50 else _YELLOW if latest_risk >= 20 else _GREEN
 
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:
@@ -2933,7 +2941,7 @@ def _run_doctor(workspace: Path, as_json: bool = False) -> None:
 
     # 1. IDE hooks — per-agent config with the dispatcher wired in.
     agents_with_hooks: List[str] = []
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -3065,7 +3073,7 @@ def _print_status_overview(workspace: Path) -> None:
     # Hooks + mode
     agents_with_hooks: List[str] = []
     mode: Optional[str] = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from prismor.runtime.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"]
 
 
 def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[Dict[str, Any], bool]:
@@ -28,6 +28,8 @@ def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[D
         return _strip_codex(config, marker)
     if agent == "copilot":
         return _strip_copilot(config, marker)
+    if agent == "grok":
+        return _strip_grok(config, marker)
     return _strip_windsurf(config, marker)
 
 
@@ -54,6 +56,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_codex(config, command)
         elif current_agent == "copilot":
             config = _merge_copilot(config, command)
+        elif current_agent == "grok":
+            config = _merge_grok(config, command)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -222,6 +226,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_codex(payload, session_id, workspace)
     elif agent == "copilot":
         event = _normalize_copilot(payload, session_id)
+    elif agent == "grok":
+        event = _normalize_grok(payload, session_id, workspace)
     else:
         event = _normalize_cursor(payload, session_id)
     if isinstance(event, dict) and event.get("type") == "shell" and event.get("command"):
@@ -328,6 +334,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".codex" / "hooks.json"
         if agent == "copilot":
             return workspace / ".github" / "copilot" / "hooks.json"
+        if agent == "grok":
+            return workspace / ".grok" / "hooks" / "prismor.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -342,6 +350,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".codex" / "hooks.json"
     if agent == "copilot":
         return home / ".copilot" / "hooks.json"
+    if agent == "grok":
+        return home / ".grok" / "hooks" / "prismor.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -770,6 +780,23 @@ def _merge_codex(config: Dict[str, Any], command: str) -> Dict[str, Any]:
     return {**config, "hooks": hooks}
 
 
+def _merge_grok(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    hooks = dict(config.get("hooks", {}))
+    hooks["UserPromptSubmit"] = _merge_claude_entries(
+        hooks.get("UserPromptSubmit", []),
+        {"matcher": "*", "hooks": [{"type": "command", "command": command}]},
+    )
+    for event_name in ["PreToolUse", "PostToolUse"]:
+        hooks[event_name] = _merge_claude_entries(
+            hooks.get(event_name, []),
+            {
+                "matcher": "Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*",
+                "hooks": [{"type": "command", "command": command}],
+            },
+        )
+    return {**config, "hooks": hooks}
+
+
 def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
     hooks = dict(config.get("hooks", {}))
     removed = False
@@ -785,6 +812,25 @@ def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any],
 
 
 def _strip_codex(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        cleaned = []
+        for entry in entries:
+            inner_hooks = entry.get("hooks", [])
+            filtered = [h for h in inner_hooks if marker not in h.get("command", "")]
+            if len(filtered) < len(inner_hooks):
+                removed = True
+            if filtered:
+                cleaned.append({**entry, "hooks": filtered})
+        hooks[event_name] = cleaned
+    return {**config, "hooks": hooks}, removed
+
+
+def _strip_grok(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
     hooks = dict(config.get("hooks", {}))
     removed = False
     for event_name in list(hooks.keys()):
@@ -881,6 +927,55 @@ def _normalize_codex(payload: Dict[str, Any], session_id: str, workspace: Path) 
         tool_name=tool_name,
         tool_input=tool_input,
         response=payload.get("tool_response", payload.get("response")),
+        is_post=(hook_event == "PostToolUse"),
+        workspace=workspace,
+    )
+    if mcp_event is not None:
+        return mcp_event
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _normalize_grok(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
+    hook_event = payload.get("hookEventName") or payload.get("hook_event_name") or "unknown"
+    tool_name = payload.get("toolName") or payload.get("tool_name") or ""
+    tool_input = payload.get("toolInput") or payload.get("tool_input") or {}
+    base = {
+        "ts": payload.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "agent": "grok",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+    }
+    if hook_event == "UserPromptSubmit":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    if tool_name == "Bash":
+        return {
+            **base,
+            "type": "shell",
+            "command": tool_input.get("command", ""),
+            "stdout": payload.get("stdout", ""),
+            "stderr": payload.get("stderr", ""),
+        }
+    if tool_name == "Read":
+        return {**base, "type": "file_read", "path": tool_input.get("file_path") or tool_input.get("path", "")}
+    if tool_name in {"Edit", "MultiEdit", "Write"}:
+        return {
+            **base,
+            "type": "file_write",
+            "path": tool_input.get("file_path") or tool_input.get("path", ""),
+            "content": (
+                _join_edits(tool_input.get("edits", []))
+                or tool_input.get("content", "")
+                or tool_input.get("new_string", "")
+            ),
+        }
+    if tool_name in {"WebFetch", "WebSearch"}:
+        return {**base, "type": "network", "url": tool_input.get("url", ""), "response": payload.get("response", "")}
+    mcp_event = _classify_mcp_event(
+        base=base,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        response=payload.get("toolResponse", payload.get("response")),
         is_post=(hook_event == "PostToolUse"),
         workspace=workspace,
     )

--- a/prismor/runtime/integrations/registry.yaml
+++ b/prismor/runtime/integrations/registry.yaml
@@ -108,6 +108,19 @@ agents:
     normalizer: _normalize_copilot
     sources: ["https://docs.github.com/en/copilot/reference/hooks-configuration"]
 
+  - id: grok
+    name: Grok Build (xAI)
+    kind: coding-agent
+    surface: hook-config
+    status: shipped
+    config_paths: { project: ".grok/hooks/prismor.json", user: "~/.grok/hooks/prismor.json" }
+    events: [UserPromptSubmit, PreToolUse, PostToolUse]
+    blocking: exit-2
+    normalizer: _normalize_grok
+    sweep_dir: "~/.grok/"
+    notes: "Also natively reads .claude/settings.json and .cursor/hooks.json. Tool-name matchers assume Claude-Code-compatible tool names (Bash/Read/Edit/Write/...) by analogy; not yet verified against a live grok binary."
+    sources: ["https://docs.x.ai/build/features/hooks", "https://docs.x.ai/build/overview"]
+
   # ── Coding agents — roadmap (hook surface exists, adapter not built) ──────
   - id: gemini
     name: Gemini CLI (Google)

--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -236,6 +236,7 @@ def _detect_agents(target: Path) -> dict:
         "openclaw": shutil.which("openclaw") is not None or (target / ".openclaw").exists(),
         "hermes":   shutil.which("hermes") is not None or (target / ".hermes").exists(),
         "codex":    shutil.which("codex") is not None or (target / ".codex").exists() or (home / ".codex").exists(),
+        "grok":     shutil.which("grok") is not None or (target / ".grok").exists() or (home / ".grok").exists(),
     }
 
 
@@ -307,6 +308,7 @@ def _step_agents(target: Path) -> list:
         {"name": "openclaw", "label": "OpenClaw",    "on": detected.get("openclaw", False)},
         {"name": "hermes",   "label": "Hermes",      "on": detected.get("hermes", False)},
         {"name": "codex",    "label": "Codex",       "on": detected.get("codex", False)},
+        {"name": "grok",     "label": "Grok Build",  "on": detected.get("grok", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True

--- a/prismor/runtime/sweep.py
+++ b/prismor/runtime/sweep.py
@@ -53,6 +53,7 @@ TOOL_DIRS: dict[str, Path] = {
     "claude": Path.home() / ".claude",
     "trae": Path.home() / ".trae",
     "kilocode": Path.home() / ".kilocode",
+    "grok": Path.home() / ".grok",
 }
 
 # Config files that should NEVER be redacted (they hold keys the tools need)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -259,6 +259,7 @@ def detect_agents(target):
         "windsurf": (td/".windsurf").exists() or (home/".codeium").exists(),
         "openclaw": shutil.which("openclaw") is not None or (td/".openclaw").exists() or (home/".openclaw").exists(),
         "hermes":   shutil.which("hermes") is not None or (td/".hermes").exists() or (home/".hermes").exists(),
+        "grok":     shutil.which("grok") is not None or (td/".grok").exists() or (home/".grok").exists(),
     }
 
 # ── Severity colors ──────────────────────────────────────────────────────────
@@ -325,6 +326,7 @@ def step_agents(target):
         {"name": "windsurf", "label": "Windsurf",     "on": detected.get("windsurf", False)},
         {"name": "openclaw", "label": "OpenClaw",     "on": detected.get("openclaw", False)},
         {"name": "hermes",   "label": "Hermes",       "on": detected.get("hermes", False)},
+        {"name": "grok",     "label": "Grok Build",   "on": detected.get("grok", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -15,6 +15,7 @@ from prismor.runtime.hooks import (
     _strip_claude,
     _strip_codex,
     _strip_cursor,
+    _strip_grok,
     _strip_windsurf,
     install_hooks,
     normalize_payload,
@@ -137,6 +138,36 @@ class TestStripCodex(unittest.TestCase):
         self.assertFalse(removed)
 
 
+class TestStripGrok(unittest.TestCase):
+    """Test _strip_grok removes Prismor entries."""
+
+    def test_removes_prismor_hooks(self):
+        marker = "/repo/prismor/runtime/cli.py"
+        config = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*",
+                        "hooks": [
+                            {"type": "command", "command": f'python3 "{marker}" hook-dispatch --agent grok'},
+                            {"type": "command", "command": "other-tool --check"},
+                        ],
+                    }
+                ]
+            }
+        }
+        result, removed = _strip_grok(config, marker)
+        self.assertTrue(removed)
+        self.assertEqual(len(result["hooks"]["PreToolUse"]), 1)
+        self.assertEqual(len(result["hooks"]["PreToolUse"][0]["hooks"]), 1)
+        self.assertEqual(result["hooks"]["PreToolUse"][0]["hooks"][0]["command"], "other-tool --check")
+
+    def test_no_change(self):
+        config = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "unrelated"}]}]}}
+        result, removed = _strip_grok(config, "/repo/prismor/runtime/cli.py")
+        self.assertFalse(removed)
+
+
 class TestStripWindsurf(unittest.TestCase):
     """Test _strip_windsurf removes Prismor entries."""
 
@@ -195,6 +226,8 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
             config_path = self.workspace / ".cursor" / "hooks.json"
         elif agent == "codex":
             config_path = self.workspace / ".codex" / "hooks.json"
+        elif agent == "grok":
+            config_path = self.workspace / ".grok" / "hooks" / "prismor.json"
         else:
             config_path = self.workspace / ".windsurf" / "hooks.json"
         self.assertTrue(config_path.exists())
@@ -230,6 +263,9 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
 
     def test_codex_roundtrip(self):
         self._roundtrip("codex")
+
+    def test_grok_roundtrip(self):
+        self._roundtrip("grok")
 
     def test_codex_install_enables_hooks_feature_flag_on_fresh_config(self):
         # Regression for PrismorSec/prismor#149: without [features].hooks set
@@ -656,6 +692,50 @@ class TestNormalizePayloadCodex(unittest.TestCase):
             },
         }
         result = normalize_payload(agent="codex", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "file_write")
+        self.assertIn("lodash", event["content"])
+
+
+class TestNormalizePayloadGrok(unittest.TestCase):
+    """Test Grok Build payload normalization (camelCase field names per docs.x.ai/build/features/hooks)."""
+
+    def test_user_prompt(self):
+        payload = {
+            "hookEventName": "UserPromptSubmit",
+            "sessionId": "grok-1",
+            "prompt": "Review this change",
+        }
+        result = normalize_payload(agent="grok", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "prompt")
+        self.assertEqual(event["prompt"], "Review this change")
+        self.assertEqual(event["agent"], "grok")
+
+    def test_bash_tool(self):
+        payload = {
+            "hookEventName": "PreToolUse",
+            "sessionId": "grok-2",
+            "toolName": "Bash",
+            "toolInput": {"command": "git status"},
+        }
+        result = normalize_payload(agent="grok", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "git status")
+
+    def test_edit_tool_maps_to_file_write(self):
+        payload = {
+            "hookEventName": "PreToolUse",
+            "sessionId": "grok-3",
+            "toolName": "Edit",
+            "toolInput": {
+                "file_path": "/src/package.json",
+                "old_string": '"dependencies": {}',
+                "new_string": '"dependencies": {"lodash": "4.17.4"}',
+            },
+        }
+        result = normalize_payload(agent="grok", payload=payload, workspace=Path("/tmp"))
         event = result["event"]
         self.assertEqual(event["type"], "file_write")
         self.assertIn("lodash", event["content"])


### PR DESCRIPTION
## Summary
- Adds Grok Build (xAI) as a supported coding-agent hook integration, following the same `install-hooks`/`hook-dispatch` pipeline used for Claude Code, Cursor, Windsurf, OpenClaw, Hermes, Codex, and Copilot CLI.
- Writes a dedicated `.grok/hooks/prismor.json` hook file (Grok reads a directory of independent hook files rather than one shared config), registers `UserPromptSubmit`/`PreToolUse`/`PostToolUse`, and implements Grok's documented `{"decision": "deny", "reason": "..."}` stdout + exit-2 response contract for `PreToolUse` (its only blocking event).
- Fixes 8 call sites in `cli.py` (`--agent` argparse `choices=[...]` for `scan`/`install-hooks`/`uninstall-hooks`/`hook-dispatch`, `_find_hook_config`, and 3 dashboard/status loops) that hardcoded the agent list separately from `hooks.py`'s `_SUPPORTED_AGENTS` — without this, `--agent grok` would 404 at the CLI layer even with the hooks.py support wired in.
- Registers the integration in `registry.yaml`, `sweep.py` (`TOOL_DIRS`), `setup_wizard.py`, `scripts/setup.py`, and documents it in `AGENT_INTEGRATIONS.md`.

## Caveat
Built entirely from `docs.x.ai/build/features/hooks` and `docs.x.ai/build/overview` — no `grok` binary was available to smoke-test against. Tool-name matchers (`Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*`) assume Claude-Code-compatible tool names by analogy (Grok Build natively reads `.claude/settings.json`, which strongly suggests but doesn't confirm this). Flagged explicitly in `AGENT_INTEGRATIONS.md` and the registry `notes` field — worth a `grok inspect` spot-check before fully trusting this in `enforce` mode.

## Test plan
- [x] `pytest tests/test_hooks.py tests/test_hooks_extended.py` — 89 passed, including new `TestStripGrok`, `TestNormalizePayloadGrok`, and `test_grok_roundtrip`.
- [x] `pytest tests/` full suite — no new failures introduced (pre-existing unrelated failures confirmed identical with these changes stashed out).
- [x] Live dry run in a scratch workspace: `install-hooks --agent grok` → wrote correct `.grok/hooks/prismor.json`; a `PreToolUse` payload for `rm -rf /` returned `{"decision": "deny", "reason": "..."}` on stdout with exit code 2; an allowed command returned exit 0; `uninstall-hooks --agent grok` cleaned up correctly.
- [x] `scripts/verify_registry.sh` — the new `grok` entry validates (pre-existing unrelated schema failure on `surface: http` entries, not touched by this PR).