### PR TITLE
fix(setup): default interactive wizard to observe mode

### DIFF
--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -273,7 +273,7 @@ def _control_line(items: List[tuple]) -> str:
 
 # ── Step 1: Enforcement Mode ─────────────────────────────────────────────────
 
-def _step_mode(current: str = "enforce") -> str:
+def _step_mode(current: str = "observe") -> str:
     opts = [
         ("observe", "Log and warn, never block"),
         ("enforce", "Block dangerous actions in real time"),
@@ -775,7 +775,7 @@ def run_wizard(target: Path) -> None:
     # step. Rules are loaded only so the confirm screen can show the count and
     # _do_install can write policy overrides if any are ever disabled.
     rules = _load_rules()
-    mode = "enforce"
+    mode = "observe"
     agents = None
     cloak = True
     scope = "project"
@@ -815,7 +815,7 @@ def run_wizard(target: Path) -> None:
                 break
     except Exception:
         rules = _load_rules()
-        mode = "enforce"
+        mode = "observe"
         agents = ["claude"]
         cloak = False
         scope = "project"


### PR DESCRIPTION
## Summary
- The interactive TUI wizard (\`prismor setup\`) defaulted its mode-selection step to \`enforce\`, while every non-interactive path (\`--non-interactive\`, \`install-hooks\`, the \`policy_engine\` fallback) already defaults to \`observe\`.
- Aligns the interactive wizard with the rest of the CLI so first-time users see \`observe\` pre-selected.

## Test plan
- [x] \`pytest tests/test_cli.py\` — 40 passed, 4 pre-existing unrelated failures (analyze/cloak-env tests, environment-specific, untouched by this change)
- [x] Manually verified the three default sites: \`_step_mode()\`, \`run_wizard()\` initial value, and its exception fallback