### PR TITLE
feat(runtime): print scoped unblock steps on every enforcement block

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -127,6 +127,14 @@ def _color(text: str, color: str) -> str:
     return f"{color}{text}{_NC}"
 
 
+def _block_header(finding: Dict[str, Any]) -> str:
+    """The first stderr line of a deny — carries the rule id every override needs."""
+    line = f"Prismor blocked this action: [{finding['severity']}] {finding['title']}"
+    if finding.get("ruleId"):
+        line += f" (rule: {finding['ruleId']})"
+    return line + "\n"
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -970,10 +978,34 @@ def main(argv: Optional[List[str]] = None) -> None:
             # (async approval queue); here they deny with a clear reason.
             verdict = str(blocking.get("action") or "block").lower()
             reason = f"[{blocking['severity']}] {blocking['title']}"
+            if blocking.get("ruleId"):
+                # The rule id is what every override — allowlist, mode, exemption
+                # — is keyed on. Without it here the human has to go hunting at
+                # exactly the moment they need it.
+                reason += f" (rule: {blocking['ruleId']})"
             if blocking.get("evidence"):
                 reason += f"\n{blocking['evidence']}"
             if blocking.get("remediation"):
                 reason += f"\nRecommended fix: {blocking['remediation']}"
+
+            # Narrowest-first unblock steps, so a false positive costs one
+            # allowlist entry rather than an uninstall.
+            unblock_text = ""
+            try:
+                from prismor.runtime import unblock as _unblock
+                from prismor.runtime.enterprise import identity as _identity
+                from prismor.runtime.enterprise import workspace_scope as _scope
+                unblock_text = _unblock.format_unblock(
+                    blocking,
+                    workspace=workspace,
+                    session_id=normalized["sessionId"],
+                    org_managed=_scope.is_managed(workspace),
+                    enrolled=_identity.is_enrolled(),
+                )
+            except Exception:
+                pass  # best-effort — a block must never depend on its own help text
+            if unblock_text:
+                reason += f"\n\n{unblock_text}"
 
             if verdict == "defer":
                 # DEFER: hold the ambiguous action and escalate to the deeper
@@ -1048,14 +1080,18 @@ def main(argv: Optional[List[str]] = None) -> None:
                     # Grok Build reads {"decision": "deny", "reason": ...} from stdout
                     # AND requires exit code 2 (unlike Copilot, which ignores exit code).
                     sys.stdout.write(json.dumps({"decision": "deny", "reason": reason}) + "\n")
-                    sys.stderr.write(f"Prismor blocked this action: [{blocking['severity']}] {blocking['title']}\n")
+                    sys.stderr.write(_block_header(blocking))
+                    if unblock_text:
+                        sys.stderr.write(f"\n{unblock_text}\n")
                     raise SystemExit(2)
                 else:
-                    sys.stderr.write(f"Prismor blocked this action: [{blocking['severity']}] {blocking['title']}\n")
+                    sys.stderr.write(_block_header(blocking))
                     if blocking.get("evidence"):
                         sys.stderr.write(f"{blocking['evidence']}\n")
                     if blocking.get("remediation"):
                         sys.stderr.write(f"Recommended fix: {blocking['remediation']}\n")
+                    if unblock_text:
+                        sys.stderr.write(f"\n{unblock_text}\n")
                     raise SystemExit(2)
         elif current_findings:
             # Observe: surface all findings so agents know every package to fix.

