### PR TITLE
feat(scanner): add MCP typosquat detection and schema-drift monitoring

### DIFF
--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.24.1"
+__version__ = "1.25.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/scanner.py
+++ b/prismor/runtime/scanner.py
@@ -12,6 +12,7 @@ Usage (from CLI):
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 import re
 import shlex
@@ -690,10 +691,158 @@ def _truncate_url(url: str, limit: int = 120) -> str:
     return base if len(base) <= limit else base[: limit - 3] + "..."
 
 
+# ── Typosquat detection ──────────────────────────────────────────────────────
+#
+# Well-known / official MCP server names. A server whose name is a close-but-
+# not-exact match to one of these (edit distance 1-2) is riding on the
+# reputation of a trusted name without actually being it.
+_KNOWN_MCP_SERVERS = frozenset({
+    "github", "gitlab", "filesystem", "fetch", "memory", "puppeteer",
+    "playwright", "brave-search", "google-drive", "gdrive", "slack",
+    "postgres", "postgresql", "sqlite", "redis", "docker", "kubernetes",
+    "aws", "gcp", "azure", "sentry", "notion", "linear", "jira",
+    "confluence", "figma", "stripe", "twilio", "sendgrid", "everything",
+})
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Edit distance between two strings. No external dependency."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        cur = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            cur[j] = min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost)
+        prev = cur
+    return prev[-1]
+
+
+def _check_typosquat(name: str) -> Optional[Dict[str, Any]]:
+    """Flag a server name that closely resembles a well-known MCP server.
+
+    Exact matches to a known name are legitimate and never flagged; only a
+    close-but-wrong name is (``githu``, `git-hub`, `githib`) — the shape a
+    typosquat takes when it wants to be mistaken for the real thing.
+    """
+    candidate = (name or "").strip().lower()
+    if not candidate or candidate in _KNOWN_MCP_SERVERS or len(candidate) < 4:
+        return None
+    best_match: Optional[str] = None
+    best_distance: Optional[int] = None
+    for known in _KNOWN_MCP_SERVERS:
+        if abs(len(candidate) - len(known)) > 2:
+            continue  # cheap pre-filter before the O(n*m) edit-distance pass
+        distance = _levenshtein(candidate, known)
+        if best_distance is None or distance < best_distance:
+            best_match, best_distance = known, distance
+    if best_match and best_distance is not None and 0 < best_distance <= 2:
+        return {
+            "id": f"mcp-typosquat-{name}",
+            "severity": "HIGH",
+            "category": "skill_risk",
+            "title": f"MCP server name '{name}' closely resembles well-known server '{best_match}' (possible typosquat)",
+            "evidence": f"name={name!r} nearest_known={best_match!r} edit_distance={best_distance}",
+            "eventIndex": 0,
+            "ruleId": "mcp-typosquat-name",
+            "action": "warn",
+            "skillName": name,
+        }
+    return None
+
+
+# ── Schema-drift monitoring ───────────────────────────────────────────────────
+#
+# A "rug pull" MCP server passes review with a benign schema, then the
+# maintainer (or a compromised registry) swaps in new tools / a new endpoint
+# after the agent has been configured to trust it. Config edits are otherwise
+# invisible between scans, so this compares each scan's fingerprint of the
+# security-relevant fields against the last one seen and flags a change.
+
+def _drift_state_path() -> Path:
+    from prismor.runtime.store import prismor_home
+    return prismor_home() / "mcp_schema_snapshots.json"
+
+
+def _load_drift_state() -> Dict[str, Any]:
+    path = _drift_state_path()
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_drift_state(state: Dict[str, Any]) -> None:
+    path = _drift_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError:
+        pass  # best-effort; drift detection just degrades to "no prior snapshot"
+
+
+def _schema_fingerprint(cfg: Dict[str, Any]) -> str:
+    """Stable hash of the fields an attacker would change post-approval:
+    the declared tool set + schemas, the remote endpoint, and the stdio
+    command/args."""
+    tools = cfg.get("tools") or []
+    tool_shape = sorted(
+        (
+            str(t.get("name", "")),
+            json.dumps(t.get("inputSchema") or t.get("input_schema") or {}, sort_keys=True),
+        )
+        for t in tools if isinstance(t, dict)
+    )
+    material = {
+        "tools": tool_shape,
+        "url": next((cfg.get(k) for k in _URL_KEYS if cfg.get(k)), None),
+        "command": cfg.get("command"),
+        "args": cfg.get("args"),
+    }
+    blob = json.dumps(material, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _check_drift(entry: Dict[str, Any], state: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Compare this scan's fingerprint against the last one recorded for the
+    same (agent, source file, server name). Updates ``state`` in place."""
+    name = entry.get("name", "unnamed")
+    source = entry.get("source", "")
+    cfg = entry.get("config") or {}
+    if not isinstance(cfg, dict):
+        return None
+    key = f"{entry.get('agent', 'unknown')}:{source}:{name}"
+    fingerprint = _schema_fingerprint(cfg)
+    prior = state.get(key)
+    state[key] = {"fingerprint": fingerprint, "name": name, "source": source}
+    if prior and prior.get("fingerprint") and prior["fingerprint"] != fingerprint:
+        return {
+            "id": f"mcp-drift-{name}",
+            "severity": "HIGH",
+            "category": "skill_risk",
+            "title": f"MCP server '{name}' schema changed since the last scan (possible rug pull)",
+            "evidence": (
+                f"server={name!r} source={source!r} "
+                f"prior_fingerprint={prior['fingerprint'][:12]} current_fingerprint={fingerprint[:12]}"
+            ),
+            "eventIndex": 0,
+            "ruleId": "mcp-schema-drift",
+            "action": "warn",
+            "skillName": name,
+        }
+    return None
+
+
 def audit_mcp_schema(
     entry: Dict[str, Any],
     egress_allowlist: Optional[List[str]] = None,
     mcp_action: str = "warn",
+    drift_state: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Static analysis of an MCP server / skill config.
 
@@ -719,6 +868,18 @@ def audit_mcp_schema(
 
     # Remote-transport hygiene (HTTP/SSE/streamable-HTTP MCP servers).
     findings.extend(_audit_remote_transport(name, cfg, egress_allowlist, mcp_action))
+
+    # Typosquat check — name similarity to a well-known MCP server.
+    typosquat_finding = _check_typosquat(name)
+    if typosquat_finding:
+        findings.append(typosquat_finding)
+
+    # Schema-drift check against the last scan (opt-in via drift_state; the
+    # standalone audit_mcp_schema() callers in tests get none unless they ask).
+    if drift_state is not None:
+        drift_finding = _check_drift(entry, drift_state)
+        if drift_finding:
+            findings.append(drift_finding)
 
     # Unicode-confusable checks — homoglyph spoofing in server/tool names and
     # invisible characters embedded in tool descriptions (hidden instructions).
@@ -912,6 +1073,7 @@ def _synthesize_event(entry: Dict[str, Any]) -> Dict[str, Any]:
 def scan_skills(
     workspace: Optional[Path] = None,
     agent: Optional[str] = None,
+    track_drift: bool = True,
 ) -> Dict[str, Any]:
     """Scan all discovered skill/MCP configs and return findings.
 
@@ -925,6 +1087,10 @@ def scan_skills(
     """
     engine = PolicyEngine(workspace=workspace)
     configs = discover_configs(agent=agent, workspace=workspace)
+
+    # Loaded once per scan and saved once at the end, so drift is compared
+    # against the previous *scan*, not the previous entry within this one.
+    drift_state = _load_drift_state() if track_drift else None
 
     all_entries: List[Dict[str, Any]] = []
     for cfg in configs:
@@ -947,6 +1113,7 @@ def scan_skills(
             entry,
             egress_allowlist=engine.egress_allowlist,
             mcp_action=engine.mcp_transport_action,
+            drift_state=drift_state,
         ):
             sf["skillSource"] = entry.get("source", "")
             sf["agent"] = entry.get("agent", "unknown")
@@ -960,6 +1127,9 @@ def scan_skills(
                 af["skillSource"] = entry.get("source", "")
                 af["agent"] = entry.get("agent", "unknown")
                 findings.append(af)
+
+    if drift_state is not None:
+        _save_drift_state(drift_state)
 
     # Sort by severity: CRITICAL first, then HIGH, MEDIUM, LOW
     findings.sort(key=lambda f: _SEVERITY_ORDER.get(f.get("severity", "UNKNOWN"), 99))

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -12,6 +12,7 @@ Run:  python3 tests/test_mcp_security.py
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -197,6 +198,96 @@ fc2 = PolicyEngine(workspace=tmp).evaluate(ev_c2, index=0, session_id="sess-C2")
 # version, but routing MCP output through injection scanning is the guarantee.
 check("HTML-hidden injection in MCP output is flagged",
       "prompt_injection" in categories(fc2), rule_ids(fc2))
+
+
+# ── D. MCP server name typosquat detection ───────────────────────────────────
+print("\n[D] MCP server name typosquat detection")
+
+exact_known = {"name": "github", "config": {"command": "npx", "args": ["mcp-server-github"]}}
+check("exact match to a known server name is not flagged",
+      "mcp-typosquat-name" not in rule_ids(audit_mcp_schema(exact_known)))
+
+near_miss = {"name": "githu", "config": {"command": "npx", "args": ["evil"]}}
+ids_typo = rule_ids(audit_mcp_schema(near_miss))
+check("single-character near-miss of 'github' is flagged as a typosquat",
+      "mcp-typosquat-name" in ids_typo, ids_typo)
+
+near_miss_hyphen = {"name": "git-hub", "config": {"command": "npx", "args": ["evil"]}}
+ids_typo2 = rule_ids(audit_mcp_schema(near_miss_hyphen))
+check("hyphenated near-miss of 'github' is flagged as a typosquat",
+      "mcp-typosquat-name" in ids_typo2, ids_typo2)
+
+unrelated = {"name": "totally-custom-internal-server", "config": {"command": "npx", "args": ["x"]}}
+check("a name unrelated to any known server is not flagged",
+      "mcp-typosquat-name" not in rule_ids(audit_mcp_schema(unrelated)))
+
+
+# ── E. MCP schema-drift monitoring ────────────────────────────────────────────
+print("\n[E] MCP schema-drift monitoring (rug-pull detection)")
+
+base_entry = {
+    "name": "driftbot",
+    "agent": "claude",
+    "source": "/tmp/drift-test/.mcp.json",
+    "config": {"command": "node", "args": ["index.js"], "tools": [
+        {"name": "read_file", "inputSchema": {"properties": {"path": {"type": "string"}}}},
+    ]},
+}
+drift_state_d = {}
+first_scan = audit_mcp_schema(base_entry, drift_state=drift_state_d)
+check("first scan of a server records a fingerprint but flags no drift",
+      "mcp-schema-drift" not in rule_ids(first_scan), rule_ids(first_scan))
+
+unchanged_entry = json.loads(json.dumps(base_entry))
+second_scan_same = audit_mcp_schema(unchanged_entry, drift_state=drift_state_d)
+check("an unchanged config on the next scan flags no drift",
+      "mcp-schema-drift" not in rule_ids(second_scan_same), rule_ids(second_scan_same))
+
+changed_entry = json.loads(json.dumps(base_entry))
+changed_entry["config"]["tools"].append(
+    {"name": "exec_shell", "inputSchema": {"properties": {"cmd": {"type": "string"}}}}
+)
+third_scan_changed = audit_mcp_schema(changed_entry, drift_state=drift_state_d)
+check("a tool added after the server was already trusted flags schema drift",
+      "mcp-schema-drift" in rule_ids(third_scan_changed), rule_ids(third_scan_changed))
+
+check("audit_mcp_schema() with no drift_state (default None) performs no drift check",
+      "mcp-schema-drift" not in rule_ids(audit_mcp_schema(changed_entry)))
+
+# End-to-end through scan_skills(): drift state persists across two scans of
+# the same workspace, isolated to a throwaway PRISMOR_HOME so this never
+# touches the developer's real ~/.prismor state.
+from prismor.runtime.scanner import scan_skills
+
+drift_home = Path(tempfile.mkdtemp(prefix="mcp-drift-home-"))
+drift_ws = Path(tempfile.mkdtemp(prefix="mcp-drift-ws-"))
+(drift_ws / ".mcp.json").write_text(json.dumps({
+    "mcpServers": {"driftbot": {"command": "node", "args": ["index.js"], "tools": [
+        {"name": "read_file", "inputSchema": {"properties": {"path": {"type": "string"}}}},
+    ]}}
+}), encoding="utf-8")
+
+old_home = os.environ.get("PRISMOR_HOME")
+os.environ["PRISMOR_HOME"] = str(drift_home)
+try:
+    result1 = scan_skills(workspace=drift_ws, agent="claude")
+    check("scan_skills(): first scan of a workspace flags no drift",
+          "mcp-schema-drift" not in rule_ids(result1["findings"]), rule_ids(result1["findings"]))
+
+    (drift_ws / ".mcp.json").write_text(json.dumps({
+        "mcpServers": {"driftbot": {"command": "node", "args": ["index.js"], "tools": [
+            {"name": "read_file", "inputSchema": {"properties": {"path": {"type": "string"}}}},
+            {"name": "exec_shell", "inputSchema": {"properties": {"cmd": {"type": "string"}}}},
+        ]}}
+    }), encoding="utf-8")
+    result2 = scan_skills(workspace=drift_ws, agent="claude")
+    check("scan_skills(): second scan after a schema change flags drift",
+          "mcp-schema-drift" in rule_ids(result2["findings"]), rule_ids(result2["findings"]))
+finally:
+    if old_home is None:
+        os.environ.pop("PRISMOR_HOME", None)
+    else:
+        os.environ["PRISMOR_HOME"] = old_home
 
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds typosquat detection to the MCP scanner: flags server names that closely resemble a well-known MCP server name (Levenshtein distance), catching e.g. `githu` or `git-hub` riding on `github`'s reputation.
- Adds schema-drift monitoring: fingerprints each server's tools/endpoint/command on every scan and flags a change since the last scan — catches the "rug pull" pattern where a server passes review benign and later swaps in new capability. State persists to `~/.prismor/mcp_schema_snapshots.json`, opt-in via `scan_skills(track_drift=True)` (default on).
- Bumps version to 1.25.0.

## Test plan
- [x] `python3 tests/test_mcp_security.py` — 31/31 passing (21 pre-existing + 10 new)
- [x] Verified `audit_mcp_schema()` stays backward compatible for direct callers (drift check is opt-in via new `drift_state` param, default `None`)
- [x] Verified `scan_skills`'s only caller (`cli.py`) uses keyword args, so the new `track_drift` param is non-breaking

https://claude.ai/code/session_019PQ9yGPdGqa1R9jhnLP9R8