### PR TITLE
feat(runtime): org subject_controls — suspend/deny per end user or client team

### DIFF
--- a/prismor/runtime/enterprise/remote_policy.py
+++ b/prismor/runtime/enterprise/remote_policy.py
@@ -219,9 +219,18 @@ def check_and_refresh(interval: Optional[float] = None) -> bool:
         latest_tool_denies_sig is not None
         and str(latest_tool_denies_sig) != str(_current_tool_denies_sig())
     )
+    # Per-subject controls (suspend / deny for an end user or client team,
+    # settings.subject_controls) also live in the resolved policy without a
+    # version bump — compare their signature so an admin's suspension reaches
+    # every device within one debounce interval.
+    latest_subject_sig = body.get("subjectControlsSig")
+    subject_controls_changed = (
+        latest_subject_sig is not None
+        and str(latest_subject_sig) != str(_current_subject_controls_sig())
+    )
     if (version_changed or profile_changed or capture_changed
             or repos_changed or controls_changed or rule_ex_changed
-            or tool_denies_changed):
+            or tool_denies_changed or subject_controls_changed):
         return fetch(force=True)
     return False
 
@@ -285,6 +294,28 @@ def _current_agent_controls_sig() -> str:
         lines = sorted(
             f"{name}:{'1' if c.get('enabled', True) else '0'}:{c.get('mode') or ''}:{c.get('iam_profile') or ''}"
             for name, c in controls.items() if isinstance(c, dict)
+        )
+        if not lines:
+            return ""
+        import hashlib
+        return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def _current_subject_controls_sig() -> str:
+    """Signature of the cached policy's per-subject controls, matching the
+    server's subjectControlsSig format (sorted ``key:suspended:deny-csv``
+    lines → sha256 → 16 hex chars; empty when none) so the device re-pulls
+    the moment an org admin suspends or reconfigures an end user / client."""
+    try:
+        pol = verify_and_load()
+        controls = ((pol or {}).get("settings") or {}).get("subject_controls") or {}
+        if not isinstance(controls, dict) or not controls:
+            return ""
+        lines = sorted(
+            f"{key}:{'1' if c.get('suspended') else '0'}:{','.join(sorted(str(t) for t in (c.get('deny_tools') or [])))}"
+            for key, c in controls.items() if isinstance(c, dict)
         )
         if not lines:
             return ""

