### PR TITLE
docs: add agentic AI architecture review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 🧾 [Signed Audit Trail](docs/audit-trail.md) hash-chains and Ed25519-signs every agent action locally, so `prismor trail verify` proves the history hasn't been edited, deleted, or rewritten
 - 📑 [Attestation Bundle](docs/attestation-bundle.md) packages posture, agent inventory, host discovery, framework-control coverage (OWASP LLM/Agentic, NIST AI RMF, EU AI Act), and the trail anchor into one Ed25519-signed file an auditor re-verifies with `prismor attest verify`
 - 🔦 [Host Discovery](docs/attestation-bundle.md#host-discovery) sweeps the machine with `prismor discover` and flags any AI agent running without Prismor hooks (shadow AI)
+- 🗺️ [Agentic AI Architecture Review](docs/agentic-architecture-review.md) is a design-time checklist for multi-agent/tool-using systems — permission scope, memory integrity, inter-agent trust, human-oversight placement — each item mapped to a real control ID and, where one exists, the Prismor rule that backstops it
 - 🐳 [Docker and Containers](docs/docker.md) covers container hardening, prerequisites, and known limitations
 
 Full command map across every capability: [CLI Reference](docs/cli-reference.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -208,6 +208,7 @@ pick the smallest tool that answers the question:
 | "Show all registered workspaces" | `prismor status --all` (terminal overview across every workspace where hooks are installed) |
 | "Open the dashboard" | `prismor dashboard` → http://127.0.0.1:7070 (opens a browser; `--no-open` for headless) |
 | "Am I on the latest version?" | `prismor update --check` (install with `prismor update`) |
+| "Review my agent/tool architecture for security gaps" | walk [`docs/agentic-architecture-review.md`](./docs/agentic-architecture-review.md), then `prismor attest coverage` for what's already enforced |
 
 ---
 
@@ -249,6 +250,7 @@ Capability deep dives:
 - [`docs/hermes.md`](./docs/hermes.md): Hermes Agent integration — secret cloaking plugin, pip auto-discovery, CLI install path
 - [`docs/semantic-guard.md`](./docs/semantic-guard.md): opt-in LLM-assisted prompt-injection guard
 - [`docs/skill-scanner.md`](./docs/skill-scanner.md): MCP server + skill risk scanning
+- [`docs/agentic-architecture-review.md`](./docs/agentic-architecture-review.md): design-time checklist for multi-agent/tool-using system architecture, mapped to OWASP Agentic AI, OWASP LLM Top 10, NIST AI RMF, and EU AI Act controls
 - [`docs/network-isolation.md`](./docs/network-isolation.md): egress allowlists, raw-IP detection
 - [`docs/canary.md`](./docs/canary.md): honeytoken tripwires for recon detection
 - [`docs/iam.md`](./docs/iam.md): named agent identities and permission profiles

--- a/docs/agentic-architecture-review.md
+++ b/docs/agentic-architecture-review.md
@@ -1,0 +1,224 @@
+# Agentic AI Architecture Review
+
+A structured checklist for reviewing the **design** of a multi-agent or
+tool-using AI system — before it ships, when you add a new tool or agent, or
+on a recurring cadence. It is a companion to [Attestation
+Bundle](attestation-bundle.md#framework-coverage): `prismor attest coverage`
+reports what your *runtime* policy already enforces at the tool-call boundary;
+this checklist covers the design decisions a tool-call interceptor cannot see
+at all — service account scope, memory store architecture, inter-agent trust,
+approval-gate placement. Some findings here translate into a Prismor policy
+rule. Others are architecture choices no runtime guard can retrofit.
+
+Every category below cites a real control ID already used in this repo's own
+framework packs (`prismor/runtime/checklists/*.yaml`) so the mapping between
+"design review finding" and "runtime control" stays concrete instead of
+aspirational.
+
+## When to use this
+
+- Before an agent gets its first tool, API credential, or system-command
+  access.
+- When a new agent joins an existing multi-agent pipeline (orchestrator/worker,
+  swarm, hierarchical delegation).
+- When an agent gains persistent memory (vector store, session database,
+  scratchpad) that survives across sessions.
+- Before a compliance review (SOC 2, ISO 27001, EU AI Act high-risk
+  obligations) that now needs an AI risk assessment.
+- On a recurring cadence for any agent with standing credentials or write
+  access — tool lists and permissions drift upward over time if nobody prunes
+  them.
+
+## Review categories
+
+### 1. Permission scope (`owasp-llm-top10:LLM06`, `owasp-agentic-t10:T03`)
+
+**Design question:** does every agent identity hold only the tools and data
+access its specific task requires, or does it inherit a broader credential
+(the deploying user's session, a shared service account, an admin-scoped API
+key)?
+
+**Look for:**
+- Tool registrations broader than the task (an agent that only needs to read
+  a table also has write/delete).
+- One service account or API key shared across multiple agents.
+- Tool lists that grow without a pruning step — permission drift.
+
+**Runtime backstop:** Prismor's `privilege-escalation` and
+`agent-config-tampering` rules catch an agent trying to *use* excess privilege
+at the tool-call boundary; they cannot tell you the privilege was
+over-provisioned in the first place. Least-privilege scoping is a design-time
+fix. See [IAM](iam.md) for per-agent identity and permission profiles, and
+[Scoped Agent](scoped-agent.md) for session-scoped, task-derived
+`allowed_tools`/`deny_tools`.
+
+### 2. Tool input/output handling (`owasp-agentic-t10:T02`, `owasp-llm-top10:LLM05`)
+
+**Design question:** do tool schemas validate inputs, or does the agent pass
+free-form, model-generated strings straight into a shell, a SQL query, or a
+filesystem path? Are tool *outputs* sanitized before they re-enter the agent's
+context?
+
+**Look for:**
+- A SQL or shell tool that accepts a raw string instead of parameterized
+  arguments.
+- Filesystem tools where the path argument is fully agent-controlled.
+- No validation on tool results before they're fed back into the next
+  reasoning step (a compromised or malicious tool output becomes trusted
+  context).
+
+**Runtime backstop:** `destructive-command`, `remote-execution`, and
+`model-manipulation` cover known-dangerous command and output-tampering
+patterns at runtime. Schema-level input validation and output sanitization on
+custom tools is not something a hook can add after the fact — it has to be
+built into the tool.
+
+### 3. Persistent memory integrity (`owasp-agentic-t10:ASI06`)
+
+**Design question:** can an agent write to its own long-term memory (vector
+store, conversation history, shared scratchpad) based on content it did not
+author — a document it summarized, a page it browsed, another agent's
+output? If so, is that memory trusted the same way on the next session?
+
+**Look for:**
+- Vector databases the agent both reads from and writes to with no source
+  provenance tracked.
+- Shared memory in multi-agent systems where any agent can write context
+  another agent later treats as fact.
+- No TTL or review cycle on memory entries sourced from untrusted input.
+
+**Runtime backstop:** Prismor's `memory-embedded-directive` rule (category
+`memory_poisoning`) scans project memory files (`CLAUDE.md`, `AGENTS.md`) for
+embedded directives on session start and fires a `memory_poisoning` finding —
+currently **warn**, not block, by design, since legitimate project
+conventions and a poisoned instruction can read identically without further
+context. Treat this rule as a detection signal to review, not a guarantee the
+memory is clean. Broader agent-memory stores (vector DBs, custom scratchpads)
+are outside this rule's scope and need their own provenance/TTL design.
+
+### 4. Inter-agent trust boundaries (`owasp-agentic-t10:T03`)
+
+**Design question:** in a multi-agent system, does a receiving agent verify
+the identity and authorization of the agent that sent it a message, or does
+it treat inbound agent-to-agent messages as trusted by default?
+
+**Look for:**
+- Orchestrator/worker or swarm patterns where inter-agent messages are plain
+  text with no authentication envelope.
+- A downstream agent that executes instructions embedded in an upstream
+  agent's output without re-validating them as untrusted input.
+- No documented trust model stating which agents may instruct which others,
+  and for what operations.
+
+**Runtime backstop:** none today — Prismor governs the tool-call boundary
+between an agent and its host machine, not agent-to-agent message passing
+inside a custom orchestration framework. This is a pure design review item:
+treat every inbound inter-agent message the same way you'd treat untrusted
+user input.
+
+### 5. Data exfiltration paths (`owasp-llm-top10:LLM02`)
+
+**Design question:** does any single agent have simultaneous access to
+sensitive data (source code, credentials, PII, financial records) *and* a
+tool that can send data somewhere external (HTTP requests, email, webhooks,
+chat integrations)?
+
+**Look for:**
+- One agent session with both a database-read tool and a web-request tool.
+- Tool parameters that accept arbitrary URLs, email addresses, or webhook
+  endpoints — each is an exfiltration channel.
+- Agent-generated markdown or HTML that renders external image URLs (a known
+  encode-data-in-the-request-line pattern).
+
+**Runtime backstop:** `secret-exfiltration`, `bulk-pii-exfiltration`,
+`secret-in-url-params`, and `credential-in-header` catch known exfiltration
+shapes in tool-call parameters. [Network Isolation](network-isolation.md)
+lets you allowlist egress destinations so an unexpected webhook or raw-IP
+target is blocked regardless of what triggered the call. Separating
+data-reading agents from communication-capable agents is still a design
+choice these controls only backstop, not replace.
+
+### 6. Human-in-the-loop placement (`nist-ai-rmf:MANAGE-2.1`, `eu-ai-act:ART14`)
+
+**Design question:** for actions that need a human sign-off, is the approval
+gate enforced outside the agent's reach (a separate service), or can the
+agent influence whether the gate fires — batching actions below a threshold,
+rephrasing a request to look routine, or hitting a fail-open path when the
+approval service is unavailable?
+
+**Look for:**
+- Approval thresholds stored somewhere the agent can write to.
+- Batch operations that bundle several risky actions into one low-context
+  approval request.
+- A fail-open path: if the approval service is down, the action proceeds
+  instead of halting.
+
+**Runtime backstop:** Prismor's step-up approval subsystem is the
+human-oversight control mapped to `nist-ai-rmf:MANAGE-2.1` and
+`eu-ai-act:ART14` in the framework crosswalk — a rule set to require approval
+halts execution until a human confirms, and fails closed if that confirmation
+never arrives. Whether the *right* actions are gated at all is still a design
+decision made in your policy, not something the runtime infers on its own.
+
+### 7. Resource and cost bounds (`owasp-llm-top10:LLM10`, `owasp-agentic-t10:T04`)
+
+**Design question:** does any agent or recursive agent-spawning pattern have
+a hard ceiling on tokens, API calls, or spend per session, or can a reasoning
+loop or adversarial input run unbounded?
+
+**Look for:**
+- No token or cost budget per agent session or per identity.
+- Recursive agent spawning (agent creates sub-agents) with no depth limit.
+- Retry logic without a maximum attempt count or backoff.
+
+**Runtime backstop:** the `dos-resource-exhaustion` rule catches known
+resource-exhaustion command patterns at the tool-call layer. Token/cost
+budgets and recursion depth limits live in the agent framework or
+orchestrator configuration and need to be set independently of any runtime
+guard.
+
+### 8. Agent identity and credential hygiene (`owasp-llm-top10:LLM02`, `soc2:CC6.1`)
+
+**Design question:** does each agent instance have its own verifiable,
+short-lived identity, or do multiple agents share one long-lived API key —
+making it impossible to tell, after an incident, which agent did what?
+
+**Look for:**
+- A single static API key referenced by every agent in the deployment.
+- Credentials embedded in agent configuration or environment variables with
+  no rotation.
+- Audit logs that record actions under a generic "agent" identity instead of
+  a specific agent/session ID.
+
+**Runtime backstop:** [IAM](iam.md) gives each agent a named identity and
+least-privilege permission profile; the [Signed Audit
+Trail](audit-trail.md) hash-chains every action Prismor observes to the
+identity that took it, so a post-incident review isn't blocked on "which
+agent was this." Prismor cannot invent per-agent identity if your deployment
+never creates one — that has to exist upstream.
+
+## After the review
+
+Findings that map to an existing Prismor rule (see `map:` in
+`prismor/runtime/checklists/crosswalk.v1.yaml`) become a policy check you can
+verify stays enforced over time:
+
+```bash
+prismor attest coverage        # confirm the mapped controls are covered by an active rule
+prismor attest                 # bundle posture + coverage + audit-trail anchor into one signed file
+```
+
+Findings with no runtime backstop (categories 3's memory-store architecture,
+category 4, most of category 6 and 8) are design fixes: least-privilege
+service accounts, signed inter-agent messages, fail-closed approval services,
+per-agent credential issuance. Track them the same way you'd track any other
+architecture debt — they won't show up in `prismor audit` until you build the
+control that makes them visible.
+
+## Limitations
+
+This is a design checklist, not a scanner. It depends on you (or the agent
+running it) actually reading the architecture, tool schemas, and
+configuration — it cannot prove a control exists or a threat is absent when
+the evidence is unavailable or runtime-only. Treat every finding as a
+hypothesis to confirm against the real system, not a verdict.


### PR DESCRIPTION
## Summary
- Adds `docs/agentic-architecture-review.md`: a design-time checklist for reviewing multi-agent/tool-using system architecture — permission scope, tool input/output handling, persistent memory integrity, inter-agent trust boundaries, data exfiltration paths, human-in-the-loop placement, resource bounds, and agent identity/credential hygiene.
- Every category cites a real control ID already defined in this repo's own framework packs (`prismor/runtime/checklists/*.yaml`) and, where one exists, links to the Prismor rule/subsystem that backstops it at runtime — no invented control numbers.
- Explicitly scoped as a **complement** to `prismor attest coverage` (which reports runtime enforcement posture): this doc covers the architecture decisions a tool-call interceptor can't observe at all (e.g. service-account scope, memory-store design, inter-agent authentication), and says so.
- Wires it into `SKILL.md`'s on-demand-audits table and reference section, and into the README docs index, following the existing doc-linking conventions.

## Test plan
- [x] `python3 scripts/check_oss_safe.py` — passes (no leaks/must-never-ship material)
- [x] Every framework control ID cited (`owasp-llm-top10:*`, `owasp-agentic-t10:*`, `nist-ai-rmf:*`, `eu-ai-act:*`, `soc2:*`) verified against `prismor/runtime/checklists/*.yaml` and `crosswalk.v1.yaml`
- [x] All linked docs (`iam.md`, `scoped-agent.md`, `network-isolation.md`, `audit-trail.md`, `attestation-bundle.md`) confirmed to exist
- [ ] Docs-only change — no runtime behavior affected