--- a/prismor/runtime/unblock.py
+++ b/prismor/runtime/unblock.py
@@ -1,0 +1,271 @@
+"""Human-actionable unblock steps to print alongside an enforcement block.
+
+A block that only says "no" pushes the human toward the one lever they can
+always find: turning Prismor off. Every deny path therefore prints the
+*narrowest* override that would let this specific call through — one call, one
+rule, one session, one repo — and only then the broader ones. The floor rules
+say so plainly instead of offering an override that would be silently ignored.
+
+The steps address the human at the keyboard, not the model. `.prismor/policy.yaml`
+and the agent hook configs are guarded by the `agent-config-tampering` rule, so
+an agent that tries to apply them for itself just earns a second block.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from prismor.runtime.policy_engine import (
+    _CORE_BLOCK_CATEGORIES,
+    _NON_OVERRIDABLE_RULE_IDS,
+)
+
+# Longest evidence we will paste back as a literal allowlist pattern. Beyond
+# this the string is probably a whole command line whose incidental parts (pids,
+# temp paths, timestamps) would never match twice, so a copied pattern would be
+# a dead entry that leaves the user believing they made an exception.
+_MAX_LITERAL_EVIDENCE = 120
+
+# Longest rule pattern worth quoting back. The core rules carry multi-line
+# lookahead regexes that fill a screen; past this, naming the rule is kinder.
+_MAX_READABLE_PATTERN = 80
+
+
+def is_floor(finding: Dict[str, Any]) -> bool:
+    """True when no local policy layer can disable or weaken this finding.
+
+    Mirrors the clamp in PolicyEngine._apply_override: for these rule IDs and
+    categories, `enabled: false`, `mode: observe` and `disable_patterns` are
+    dropped from every override layer, including a signed org bundle.
+    """
+    return (
+        str(finding.get("ruleId") or "") in _NON_OVERRIDABLE_RULE_IDS
+        or str(finding.get("category") or "") in _CORE_BLOCK_CATEGORIES
+    )
+
+
+def _policy_path(workspace: Optional[Path]) -> str:
+    return str((workspace / ".prismor" / "policy.yaml")) if workspace else ".prismor/policy.yaml"
+
+
+def _literal_pattern(finding: Dict[str, Any]) -> Optional[str]:
+    """A regex matching exactly this evidence, or None if it won't generalize.
+
+    Three things make a suggestion worse than none, because each yields an entry
+    that looks right and silently never matches:
+      - truncated evidence (`_truncate` appends an ellipsis at 220 chars);
+      - evidence long enough to be a whole command line, whose pids and temp
+        paths would never recur;
+      - a newline, which YAML would fold into a space inside a quoted scalar.
+    Evidence joins each matched field with a newline, so the first line is the
+    primary one (the path or command); allowlists match with `search`, so a
+    first-line pattern still hits the joined blob.
+    """
+    evidence = str(finding.get("evidence") or "").strip()
+    first_line = evidence.split("\n", 1)[0].strip()
+    if not first_line or first_line.endswith("...") or len(first_line) > _MAX_LITERAL_EVIDENCE:
+        return None
+    return re.escape(first_line)
+
+
+def _yaml_single_quoted(value: str) -> str:
+    """Quote a regex for YAML single-quoted style.
+
+    Regexes are full of backslashes, and YAML's double-quoted style would read
+    `\\.` as an unknown escape and refuse to parse. Single-quoted style is
+    literal — only the quote itself needs doubling.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _allowlist_yaml(rule_id: str, finding: Dict[str, Any]) -> List[str]:
+    """YAML for an allowlist entry suppressing this rule for this evidence only."""
+    pattern = _literal_pattern(finding)
+    if pattern is None:
+        pattern = "<regex matching only the case you want to allow>"
+    # Column 0 for the top-level key: these lines are meant to be pasted
+    # straight into policy.yaml, and a decorative indent makes them unparseable.
+    return [
+        "allowlists:",
+        f"  - id: allow-{rule_id}",
+        f"    rule_ids: [{_yaml_single_quoted(rule_id)}]",
+        "    patterns:",
+        f"      - {_yaml_single_quoted(pattern)}",
+        "    reason: '<why this specific case is safe>'",
+    ]
+
+
+def _rule_override_steps(rule_id: str, finding: Dict[str, Any], workspace: Optional[Path]) -> List[str]:
+    """The standard narrow-to-broad ladder for an ordinary policy rule."""
+    path = _policy_path(workspace)
+    steps = [
+        f"1. Allow only this case — add to {path}:",
+    ]
+    steps += _allowlist_yaml(rule_id, finding)
+    steps += [
+        f"2. Or keep the rule but stop it blocking (still logged) — in {path}:",
+        "rules:",
+        f"  - id: {rule_id}",
+        "    mode: observe",
+        f"3. Or turn the rule off in this repo only: prismor policy edit  (or set `enabled: false` on {rule_id})",
+        f"Then verify without re-running the agent: prismor check '<your command>'",
+    ]
+    return steps
+
+
+def _floor_steps(rule_id: str, finding: Dict[str, Any], enrolled: bool) -> List[str]:
+    """Floor rules: say so, then give the outs that actually exist."""
+    steps = [
+        f"{rule_id} is a floor rule — `enabled: false`, `mode: observe` and "
+        "`disable_patterns` are ignored for it in every policy layer, so editing "
+        "policy.yaml will not clear this block.",
+    ]
+    # Only quote the pattern when a human could actually read it — the core
+    # rules carry multi-line lookahead regexes that fill a screen and tell the
+    # reader nothing the title did not.
+    pattern = str(finding.get("pattern") or "")
+    if pattern and len(pattern) <= _MAX_READABLE_PATTERN:
+        steps.append(f"1. Narrow the action so it stops matching: {pattern}")
+    else:
+        steps.append(
+            "1. Narrow the action so it stops matching — see what the rule covers "
+            f"with: prismor policy show | grep {rule_id}"
+        )
+    steps.append(
+        "2. Or run it yourself in a terminal outside the agent session — Prismor "
+        "governs agent tool calls, not you."
+    )
+    if enrolled:
+        steps.append(
+            "3. Or ask an admin for a scoped exemption: prismor exempt request "
+            '--reason "<why>" — they can grant it for one rule against this '
+            "session, device, or user, with an expiry. It lands in your next "
+            "signed policy pull."
+        )
+    return steps
+
+
+def _subsystem_steps(
+    rule_id: str,
+    finding: Dict[str, Any],
+    workspace: Optional[Path],
+    session_id: Optional[str],
+) -> Optional[List[str]]:
+    """Steps for blocks that policy.yaml does not govern. None = not one of these."""
+    if rule_id == "agent-disabled":
+        # Not a policy rule: a kill switch in agents.yaml or the org control
+        # plane, hardcoded to enforce. An allowlist would do nothing. The
+        # finding's own remediation already names the layer that pulled it
+        # (local / org / both), and only that layer can lift it — so defer to
+        # it rather than invent a second, vaguer answer.
+        steps = ["This agent is paused — every tool call is blocked, not just this one."]
+        remediation = str(finding.get("remediation") or "").strip()
+        if remediation:
+            steps.append(f"1. {remediation}")
+        steps.append("2. Check which layer paused it: prismor agents list")
+        return steps
+
+    if rule_id == "iam":
+        path = str((workspace / ".prismor" / "iam.yaml")) if workspace else ".prismor/iam.yaml"
+        return [
+            "This is an agent identity limit, not a policy rule.",
+            f"1. See what this identity may do: prismor iam show $PRISMOR_AGENT_ID",
+            f"2. Grant the tool in {path} (or ~/.prismor/iam.yaml) — remove it from "
+            "`deny_tools`, or add it to `allow_tools`.",
+            "3. Or run the agent under an identity that already has it: PRISMOR_AGENT_ID=<name>",
+        ]
+
+    if rule_id == "scoped-agent":
+        sid = session_id or "<session-id>"
+        return [
+            "This is a session scope Prismor synthesized from your first prompt — "
+            "it is not a policy rule and it dies with the session.",
+            f"1. See the scope: prismor scope show {sid}",
+            f"2. Widen it: prismor scope edit {sid}",
+            f"3. Or drop it for this session entirely: prismor scope clear {sid}",
+        ]
+
+    if rule_id == "tool-category-crossover":
+        path = _policy_path(workspace)
+        return [
+            "This is the tool-category crossover guard: the session combined tool "
+            "tags your policy declares incompatible. The finding cannot be "
+            "downgraded once it fires, so relax the tagging instead — in "
+            f"{path}, under `settings.tool_tags`:",
+            "  - drop the tag from the tool that should not carry it (`tags:`), or",
+            "  - narrow which tag pairs conflict (`incompatible:`), or",
+            "  - `enabled: false` to turn the guard off for this repo.",
+            "Start a fresh session afterwards — tags accumulate across the session.",
+        ]
+
+    if rule_id.startswith("codex-cloak-"):
+        return [
+            "This is secret cloaking, not a policy rule — Codex hooks cannot "
+            "rewrite a Bash command or scrub its output, so the real value would "
+            "reach the process and the transcript.",
+            "1. Run it through Prismor, which substitutes and scrubs: "
+            "prismor cloak run -- <command>",
+            "2. If the placeholder is unregistered: prismor cloak add <NAME>",
+            "3. If it fired on something that is not a secret: prismor cloak list, "
+            "then prismor cloak remove <NAME> to drop the bad registration.",
+        ]
+
+    return None
+
+
+def unblock_steps(
+    finding: Dict[str, Any],
+    *,
+    workspace: Optional[Path] = None,
+    session_id: Optional[str] = None,
+    org_managed: bool = False,
+    enrolled: bool = False,
+) -> List[str]:
+    """Ordered narrow-to-broad steps a human can take to clear this block."""
+    rule_id = str(finding.get("ruleId") or "").strip()
+    if not rule_id or rule_id == "unknown":
+        return []
+
+    steps = _subsystem_steps(rule_id, finding, workspace, session_id)
+    if steps is None:
+        if is_floor(finding):
+            steps = _floor_steps(rule_id, finding, enrolled)
+        else:
+            steps = _rule_override_steps(rule_id, finding, workspace)
+            if org_managed:
+                # The remote layer merges after the project layer, so a local
+                # override only survives on rules the org bundle stays silent
+                # about. Say which way it can fail rather than let the user
+                # edit a file that gets overwritten on the next pull.
+                steps.append(
+                    "This workspace is org-managed: the above works only if your "
+                    "org's signed policy does not pin this rule. If the block "
+                    "persists after the next policy pull, ask an admin: "
+                    'prismor exempt request --reason "<why>"'
+                )
+
+    return steps
+
+
+def format_unblock(
+    finding: Dict[str, Any],
+    *,
+    workspace: Optional[Path] = None,
+    session_id: Optional[str] = None,
+    org_managed: bool = False,
+    enrolled: bool = False,
+) -> str:
+    """Render the steps as a block of text, or "" when there is nothing to say."""
+    steps = unblock_steps(
+        finding,
+        workspace=workspace,
+        session_id=session_id,
+        org_managed=org_managed,
+        enrolled=enrolled,
+    )
+    if not steps:
+        return ""
+    header = "To unblock (for the human, not the agent — Prismor guards its own config):"
+    return "\n".join([header] + steps)

