### PR TITLE
feat(runtime): add Kiro CLI (AWS) coding-agent hook integration

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -2,7 +2,7 @@
 
 How Prismor integrates with each major AI coding agent — what ships today, what's planned, and what mechanism each agent exposes for runtime security monitoring.
 
-_Last updated: 2026-07-11._
+_Last updated: 2026-07-13._
 
 ---
 
@@ -29,9 +29,9 @@ _Generated from `prismor/runtime/integrations/registry.yaml` — do not edit by 
 | Codex (OpenAI) | coding-agent | hook-config | ✅ | `exit-2` |
 | GitHub Copilot CLI | coding-agent | hook-config | ✅ | `json-permission` |
 | Grok Build (xAI) | coding-agent | hook-config | ✅ | `exit-2` |
+| Kiro CLI (AWS) | coding-agent | hook-config | ✅ | `exit-2` |
 | Gemini CLI (Google) | coding-agent | hook-config | 🟡 | `exit-2` |
 | OpenCode | coding-agent | sdk | 🟡 | `throw` |
-| Kiro (AWS) | coding-agent | hook-config | 🟡 | `exit-2` |
 | Factory Droid | coding-agent | hook-config | 🟡 | `json-permission` |
 | Google Antigravity | coding-agent | rules-only | — | — |
 | Aider | coding-agent | rules-only | — | — |
@@ -138,6 +138,18 @@ Prismor integrates with Hermes at two complementary layers:
 - **Not yet verified against a live `grok` install.** This integration is built entirely from [docs.x.ai/build/features/hooks](https://docs.x.ai/build/features/hooks) and [docs.x.ai/build/overview](https://docs.x.ai/build/overview) — no `grok` binary was available to smoke-test against at implementation time. Before relying on this in `enforce` mode, run `grok inspect` to confirm the real built-in tool names, and verify a deliberately blocked command is actually denied end to end (the same live check done for Codex above).
 - **Project-hook trust:** Grok requires trust before running project-level hooks (`/hooks-trust` or `--trust` inside `grok`, recorded in `~/.grok/trusted_folders.toml`). This is a one-time manual step Prismor does not automate.
 - **Code:** `prismor/runtime/hooks.py` `_merge_grok()`, `_strip_grok()`, `_normalize_grok()`.
+
+### Kiro CLI (AWS)
+
+- **Config:** `~/.kiro/agents/kiro_default.json` (user) or `<repo>/.kiro/agents/kiro_default.json` (project). Unlike every other shipped agent, Kiro's hooks are not a dedicated hooks file — they're a `"hooks"` field inside a *named agent config*, and the one that runs by default (`kiro_default`) has no on-disk file until one is created.
+- **Events hooked:** `userPromptSubmit`, `preToolUse`, `postToolUse` (lowerCamelCase — Kiro's own convention, distinct from every other agent's PascalCase event names). `preToolUse` is the only blocking event; a `stop` hook also exists (can block session termination via JSON) but is intentionally not wired, same precedent as skipping Claude's `Stop` hook.
+- **Matcher:** entries omit the `matcher` field entirely, which Kiro documents as applying the hook to every tool — the broadest coverage, equivalent to the `"*"`/`mcp__.*` matchers used elsewhere.
+- **Blocking:** exit 2 from the `preToolUse` hook blocks the tool call, with stderr surfaced back to the model as context. No structured stdout JSON response is required (unlike Grok/Copilot) — this fits the same fail-closed `else` branch already used for Cursor/Windsurf/Codex.
+- **Self-contained install, not a hooks-only fragment.** Whether Kiro merges a partial `kiro_default.json` override with its built-in tool list, or replaces it outright, is undocumented — kiro.dev has no example of overriding the built-in default agent, only creating new named ones. To avoid silently stripping a user's default tools (`read`, `write`, `shell`, ...) the moment Prismor installs hooks, a *fresh* file is seeded with an explicit tools list (`_KIRO_DEFAULT_TOOLS`) alongside the hooks. An existing file — the user's own customized `kiro_default`, or a prior Prismor install — is left otherwise untouched; only `"hooks"` is merged into it.
+- **Tool-name taxonomy:** canonical snake_case (`execute_bash`, `fs_read`, `fs_write`, `use_aws`) plus short aliases (`shell`, `read`, `write`, `aws`) — normalization matches on both forms. `fs_write`'s `tool_input` shape (`{"operations": [{"mode": ..., "path": ...}]}`) is not fully documented past the `path` field; content extraction from the first operation is best-effort with several fallback field names.
+- **Sweep target:** `~/.kiro/`.
+- **Not yet verified against a live `kiro-cli` binary.** Built from [kiro.dev/docs/cli/hooks](https://kiro.dev/docs/cli/hooks/), the [agent configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/), and community documentation at [Ar9av/agent-manual](https://github.com/Ar9av/agent-manual/blob/main/tools/kiro/README.md). Before relying on this in `enforce` mode, confirm live whether a partial `kiro_default.json` is merged or replaces built-in defaults, and verify a deliberately blocked command is actually denied end to end.
+- **Code:** `prismor/runtime/hooks.py` `_merge_kiro()`, `_strip_kiro()`, `_normalize_kiro()`.
 
 ---
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1009,7 +1009,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                         "permissionDecisionReason": reason,
                     }) + "\n")
                     return
