### PR TITLE
feat(sandbox): add graduated privilege rings (0-3)

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1133,6 +1133,8 @@ def main(argv: Optional[List[str]] = None) -> None:
             print(f"  {_color('Backend:', _GREEN)}      {report['backend']}")
             print(f"  {_color('Image:', _GREEN)}        {report['image']}")
             print(f"  {_color('Network:', _GREEN)}      {report['network']}")
+            if report.get("ring") is not None:
+                print(f"  {_color('Ring:', _GREEN)}        {report['ring']} ({report.get('ring_label')})")
             docker = report["docker"]
             if docker.get("cli_found") and docker.get("server_reachable"):
                 print(f"  {_color('Docker:', _GREEN)}       available ({docker.get('server_version', 'unknown')})")

--- a/prismor/runtime/sandbox.py
+++ b/prismor/runtime/sandbox.py
@@ -38,10 +38,77 @@ DEFAULT_SANDBOX_CONFIG: Dict[str, Any] = {
 _VALID_NETWORKS = {"none", "bridge", "host", "allowlist"}
 _VALID_MOUNTS = {"ro", "rw"}
 
+# ── Privilege rings ───────────────────────────────────────────────────────
+#
+# A ring is a named bundle of (network, workspace_mount, resource_limits)
+# defaults — coarse, pre-reviewed profiles instead of hand-tuning every
+# field. Explicit config always wins: a workspace that sets `ring: "1"` and
+# also sets `network: "host"` gets "host", the ring only supplies defaults.
+#
+# "host" network is intentionally never a ring default — a ring that wants
+# it must be configured explicitly outside the presets, on purpose. cap-drop
+# ALL + no-new-privileges (see build_docker_argv) applies unconditionally
+# at every ring; rings tune the outer blast radius (network/mounts/limits),
+# not the process-capability floor.
+_RING_PRESETS: Dict[str, Dict[str, Any]] = {
+    "0": {  # read-only: inspect only, nothing can be written, no network
+        "network": "none",
+        "workspace_mount": "ro",
+        "resource_limits": {"cpus": "0.5", "memory": "512m", "pids_limit": 128, "timeout_seconds": 120},
+    },
+    "1": {  # default: workspace-write, still no network (matches the prior single-tier default)
+        "network": "none",
+        "workspace_mount": "rw",
+        "resource_limits": {"cpus": "1.0", "memory": "1g", "pids_limit": 256, "timeout_seconds": 300},
+    },
+    "2": {  # network-allowlisted: workspace-write + egress restricted to the policy allowlist
+        "network": "allowlist",
+        "workspace_mount": "rw",
+        "resource_limits": {"cpus": "2.0", "memory": "2g", "pids_limit": 512, "timeout_seconds": 600},
+    },
+    "3": {  # broadest: bridged network, still isolated from the host network stack
+        "network": "bridge",
+        "workspace_mount": "rw",
+        "resource_limits": {"cpus": "4.0", "memory": "4g", "pids_limit": 1024, "timeout_seconds": 1200},
+    },
+}
+
+_RING_LABELS: Dict[str, str] = {
+    "0": "read-only (no writes, no network)",
+    "1": "workspace-write, no network",
+    "2": "workspace-write, allowlisted network",
+    "3": "workspace-write, bridged network",
+}
+
+
+def ring_names() -> List[str]:
+    """Valid ring identifiers, in ascending privilege order."""
+    return sorted(_RING_PRESETS, key=int)
+
+
+def ring_label(ring: Optional[str]) -> Optional[str]:
+    return _RING_LABELS.get(str(ring)) if ring is not None else None
+
 
 def effective_config(raw: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Return sandbox config with safe defaults applied."""
-    cfg = _deep_merge(DEFAULT_SANDBOX_CONFIG, raw or {})
+    """Return sandbox config with safe defaults applied.
+
+    If ``raw["ring"]`` names a known privilege ring, that ring's preset
+    supplies the network/mount/resource_limits defaults before the rest of
+    ``raw`` is layered on top — so an explicit field in ``raw`` still wins
+    over the ring's default for that field.
+    """
+    raw = raw or {}
+    ring_value = raw.get("ring")
+    ring_key = str(ring_value) if ring_value is not None else None
+    base = DEFAULT_SANDBOX_CONFIG
+    if ring_key in _RING_PRESETS:
+        base = _deep_merge(DEFAULT_SANDBOX_CONFIG, _RING_PRESETS[ring_key])
+    else:
+        ring_key = None  # unknown ring value — ignore rather than silently misconfigure
+
+    cfg = _deep_merge(base, raw)
+    cfg["ring"] = ring_key
     cfg["backend"] = str(cfg.get("backend") or "docker").lower()
     cfg["mode"] = str(cfg.get("mode") or "observe").lower()
     cfg["network"] = str(cfg.get("network") or "none").lower()
@@ -226,6 +293,9 @@ def status_report(config: Dict[str, Any]) -> Dict[str, Any]:
         "network": cfg.get("network"),
         "workspace_mount": cfg.get("workspace_mount"),
         "read_only_root": bool(cfg.get("read_only_root")),
+        "ring": cfg.get("ring"),
+        "ring_label": ring_label(cfg.get("ring")),
+        "resource_limits": cfg.get("resource_limits"),
         "docker": docker_status(),
     }
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -115,5 +115,100 @@ class TestSandboxCommandHandling(unittest.TestCase):
         self.assertEqual(args.encoded, "abc")
 
 
+class TestPrivilegeRings(unittest.TestCase):
+    def test_no_ring_set_is_fully_backward_compatible(self):
+        """Omitting `ring` must reproduce the pre-ring single-tier defaults
+        exactly — existing workspace configs must not change behavior."""
+        cfg = sandbox.effective_config({"enabled": True})
+        self.assertIsNone(cfg["ring"])
+        self.assertEqual(cfg["network"], "none")
+        self.assertEqual(cfg["workspace_mount"], "rw")
+        self.assertEqual(cfg["resource_limits"]["cpus"], "1.0")
+
+    def test_ring_0_is_read_only_and_networkless(self):
+        cfg = sandbox.effective_config({"enabled": True, "ring": "0"})
+        self.assertEqual(cfg["ring"], "0")
+        self.assertEqual(cfg["network"], "none")
+        self.assertEqual(cfg["workspace_mount"], "ro")
+
+    def test_ring_2_is_allowlisted_network(self):
+        cfg = sandbox.effective_config({"enabled": True, "ring": "2"})
+        self.assertEqual(cfg["network"], "allowlist")
+        self.assertEqual(cfg["workspace_mount"], "rw")
+
+    def test_ring_3_uses_bridge_not_host(self):
+        """No ring preset ever defaults to `host` networking — that's the
+        one mode a ring can't hand out automatically."""
+        cfg = sandbox.effective_config({"enabled": True, "ring": "3"})
+        self.assertEqual(cfg["network"], "bridge")
+
+    def test_rings_are_strictly_increasing_in_resource_ceiling(self):
+        limits = [
+            sandbox.effective_config({"ring": r})["resource_limits"]
+            for r in sandbox.ring_names()
+        ]
+        cpus = [float(l["cpus"]) for l in limits]
+        self.assertEqual(cpus, sorted(cpus))
+        self.assertTrue(all(a < b for a, b in zip(cpus, cpus[1:])))
+
+    def test_explicit_field_overrides_ring_default(self):
+        """A ring only supplies defaults — an explicitly set field in the
+        same config always wins, even a more permissive one than the ring."""
+        cfg = sandbox.effective_config({"ring": "0", "network": "bridge"})
+        self.assertEqual(cfg["network"], "bridge")
+        self.assertEqual(cfg["ring"], "0")
+
+    def test_unknown_ring_value_is_ignored_not_fatal(self):
+        cfg = sandbox.effective_config({"ring": "does-not-exist"})
+        self.assertIsNone(cfg["ring"])
+        self.assertEqual(cfg["network"], "none")  # falls back to plain defaults
+
+    def test_ring_names_are_ascending(self):
+        self.assertEqual(sandbox.ring_names(), ["0", "1", "2", "3"])
+
+    def test_ring_label_for_known_and_unknown_ring(self):
+        self.assertIn("read-only", sandbox.ring_label("0"))
+        self.assertIsNone(sandbox.ring_label(None))
+        self.assertIsNone(sandbox.ring_label("nope"))
+
+    def test_status_report_surfaces_ring_and_label(self):
+        report = sandbox.status_report({"ring": "1"})
+        self.assertEqual(report["ring"], "1")
+        self.assertIsNotNone(report["ring_label"])
+
+    def test_policy_engine_loads_ring_from_settings(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "policy.yaml"
+            p.write_text(
+                'version: "1.0"\n'
+                "settings:\n"
+                "  sandbox:\n"
+                "    enabled: true\n"
+                "    ring: \"2\"\n"
+                "rules: []\n",
+                encoding="utf-8",
+            )
+            engine = PolicyEngine(policy_path=p)
+            cfg = sandbox.effective_config(engine.sandbox_config)
+            self.assertEqual(cfg["ring"], "2")
+            self.assertEqual(cfg["network"], "allowlist")
+
+    def test_schema_accepts_ring_in_sandbox_settings(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(
+                'version: "1.0"\n'
+                "settings:\n"
+                "  sandbox:\n"
+                "    enabled: true\n"
+                "    ring: \"1\"\n"
+                "rules: []\n"
+            )
+            path = Path(f.name)
+        try:
+            self.assertEqual(validate_policy(path), [])
+        finally:
+            path.unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds 4 named privilege-ring presets to the Docker sandbox config (`prismor/runtime/sandbox.py`): ring 0 (read-only, no network), ring 1 (workspace-write, no network — identical to the prior single-tier default), ring 2 (workspace-write, allowlisted network), ring 3 (workspace-write, bridged network).
- Configured via `settings.sandbox.ring` in `policy.yaml`; a ring only supplies defaults — any explicitly-set field in the same config still wins.
- No ring preset ever defaults to `host` networking — that stays an explicit, deliberate opt-in outside the presets.
- `cap-drop ALL` + `no-new-privileges` still apply unconditionally at every ring (unchanged) — rings tune the outer blast radius (network/mounts/resource limits), not the process-capability floor.
- Surfaces the active ring + label in `prismor sandbox status` (both human-readable and `--json`).
- Fully backward compatible: omitting `ring` reproduces the exact prior single-tier sandbox config (covered by a dedicated test).

**Scope note:** this ships the config/enforcement layer only. Gating *which* ring an IAM agent profile is allowed to request is a natural follow-up but out of scope here — today any workspace can set any ring via `settings.sandbox.ring`, same trust model as every other sandbox setting.

## Test plan
- [x] `python3 -m pytest tests/test_sandbox.py -v` — 20/20 passing (8 pre-existing + 12 new)
- [x] `python3 -m pytest tests/test_sandbox.py tests/test_mcp_security.py tests/test_compliance.py tests/test_attestation.py -q` — 38/38 passing, no regressions
- [x] `prismor sandbox status` (human + `--json`) smoke-tested with `ring: "2"` configured via policy.yaml

https://claude.ai/code/session_019PQ9yGPdGqa1R9jhnLP9R8