--- a/tests/test_unblock.py
+++ b/tests/test_unblock.py
@@ -1,0 +1,203 @@
+"""Tests for the human-facing unblock steps printed alongside a block."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime import unblock
+from prismor.runtime.policy_engine import PolicyEngine
+
+
+def _finding(**over):
+    base = {
+        "ruleId": "secret-access",
+        "severity": "HIGH",
+        "category": "secret_access",
+        "title": "Flags reads/writes to .env",
+        "evidence": "/home/u/.ssh/id_rsa",
+        "pattern": r"\.ssh/id_rsa",
+    }
+    base.update(over)
+    return base
+
+
+class TestFloorDetection(unittest.TestCase):
+    def test_core_rule_id_is_floor(self):
+        self.assertTrue(unblock.is_floor(_finding(ruleId="destructive-command")))
+
+    def test_core_category_is_floor(self):
+        self.assertTrue(
+            unblock.is_floor(_finding(ruleId="curl-pipe-sh", category="remote_execution"))
+        )
+
+    def test_ordinary_rule_is_not_floor(self):
+        self.assertFalse(unblock.is_floor(_finding()))
+
+    def test_floor_set_is_read_from_the_engine_not_copied(self):
+        """Guards drift: a rule added to the engine's floor must not need an edit here."""
+        from prismor.runtime.policy_engine import _NON_OVERRIDABLE_RULE_IDS
+
+        for rule_id in _NON_OVERRIDABLE_RULE_IDS:
+            self.assertTrue(unblock.is_floor(_finding(ruleId=rule_id, category="x")), rule_id)
+
+
+class TestOrdinaryRuleSteps(unittest.TestCase):
+    def setUp(self):
+        self.steps = unblock.unblock_steps(_finding(), workspace=Path("/w"))
+
+    def test_narrowest_option_comes_first(self):
+        joined = "\n".join(self.steps)
+        self.assertLess(joined.index("Allow only this case"), joined.index("mode: observe"))
+        self.assertLess(joined.index("mode: observe"), joined.index("enabled: false"))
+
+    def test_names_the_policy_file(self):
+        self.assertIn("/w/.prismor/policy.yaml", "\n".join(self.steps))
+
+
+class TestSuggestedYamlIsValid(unittest.TestCase):
+    """The snippet is meant to be pasted verbatim — it must parse and work."""
+
+    def _doc(self, finding):
+        return "version: '1.0'\n" + "\n".join(
+            unblock._allowlist_yaml(finding["ruleId"], finding)
+        ) + "\n"
+
+    def test_allowlist_snippet_parses(self):
+        parsed = yaml.safe_load(self._doc(_finding()))
+        entry = parsed["allowlists"][0]
+        self.assertEqual(entry["rule_ids"], ["secret-access"])
+
+    def test_backslashes_survive_yaml_roundtrip(self):
+        """Regex patterns are backslash-heavy; double-quoted YAML would reject them."""
+        parsed = yaml.safe_load(self._doc(_finding(evidence="/home/u/.ssh/id_rsa")))
+        self.assertEqual(parsed["allowlists"][0]["patterns"], [r"/home/u/\.ssh/id_rsa"])
+
+    def test_quote_in_evidence_does_not_break_yaml(self):
+        parsed = yaml.safe_load(self._doc(_finding(evidence="echo 'hi'")))
+        self.assertIn("patterns", parsed["allowlists"][0])
+
+    def test_multi_field_evidence_does_not_fold_into_a_dead_pattern(self):
+        """Evidence joins matched fields with newlines; YAML folds those to spaces."""
+        finding = _finding(evidence="/home/u/.ssh/id_rsa\n/Volumes/Data/home/u/.ssh/id_rsa")
+        pattern = yaml.safe_load(self._doc(finding))["allowlists"][0]["patterns"][0]
+        self.assertNotIn(" ", pattern)
+        # Must still match the full multi-field blob it was derived from.
+        import re
+
+        self.assertTrue(re.search(pattern, finding["evidence"]))
+
+    def test_suggested_allowlist_actually_suppresses_the_finding(self):
+        """End-to-end: the snippet we print must clear the block it was printed for."""
+        engine = PolicyEngine()
+        before = engine.check_path("/home/u/.ssh/id_rsa", "file_read")
+        rule_ids = [f["ruleId"] for f in before]
+        self.assertIn("secret-access", rule_ids)
+
+        finding = next(f for f in before if f["ruleId"] == "secret-access")
+        snippet = yaml.safe_load(self._doc(finding))
+        engine.allowlists.append(
+            __import__(
+                "prismor.runtime.policy_engine", fromlist=["AllowlistEntry"]
+            ).AllowlistEntry(snippet["allowlists"][0])
+        )
+
+        after = [f["ruleId"] for f in engine.check_path("/home/u/.ssh/id_rsa", "file_read")]
+        self.assertNotIn("secret-access", after)
+
+        # ...and stays narrow: a different secret path still fires.
+        other = [f["ruleId"] for f in engine.check_path("/home/u/.aws/credentials", "file_read")]
+        self.assertIn("secret-access", other)
+
+
+class TestFloorSteps(unittest.TestCase):
+    def test_does_not_offer_an_override_that_would_be_ignored(self):
+        joined = "\n".join(unblock.unblock_steps(_finding(ruleId="destructive-command")))
+        self.assertIn("floor rule", joined)
+        # It may *mention* the knobs to say they are ignored, but must never
+        # hand over a snippet that looks like it would work.
+        self.assertIn("will not clear this block", joined)
+        self.assertNotIn("allowlists:", joined)
+        self.assertNotIn("prismor policy edit", joined)
+
+    def test_unreadable_pattern_is_not_dumped_verbatim(self):
+        joined = "\n".join(
+            unblock.unblock_steps(_finding(ruleId="destructive-command", pattern="x" * 300))
+        )
+        self.assertNotIn("x" * 300, joined)
+        self.assertIn("prismor policy show", joined)
+
+    def test_exemption_offered_only_when_enrolled(self):
+        f = _finding(ruleId="destructive-command")
+        self.assertNotIn("exempt request", "\n".join(unblock.unblock_steps(f)))
+        self.assertIn("exempt request", "\n".join(unblock.unblock_steps(f, enrolled=True)))
+
+
+class TestSubsystemSteps(unittest.TestCase):
+    def test_scoped_agent_names_the_session(self):
+        joined = "\n".join(
+            unblock.unblock_steps(_finding(ruleId="scoped-agent"), session_id="sess-9")
+        )
+        self.assertIn("prismor scope clear sess-9", joined)
+
+    def test_iam_points_at_identity_not_policy(self):
+        joined = "\n".join(unblock.unblock_steps(_finding(ruleId="iam"), workspace=Path("/w")))
+        self.assertIn("iam.yaml", joined)
+        self.assertNotIn("allowlists:", joined)
+
+    def test_trifecta_relaxes_tags_not_the_finding(self):
+        joined = "\n".join(
+            unblock.unblock_steps(
+                _finding(ruleId="tool-category-crossover", category="lethal_trifecta")
+            )
+        )
+        self.assertIn("tool_tags", joined)
+
+    def test_agent_disabled_defers_to_the_layer_that_paused_it(self):
+        """A paused agent is a kill switch, not a rule — an allowlist does nothing."""
+        joined = "\n".join(
+            unblock.unblock_steps(
+                _finding(
+                    ruleId="agent-disabled",
+                    category="agent-control",
+                    title="Agent is paused",
+                    evidence="agent 'ci' is paused by your org's control plane",
+                    remediation="Ask an org admin to re-enable 'ci' in the dashboard's fleet view.",
+                )
+            )
+        )
+        self.assertIn("org admin", joined)
+        self.assertNotIn("allowlists:", joined)
+        self.assertNotIn("mode: observe", joined)
+
+    def test_cloaking_steers_to_cloak_run_not_a_policy_edit(self):
+        joined = "\n".join(unblock.unblock_steps(_finding(ruleId="codex-cloak-read-guard")))
+        self.assertIn("prismor cloak run", joined)
+        self.assertNotIn("allowlists:", joined)
+
+
+class TestOrgManaged(unittest.TestCase):
+    def test_warns_that_a_local_override_may_be_overwritten(self):
+        joined = "\n".join(unblock.unblock_steps(_finding(), org_managed=True))
+        self.assertIn("exempt request", joined)
+
+    def test_personal_workspace_gets_no_admin_noise(self):
+        self.assertNotIn("exempt request", "\n".join(unblock.unblock_steps(_finding())))
+
+
+class TestFormatting(unittest.TestCase):
+    def test_addressed_to_the_human(self):
+        text = unblock.format_unblock(_finding())
+        self.assertIn("for the human", text)
+
+    def test_unknown_rule_yields_nothing_rather_than_guesswork(self):
+        self.assertEqual(unblock.format_unblock(_finding(ruleId="")), "")
+        self.assertEqual(unblock.format_unblock(_finding(ruleId="unknown")), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A block that only says "no" pushes the human toward the one lever they can always find: turning Prismor off.

The deny message carried severity, title, evidence and remediation — but not the `ruleId`, which is the key every override (allowlist, rule mode, exemption) is written against. The *observe* path already logged it; the *block* path, where you actually need it, did not.

## What

Every deny surface (Claude / Copilot / Grok JSON reasons + stderr) now prints the rule id and a **narrowest-first** ladder:

1. allowlist this one case → 2. observe this one rule → 3. disable it in this repo.

Steps adapt to what actually governs the block, instead of always suggesting a policy edit that would do nothing:

| Block type | What it offers |
|---|---|
| Ordinary rule | Pasteable allowlist → `mode: observe` → `enabled: false` |
| Floor rule | Says plainly no local override works, then the outs that exist |
| `agent-disabled` | Defers to its own layer-aware remediation (local vs org kill switch) |
| scoped-agent / IAM / trifecta / cloaking | That subsystem's own knob |
| Org-managed | Warns a local override may be overwritten by the next signed pull |

## Two deliberate design choices

- **No global off-switch is ever printed.** A socially-engineered agent should not be able to read the fastest path to disabling enforcement out of a block message.
- **Steps address the human.** `.prismor/policy.yaml` and the hook configs are guarded by `agent-config-tampering`, so an agent applying them for itself earns a second block.

## Notes for review

The suggested YAML is meant to be pasted verbatim, which took two fixes worth pinning:

- top-level keys sit at column 0 (an indented snippet does not parse);
- the pattern comes from the **first line of evidence only** — evidence joins matched fields with newlines, and a newline inside a quoted YAML scalar folds to a space, producing an entry that parses but silently never matches.

## Testing

23 new tests, including an end-to-end check that the snippet we print actually suppresses the finding it was printed for, while a neighbouring case still blocks.

Full suite, this branch vs `origin/main` baseline, same machine:

- baseline: **23 failed, 954 passed**
- this branch: **23 failed, 977 passed** (+23 = exactly the new tests)

Identical failure sets — **no new failures**. The 23 are pre-existing on `main`; most look environment-dependent (they assume a non-enrolled machine), plus `test_oss_guard` tripping on an AWS-key-shaped fixture in `test_false_positive_fixes.py`. Worth a separate look.