-                # No inline-approval surface (cursor/windsurf/codex/grok): fail closed.
+                # No inline-approval surface (cursor/windsurf/codex/grok/kiro): fail closed.
                 sys.stderr.write(f"Prismor requires approval for this action (no approval surface — blocked): {reason}\n")
                 raise SystemExit(2)
 
@@ -2030,7 +2030,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── deps ──────────────────────────────────────────────────────────
@@ -2160,7 +2160,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
@@ -2174,13 +2174,13 @@ def build_parser() -> argparse.ArgumentParser:
         "`prismor cloak install`.",
     )
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -2539,6 +2539,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".github" / "copilot" / "hooks.json"
     if agent == "grok":
         return workspace / ".grok" / "hooks" / "prismor.json"
+    if agent == "kiro":
+        return workspace / ".kiro" / "agents" / "kiro_default.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -2646,7 +2648,7 @@ def _print_dashboard(days: int = 7) -> None:
         risk_color = _RED if latest_risk >= 50 else _YELLOW if latest_risk >= 20 else _GREEN
 
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:
@@ -2945,7 +2947,7 @@ def _run_doctor(workspace: Path, as_json: bool = False) -> None:
 
     # 1. IDE hooks — per-agent config with the dispatcher wired in.
     agents_with_hooks: List[str] = []
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -3077,7 +3079,7 @@ def _print_status_overview(workspace: Path) -> None:
     # Hooks + mode
     agents_with_hooks: List[str] = []
     mode: Optional[str] = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from prismor.runtime.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro"]
 
 
 def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[Dict[str, Any], bool]:
@@ -30,6 +30,8 @@ def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[D
         return _strip_copilot(config, marker)
     if agent == "grok":
         return _strip_grok(config, marker)
+    if agent == "kiro":
+        return _strip_kiro(config, marker)
     return _strip_windsurf(config, marker)
 
 
@@ -58,6 +60,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_copilot(config, command)
         elif current_agent == "grok":
             config = _merge_grok(config, command)
+        elif current_agent == "kiro":
+            config = _merge_kiro(config, command)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -228,6 +232,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_copilot(payload, session_id)
     elif agent == "grok":
         event = _normalize_grok(payload, session_id, workspace)
+    elif agent == "kiro":
+        event = _normalize_kiro(payload, session_id, workspace)
     else:
         event = _normalize_cursor(payload, session_id)
     if isinstance(event, dict) and event.get("type") == "shell" and event.get("command"):
@@ -336,6 +342,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".github" / "copilot" / "hooks.json"
         if agent == "grok":
             return workspace / ".grok" / "hooks" / "prismor.json"
+        if agent == "kiro":
+            return workspace / ".kiro" / "agents" / "kiro_default.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -352,6 +360,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".copilot" / "hooks.json"
     if agent == "grok":
         return home / ".grok" / "hooks" / "prismor.json"
+    if agent == "kiro":
+        return home / ".kiro" / "agents" / "kiro_default.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -797,6 +807,34 @@ def _merge_grok(config: Dict[str, Any], command: str) -> Dict[str, Any]:
     return {**config, "hooks": hooks}
 
 
+# Kiro CLI's built-in default agent ("kiro_default") has no on-disk config
+# until one is created; whether Kiro merges a partial override with the
+# built-in tool list or replaces it outright is undocumented (kiro.dev has
+# no example of overriding kiro_default, only creating new named agents).
+# So a *fresh* file is seeded as a fully self-contained agent -- explicit
+# tools list included -- rather than a hooks-only fragment, so that even in
+# a full-replace scenario the user does not silently lose default-agent
+# tools the moment Prismor installs hooks. An existing file (the user's own
+# customized kiro_default, or a prior Prismor install) is left otherwise
+# untouched; only "hooks" is merged into it.
+_KIRO_DEFAULT_TOOLS = [
+    "read", "glob", "grep", "write", "shell", "aws", "web_search", "web_fetch",
+    "code", "introspect", "tool_search", "delegate", "subagent", "report",
+    "session", "goal", "knowledge", "thinking", "todo",
+]
+
+
+def _merge_kiro(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    if "name" not in config:
+        config = {**config, "name": "kiro_default", "tools": list(_KIRO_DEFAULT_TOOLS)}
+    hooks = dict(config.get("hooks", {}))
+    # No "matcher" field on an entry means Kiro applies it to every tool --
+    # the broadest coverage, matching the other agents' "*"/mcp__.* matchers.
+    for event_name in ["userPromptSubmit", "preToolUse", "postToolUse"]:
+        hooks[event_name] = _merge_simple_command_entries(hooks.get(event_name, []), command)
+    return {**config, "hooks": hooks}
+
+
 def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
     hooks = dict(config.get("hooks", {}))
     removed = False
@@ -846,6 +884,20 @@ def _strip_grok(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bo
             if filtered:
                 cleaned.append({**entry, "hooks": filtered})
         hooks[event_name] = cleaned
+    return {**config, "hooks": hooks}, removed
+
+
+def _strip_kiro(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        filtered = [e for e in entries if marker not in e.get("command", "")]
+        if len(filtered) < len(entries):
+            removed = True
+        hooks[event_name] = filtered
     return {**config, "hooks": hooks}, removed
 
 
@@ -981,6 +1033,47 @@ def _normalize_grok(payload: Dict[str, Any], session_id: str, workspace: Path) -
     )
     if mcp_event is not None:
         return mcp_event
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _normalize_kiro(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
+    hook_event = payload.get("hook_event_name", "unknown")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+    base = {
+        "ts": payload.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "agent": "kiro",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+    }
+    if hook_event == "userPromptSubmit":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    # Kiro's canonical tool names are snake_case (execute_bash, fs_read,
+    # fs_write, use_aws); it also accepts camelCase/short aliases (shell,
+    # read, write, aws) depending on how the calling agent config lists
+    # its tools, so match on either form.
+    if tool_name in {"shell", "execute_bash", "execute_cmd"}:
+        return {**base, "type": "shell", "command": tool_input.get("command", "")}
+    if tool_name in {"read", "fs_read", "fsRead"}:
+        return {**base, "type": "file_read", "path": tool_input.get("path", "")}
+    if tool_name in {"write", "fs_write", "fsWrite"}:
+        # fs_write's documented shape is {"operations": [{"mode": ..., "path": ...}]}
+        # rather than a flat {path, content} -- the exact per-mode content field
+        # is not documented, so this is a best-effort extraction from the first
+        # operation with several fallback field names.
+        ops = tool_input.get("operations") or []
+        first_op = ops[0] if ops and isinstance(ops[0], dict) else {}
+        path = tool_input.get("path") or first_op.get("path", "")
+        content = (
+            tool_input.get("content")
+            or first_op.get("content")
+            or first_op.get("text")
+            or first_op.get("newText", "")
+        )
+        return {**base, "type": "file_write", "path": path, "content": content}
+    if tool_name in {"web_fetch", "web_search"}:
+        return {**base, "type": "network", "url": tool_input.get("url", "")}
     return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 

--- a/prismor/runtime/integrations/registry.yaml
+++ b/prismor/runtime/integrations/registry.yaml
@@ -121,6 +121,19 @@ agents:
     notes: "Also natively reads .claude/settings.json and .cursor/hooks.json. Tool-name matchers assume Claude-Code-compatible tool names (Bash/Read/Edit/Write/...) by analogy; not yet verified against a live grok binary."
     sources: ["https://docs.x.ai/build/features/hooks", "https://docs.x.ai/build/overview"]
 
+  - id: kiro
+    name: Kiro CLI (AWS)
+    kind: coding-agent
+    surface: hook-config
+    status: shipped
+    config_paths: { project: ".kiro/agents/kiro_default.json", user: "~/.kiro/agents/kiro_default.json" }
+    events: [userPromptSubmit, preToolUse, postToolUse]
+    blocking: exit-2
+    normalizer: _normalize_kiro
+    sweep_dir: "~/.kiro/"
+    notes: "Hooks live inside a named agent config, not a dedicated hooks file. Kiro's merge-vs-replace semantics for a partial kiro_default.json override are undocumented, so a fresh install seeds a self-contained config (explicit tools list included) rather than a hooks-only fragment. Not yet verified against a live kiro-cli binary."
+    sources: ["https://kiro.dev/docs/cli/hooks/", "https://kiro.dev/docs/cli/custom-agents/configuration-reference/", "https://github.com/Ar9av/agent-manual/blob/main/tools/kiro/README.md"]
+
   # ── Coding agents — roadmap (hook surface exists, adapter not built) ──────
   - id: gemini
     name: Gemini CLI (Google)
@@ -143,17 +156,6 @@ agents:
     blocking: throw
     normalizer: null
     sources: ["https://opencode.ai/docs/plugins/"]
-
-  - id: kiro
-    name: Kiro (AWS)
-    kind: coding-agent
-    surface: hook-config
-    status: roadmap
-    config_paths: { project: ".kiro/hooks/", user: "~/.kiro/" }
-    events: [preToolUse, postToolUse]
-    blocking: exit-2
-    normalizer: null
-    sources: ["https://kiro.dev/docs/cli/hooks/"]
 
   - id: factory-droid
     name: Factory Droid

--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -237,6 +237,7 @@ def _detect_agents(target: Path) -> dict:
         "hermes":   shutil.which("hermes") is not None or (target / ".hermes").exists(),
         "codex":    shutil.which("codex") is not None or (target / ".codex").exists() or (home / ".codex").exists(),
         "grok":     shutil.which("grok") is not None or (target / ".grok").exists() or (home / ".grok").exists(),
+        "kiro":     shutil.which("kiro-cli") is not None or shutil.which("kiro") is not None or (target / ".kiro").exists() or (home / ".kiro").exists(),
     }
 
 
@@ -309,6 +310,7 @@ def _step_agents(target: Path) -> list:
         {"name": "hermes",   "label": "Hermes",      "on": detected.get("hermes", False)},
         {"name": "codex",    "label": "Codex",       "on": detected.get("codex", False)},
         {"name": "grok",     "label": "Grok Build",  "on": detected.get("grok", False)},
+        {"name": "kiro",     "label": "Kiro CLI",    "on": detected.get("kiro", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True

--- a/prismor/runtime/sweep.py
+++ b/prismor/runtime/sweep.py
@@ -54,6 +54,7 @@ TOOL_DIRS: dict[str, Path] = {
     "trae": Path.home() / ".trae",
     "kilocode": Path.home() / ".kilocode",
     "grok": Path.home() / ".grok",
+    "kiro": Path.home() / ".kiro",
 }
 
 # Config files that should NEVER be redacted (they hold keys the tools need)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -260,6 +260,7 @@ def detect_agents(target):
         "openclaw": shutil.which("openclaw") is not None or (td/".openclaw").exists() or (home/".openclaw").exists(),
         "hermes":   shutil.which("hermes") is not None or (td/".hermes").exists() or (home/".hermes").exists(),
         "grok":     shutil.which("grok") is not None or (td/".grok").exists() or (home/".grok").exists(),
+        "kiro":     shutil.which("kiro-cli") is not None or shutil.which("kiro") is not None or (td/".kiro").exists() or (home/".kiro").exists(),
     }
 
 # ── Severity colors ──────────────────────────────────────────────────────────
@@ -327,6 +328,7 @@ def step_agents(target):
         {"name": "openclaw", "label": "OpenClaw",     "on": detected.get("openclaw", False)},
         {"name": "hermes",   "label": "Hermes",       "on": detected.get("hermes", False)},
         {"name": "grok",     "label": "Grok Build",   "on": detected.get("grok", False)},
+        {"name": "kiro",     "label": "Kiro CLI",     "on": detected.get("kiro", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -16,6 +16,7 @@ from prismor.runtime.hooks import (
     _strip_codex,
     _strip_cursor,
     _strip_grok,
+    _strip_kiro,
     _strip_windsurf,
     install_hooks,
     normalize_payload,
@@ -168,6 +169,33 @@ class TestStripGrok(unittest.TestCase):
         self.assertFalse(removed)
 
 
+class TestStripKiro(unittest.TestCase):
+    """Test _strip_kiro removes Prismor entries."""
+
+    def test_removes_prismor_hooks(self):
+        marker = "/repo/prismor/runtime/cli.py"
+        config = {
+            "name": "kiro_default",
+            "hooks": {
+                "preToolUse": [
+                    {"command": f'python3 "{marker}" hook-dispatch --agent kiro'},
+                    {"command": "other-tool --check"},
+                ]
+            },
+        }
+        result, removed = _strip_kiro(config, marker)
+        self.assertTrue(removed)
+        self.assertEqual(len(result["hooks"]["preToolUse"]), 1)
+        self.assertEqual(result["hooks"]["preToolUse"][0]["command"], "other-tool --check")
+        # Non-hooks fields (name, tools, ...) survive stripping untouched.
+        self.assertEqual(result["name"], "kiro_default")
+
+    def test_no_change(self):
+        config = {"hooks": {"preToolUse": [{"command": "unrelated"}]}}
+        result, removed = _strip_kiro(config, "/repo/prismor/runtime/cli.py")
+        self.assertFalse(removed)
+
+
 class TestStripWindsurf(unittest.TestCase):
     """Test _strip_windsurf removes Prismor entries."""
 
@@ -228,6 +256,8 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
             config_path = self.workspace / ".codex" / "hooks.json"
         elif agent == "grok":
             config_path = self.workspace / ".grok" / "hooks" / "prismor.json"
+        elif agent == "kiro":
+            config_path = self.workspace / ".kiro" / "agents" / "kiro_default.json"
         else:
             config_path = self.workspace / ".windsurf" / "hooks.json"
         self.assertTrue(config_path.exists())
@@ -266,6 +296,47 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
 
     def test_grok_roundtrip(self):
         self._roundtrip("grok")
+
+    def test_kiro_roundtrip(self):
+        self._roundtrip("kiro")
+
+    def test_kiro_install_seeds_full_tools_list_on_fresh_config(self):
+        # Kiro's merge-vs-replace semantics for a partial kiro_default.json
+        # override are undocumented, so a fresh install must be a
+        # self-contained agent config (explicit tools included) rather than
+        # a hooks-only fragment -- otherwise a full-replace-on-load Kiro
+        # would silently strip every default-agent tool the moment Prismor
+        # installs hooks.
+        install_hooks(
+            repo_root=self.repo_root, workspace=self.workspace,
+            agent="kiro", scope="project", mode="observe",
+        )
+        config_path = self.workspace / ".kiro" / "agents" / "kiro_default.json"
+        config = json.loads(config_path.read_text())
+        self.assertEqual(config["name"], "kiro_default")
+        self.assertIn("shell", config["tools"])
+        self.assertIn("read", config["tools"])
+        self.assertIn("write", config["tools"])
+
+    def test_kiro_install_preserves_existing_agent_config_fields(self):
+        # An existing kiro_default.json (the user's own customization, or a
+        # prior Prismor install) must not be clobbered -- only "hooks" gets
+        # merged in.
+        config_path = self.workspace / ".kiro" / "agents" / "kiro_default.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(json.dumps({
+            "name": "kiro_default",
+            "model": "claude-opus-4",
+            "tools": ["read", "write"],
+        }))
+        install_hooks(
+            repo_root=self.repo_root, workspace=self.workspace,
+            agent="kiro", scope="project", mode="observe",
+        )
+        config = json.loads(config_path.read_text())
+        self.assertEqual(config["model"], "claude-opus-4")
+        self.assertEqual(config["tools"], ["read", "write"])
+        self.assertIn("preToolUse", config["hooks"])
 
     def test_codex_install_enables_hooks_feature_flag_on_fresh_config(self):
         # Regression for PrismorSec/prismor#149: without [features].hooks set
@@ -738,6 +809,61 @@ class TestNormalizePayloadGrok(unittest.TestCase):
         result = normalize_payload(agent="grok", payload=payload, workspace=Path("/tmp"))
         event = result["event"]
         self.assertEqual(event["type"], "file_write")
+        self.assertIn("lodash", event["content"])
+
+
+class TestNormalizePayloadKiro(unittest.TestCase):
+    """Test Kiro CLI payload normalization (lowerCamelCase event names, snake_case/alias tool names)."""
+
+    def test_user_prompt(self):
+        payload = {
+            "hook_event_name": "userPromptSubmit",
+            "session_id": "kiro-1",
+            "prompt": "Review this change",
+        }
+        result = normalize_payload(agent="kiro", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "prompt")
+        self.assertEqual(event["prompt"], "Review this change")
+        self.assertEqual(event["agent"], "kiro")
+
+    def test_shell_tool_canonical_name(self):
+        payload = {
+            "hook_event_name": "preToolUse",
+            "session_id": "kiro-2",
+            "tool_name": "execute_bash",
+            "tool_input": {"command": "git status"},
+        }
+        result = normalize_payload(agent="kiro", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "git status")
+
+    def test_shell_tool_alias_name(self):
+        payload = {
+            "hook_event_name": "preToolUse",
+            "session_id": "kiro-3",
+            "tool_name": "shell",
+            "tool_input": {"command": "rm -rf /"},
+        }
+        result = normalize_payload(agent="kiro", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "rm -rf /")
+
+    def test_fs_write_tool_maps_to_file_write(self):
+        payload = {
+            "hook_event_name": "preToolUse",
+            "session_id": "kiro-4",
+            "tool_name": "fs_write",
+            "tool_input": {
+                "operations": [{"mode": "Line", "path": "/repo/package.json", "text": "lodash"}],
+            },
+        }
+        result = normalize_payload(agent="kiro", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "file_write")
+        self.assertEqual(event["path"], "/repo/package.json")
         self.assertIn("lodash", event["content"])
 
 


### PR DESCRIPTION
## Summary
- Adds Kiro CLI (AWS) as a supported coding-agent hook integration, following the same `install-hooks`/`hook-dispatch` pipeline as the other 8 shipped agents.
- **Structurally different from every other agent**: Kiro's hooks live inside a *named agent config* (`.kiro/agents/kiro_default.json`), not a dedicated hooks file, and the built-in default agent (`kiro_default`) has no on-disk file until one is created.
- Registers `userPromptSubmit`/`preToolUse`/`postToolUse`; `preToolUse` blocks via plain exit-2 + stderr (Kiro forwards stderr to the model directly — no structured stdout JSON needed, unlike Grok/Copilot), which fits the existing fail-closed default branch already used for Cursor/Windsurf/Codex, so no new branch was needed in `cli.py`.
- Tool-name normalization covers Kiro's snake_case canonical names + aliases (`execute_bash`/`shell`, `fs_read`/`read`, `fs_write`/`write`, `use_aws`/`aws`).
- Updates the *existing* `roadmap`-status `kiro` registry entry (which had the wrong config path and a null normalizer) in place, rather than adding a duplicate.

## Key design decision — flagged for review
Whether Kiro merges a partial `kiro_default.json` override with its built-in tool list, or replaces it outright, is **undocumented** — kiro.dev has no example of overriding the built-in default agent, only creating new named ones. Guessing wrong here could silently strip a user's default tools (`read`/`write`/`shell`/...) the moment Prismor installs hooks — a materially worse failure mode than "hooks miss some tool calls."

Mitigation: a *fresh* install seeds a **self-contained** agent config (explicit `tools` list included, see `_KIRO_DEFAULT_TOOLS` in `hooks.py`) rather than a hooks-only fragment, so even in a full-replace scenario the user keeps their tools. An *existing* file (prior customization or prior Prismor install) is left otherwise untouched — only `"hooks"` is merged in. Covered by `test_kiro_install_seeds_full_tools_list_on_fresh_config` and `test_kiro_install_preserves_existing_agent_config_fields`.

## Caveat
Not yet verified against a live `kiro-cli` binary. Built from [kiro.dev/docs/cli/hooks](https://kiro.dev/docs/cli/hooks/), the [agent config reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/), and community documentation at [Ar9av/agent-manual](https://github.com/Ar9av/agent-manual/blob/main/tools/kiro/README.md). Flagged explicitly in `AGENT_INTEGRATIONS.md` and the registry `notes` field.

## Test plan
- [x] `pytest tests/test_hooks.py tests/test_hooks_extended.py` — 98 passed, including new `TestStripKiro`, `TestNormalizePayloadKiro`, `test_kiro_roundtrip`, and the two merge-safety tests above.
- [x] `pytest tests/` full suite — no new failures (pre-existing unrelated failures unchanged).
- [x] `scripts/verify_registry.sh` — schema valid, coverage matrix in sync.
- [x] Live dry run in a scratch workspace: `install-hooks --agent kiro` on a fresh workspace wrote the documented schema with the full tools-list safety net; a `preToolUse` payload for `rm -rf /` was denied via stderr + exit 2, an allowed command returned exit 0, and `uninstall-hooks --agent kiro` cleaned up the hook entries while leaving `name`/`tools` intact.