--- a/prismor/runtime/iam.py
+++ b/prismor/runtime/iam.py
@@ -202,12 +202,58 @@ def _resolve_identity(
     return None
 
 
+def _merge_remote_subject_controls(
+    config: Dict[str, Any], remote: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Overlay org subject controls (the verified signed policy's
+    ``settings.subject_controls``) onto the local IAM agents map.
+
+    ``remote`` is keyed ``user:<id>`` / ``team:<id>`` with values
+    ``{suspended: bool, deny_tools: [...]}``. Tighten-only, mirroring
+    agents.resolve_agent_control: a suspension always wins (deny-all profile
+    regardless of any local entry), remote deny_tools union with a local
+    profile's, and a remote entry never widens what a local profile allows.
+    A subject with no local profile gets an allow-all-except-denied base, so
+    an org deny doesn't accidentally turn into a full allowlist.
+    """
+    if not isinstance(remote, dict) or not remote:
+        return config
+    agents = dict((config or {}).get("agents") or {})
+    changed = False
+    for key, ctl in remote.items():
+        if not isinstance(ctl, dict) or not isinstance(key, str):
+            continue
+        if not (key.startswith("user:") or key.startswith("team:")):
+            continue
+        local = agents.get(key)
+        local = dict(local) if isinstance(local, dict) else None
+        if ctl.get("suspended"):
+            merged: Dict[str, Any] = {
+                "allowed_tools": [], "deny_tools": [], "deny_network": True,
+                "allowed_paths": ["**"], "__suspended__": True,
+            }
+        else:
+            base = local or {
+                "allowed_tools": ["*"], "deny_tools": [],
+                "deny_network": False, "allowed_paths": ["**"],
+            }
+            remote_denies = [t for t in (ctl.get("deny_tools") or []) if isinstance(t, str)]
+            deny = list(dict.fromkeys(list(base.get("deny_tools") or []) + remote_denies))
+            merged = {**base, "deny_tools": deny}
+        agents[key] = merged
+        changed = True
+    if not changed:
+        return config
+    return {**(config or {}), "agents": agents}
+
+
 def check_iam(
     workspace: Optional[Path] = None,
     event: Optional[Dict[str, Any]] = None,
     session_id: str = "",
     subject: Optional[Any] = None,
     agent_profile: Optional[str] = None,
+    remote_controls: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check an event against the IAM profile for the active identity.
 
@@ -227,7 +273,7 @@ def check_iam(
     if event is None:
         return None
 
-    config = load_iam_config(workspace)
+    config = _merge_remote_subject_controls(load_iam_config(workspace), remote_controls)
     agent_id = _resolve_identity(config, subject)
     # Fall back to the per-agent IAM profile assigned in agents.yaml
     if not agent_id and agent_profile:
@@ -267,6 +313,12 @@ def check_iam(
         for key in ("title", "evidence"):
             if isinstance(finding.get(key), str):
                 finding[key] = finding[key].replace("for this session", scope)
+        # An org suspension deserves its own copy — "not in scope" undersells
+        # "an admin turned this principal off".
+        if profile.get("__suspended__"):
+            who = scope[4:]  # strip the "for " prefix → "user 'alice'"
+            finding["title"] = f"[iam:{agent_id}] {who} is suspended by org policy"
+            finding["evidence"] = f"{who} is suspended by org policy (subject_controls)"
     return finding
 
 

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -595,6 +595,14 @@ class PolicyEngine:
         # org/agent/session entries apply fleet-wide. Managed workspaces only.
         _td = settings.get("tool_denies")
         self.tool_denies: List[Dict[str, Any]] = _td if isinstance(_td, list) else []
+        # Per-subject controls (suspend / tool denies for an end user or a
+        # client team) from the verified signed policy — keyed ``user:<id>`` /
+        # ``team:<id>``. Enforced through the IAM path: the runtime passes this
+        # into iam.check_iam, which merges it tighten-only with any local
+        # iam.yaml profile (see iam._merge_remote_subject_controls). Managed
+        # workspaces only.
+        _sc = settings.get("subject_controls")
+        self.subject_controls: Dict[str, Any] = _sc if isinstance(_sc, dict) else {}
         # Global observe/enforce default for rules that don't set their own mode.
         # Defaults to "observe" — a fresh policy blocks nothing until an admin
         # flips rules (or this) to enforce.

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -307,6 +307,7 @@ def evaluate_tool_call(
             session_id=session_id,
             subject=subject,
             agent_profile=_control.iam_profile if _control else None,
+            remote_controls=getattr(engine, "subject_controls", None),
         )
         if iam_finding:
             findings.append(iam_finding)


### PR DESCRIPTION
Runtime half of click-to-suspend: the signed policy's `settings.subject_controls` map (`user:<id>` / `team:<id>` → `{suspended, deny_tools}`) enforces through the existing IAM path, merged tighten-only with local `iam.yaml` profiles. Suspended principals get dedicated denial copy, and a `subjectControlsSig` on the version poll propagates changes within one refresh debounce without a policy version bump.

Testing: 7/7 new end-to-end checks through `evaluate_tool_call` via the openai-agents adapter (suspension incl. copy, team deny, other-user isolation, local+remote deny union, signature behavior); 175 passed / 6 skipped across test_iam, test_agents_remote_control, test_remote_policy, test_policy_engine, test_scoped_wildcard. test_framework_adapters collection error is environmental (missing namespace pkg locally, fails identically on a clean tree).

Control-plane half (SubjectControl model + resolve folding + console suspend button) follows in prismor-web.