### PR TITLE
feat(eval-server): bearer-token auth for hosted mode + adapter apiKey

### DIFF
--- a/adapters/vercel-ai/README.md
+++ b/adapters/vercel-ai/README.md
@@ -131,6 +131,7 @@ follows `failMode`:
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `evalUrl` | `string` | `http://127.0.0.1:7071` | Eval-server URL |
+| `apiKey` | `string` | `$PRISMOR_EVAL_KEY` | Bearer token for an auth-enabled eval-server |
 | `subject` | `string` | `""` | End-user: `"user:alice"` or `"user=alice;team=data"` |
 | `mode` | `"enforce"\|"observe"` | `"enforce"` | Enforce blocks; observe logs only |
 | `failMode` | `"open"\|"closed"` | `"closed"` in enforce, `"open"` in observe | Behavior when the eval-server is unavailable |

--- a/adapters/vercel-ai/src/index.ts
+++ b/adapters/vercel-ai/src/index.ts
@@ -16,6 +16,12 @@ export interface PrismorOptions {
   /** URL of the running eval-server. Default: http://127.0.0.1:7071 */
   evalUrl?: string;
   /**
+   * Bearer token sent as `Authorization` to the eval-server — required when
+   * the server runs with --api-key / PRISMOR_EVAL_KEY (hosted / non-localhost
+   * mode). Default: the PRISMOR_EVAL_KEY environment variable.
+   */
+  apiKey?: string;
+  /**
    * Subject for per-user attribution: "user:alice" or "user=alice;team=data".
    * Resolved per call, in priority order: this option, then the ambient
    * useSubject() context, then the PRISMOR_SUBJECT environment variable —
@@ -176,6 +182,7 @@ async function evaluate(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...(opts.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : {}),
         ...(subject ? { "X-Prismor-Subject": subject } : {}),
         ...(opts.agentName ? { "X-Prismor-Agent-Name": opts.agentName } : {}),
       },
@@ -210,6 +217,8 @@ function resolveOpts(opts: PrismorOptions): Required<PrismorOptions> {
   const mode = opts.mode ?? "enforce";
   return {
     evalUrl: opts.evalUrl ?? "http://127.0.0.1:7071",
+    apiKey: opts.apiKey
+      ?? (typeof process !== "undefined" && process.env ? process.env.PRISMOR_EVAL_KEY ?? "" : ""),
     subject: opts.subject ?? "",
     mode,
     failMode: opts.failMode ?? (mode === "enforce" ? "closed" : "open"),

--- a/adapters/vercel-ai/test/index.test.js
+++ b/adapters/vercel-ai/test/index.test.js
@@ -243,6 +243,26 @@ test("concurrent requests with different subjects do not bleed", async () => {
   );
 });
 
+test("apiKey option sends Authorization header", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async () => "ok" };
+    const tools = prismorTools({ run_shell }, { apiKey: "prism_eval_secret" });
+    await tools.run_shell.execute({ command: "a" });
+    assert.equal(requests[0].headers["Authorization"], "Bearer prism_eval_secret");
+  });
+});
+
+test("no apiKey → no Authorization header", async () => {
+  const requests = [];
+  await withMockFetch(recordingFetch(requests), async () => {
+    const run_shell = { execute: async () => "ok" };
+    const tools = prismorTools({ run_shell });
+    await tools.run_shell.execute({ command: "a" });
+    assert.equal("Authorization" in requests[0].headers, false);
+  });
+});
+
 test("a tool with no execute() is returned unchanged", () => {
   const noop = {};
   const wrapped = prismorTool("noop", noop);

--- a/docs/frameworks-vercel-ai.md
+++ b/docs/frameworks-vercel-ai.md
@@ -159,6 +159,32 @@ Or set a default for all tools when using `prismorTools`:
 const tools = prismorTools(myTools, { eventType: "network" });
 ```
 
+## Hosted / exposed eval-server (bearer auth)
+
+By default the eval-server binds localhost with no auth. To run it as a shared
+service (one sidecar for a fleet, or exposed beyond localhost), require a
+bearer token:
+
+```bash
+prismor eval-server --host 0.0.0.0 --port 7071 --api-key "$PRISMOR_EVAL_KEY"
+# or just set PRISMOR_EVAL_KEY in the server's environment
+```
+
+`POST /v1/evaluate` then returns 401 without `Authorization: Bearer <key>`;
+`GET /health` stays open for liveness probes. On the adapter side pass the
+key (defaults to the client's own `PRISMOR_EVAL_KEY` env var):
+
+```typescript
+const tools = prismorTools(myTools, {
+  evalUrl: "https://prismor-eval.internal.example.com",
+  apiKey: process.env.PRISMOR_EVAL_KEY,
+});
+```
+
+A 401 (wrong or missing key) follows `failMode` like any other eval-server
+failure — blocked in enforce mode. Binding beyond localhost with no key
+prints a loud warning.
+
 ## Fail mode
 
 If the eval-server cannot answer (down, not yet started, crashed, or slower

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -164,6 +164,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             host=args.host,
             port=args.port,
             workspace=_Path(args.workspace) if getattr(args, "workspace", None) else None,
+            api_key=getattr(args, "api_key", None),
         )
         return
 
@@ -1989,6 +1990,7 @@ def build_parser() -> argparse.ArgumentParser:
     _ep.add_argument("--port", type=int, default=7071, help="Port to listen on (default: 7071)")
     _ep.add_argument("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
     _ep.add_argument("--workspace", default=None, help="Workspace path for policy/IAM (default: cwd)")
+    _ep.add_argument("--api-key", default=None, help="Require Authorization: Bearer <key> on /v1/evaluate (default: $PRISMOR_EVAL_KEY); needed when exposing beyond localhost")
 
     # ── check ──────────────────────────────────────────────────────────
     check_parser = subparsers.add_parser("check", help="Quick pre-check a command or file path")

--- a/prismor/runtime/eval_server.py
+++ b/prismor/runtime/eval_server.py
@@ -38,6 +38,7 @@ Non-2xx on server errors only. Policy denials are always 200 with allow=false.
 """
 from __future__ import annotations
 
+import hmac
 import json
 import os
 from datetime import datetime, timezone
@@ -94,6 +95,10 @@ class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
 
 class EvalHandler(BaseHTTPRequestHandler):
     workspace: Path = Path.cwd()
+    # When set, /v1/evaluate requires `Authorization: Bearer <api_key>` — the
+    # hosted/exposed mode. /health stays open (liveness probes). Compared
+    # constant-time. None (default) preserves the open localhost behavior.
+    api_key: Optional[str] = None
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
         pass  # silence per-request logs; server startup message is printed separately
@@ -111,7 +116,7 @@ class EvalHandler(BaseHTTPRequestHandler):
         self.send_response(204)
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-Prismor-Subject, X-Warden-Subject")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Prismor-Subject, X-Warden-Subject")
         self.end_headers()
 
     def do_GET(self) -> None:  # noqa: N802
@@ -124,6 +129,13 @@ class EvalHandler(BaseHTTPRequestHandler):
         if self.path != "/v1/evaluate":
             self._send_json({"error": "not found"}, 404)
             return
+
+        if self.api_key:
+            auth = self.headers.get("Authorization", "")
+            presented = auth[7:] if auth.startswith("Bearer ") else ""
+            if not presented or not hmac.compare_digest(presented, self.api_key):
+                self._send_json({"error": "unauthorized: missing or invalid API key"}, 401)
+                return
 
         length = int(self.headers.get("Content-Length", 0))
         try:
@@ -200,13 +212,24 @@ def run_eval_server(
     host: str = "127.0.0.1",
     port: int = 7071,
     workspace: Optional[Path] = None,
+    api_key: Optional[str] = None,
 ) -> None:
-    """Start the evaluation HTTP server (blocking)."""
+    """Start the evaluation HTTP server (blocking).
+
+    ``api_key`` (or the PRISMOR_EVAL_KEY env var) turns on bearer-token auth
+    for /v1/evaluate so the server can be exposed beyond localhost.
+    """
     ws = workspace or Path.cwd()
     EvalHandler.workspace = ws
+    EvalHandler.api_key = api_key or os.environ.get("PRISMOR_EVAL_KEY") or None
 
     server = _ThreadingHTTPServer((host, port), EvalHandler)
-    print(f"[prismor] eval-server listening on http://{host}:{port}")
+    if host not in ("127.0.0.1", "localhost", "::1") and not EvalHandler.api_key:
+        print("[prismor] WARNING: binding beyond localhost with NO API key — "
+              "anyone who can reach this port can evaluate against your policy. "
+              "Pass --api-key or set PRISMOR_EVAL_KEY.")
+    print(f"[prismor] eval-server listening on http://{host}:{port}"
+          + (" (bearer auth ON)" if EvalHandler.api_key else ""))
     print(f"[prismor] workspace: {ws}")
     print(f"[prismor] POST /v1/evaluate  →  tool call → Decision")
     print(f"[prismor] GET  /health       →  liveness check")
@@ -222,6 +245,9 @@ if __name__ == "__main__":
     _p.add_argument("--port", type=int, default=7071)
     _p.add_argument("--host", default="127.0.0.1")
     _p.add_argument("--workspace", default=None)
+    _p.add_argument("--api-key", default=None,
+                    help="Require Authorization: Bearer <key> on /v1/evaluate (default: $PRISMOR_EVAL_KEY)")
     _a = _p.parse_args()
     run_eval_server(host=_a.host, port=_a.port,
-                    workspace=Path(_a.workspace) if _a.workspace else None)
+                    workspace=Path(_a.workspace) if _a.workspace else None,
+                    api_key=_a.api_key)


### PR DESCRIPTION
Lets the eval-server run as a shared/exposed service instead of localhost-only: `--api-key` (or `PRISMOR_EVAL_KEY`) requires `Authorization: Bearer <key>` on `/v1/evaluate` (constant-time compare; 401 otherwise), `/health` stays open for probes, and binding beyond localhost with no key prints a loud warning. The `prismor-warden` adapter gains an `apiKey` option (defaults to the client's `PRISMOR_EVAL_KEY`); a 401 follows `failMode` like any other eval-server failure — blocked in enforce mode.

Testing: 22/22 adapter unit tests (2 new for the header); live server verified — no key → 401, wrong key → 401, right key → 200 decision, /health → 200. Docs: hosted-mode section in frameworks-vercel-ai + adapter README option row.