### PR TITLE
fix(runtime): stop concurrent hook writes corrupting the session log

### DIFF
--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -6,8 +6,40 @@ import os
 import re
 import shutil
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
+
+try:  # POSIX advisory locks; absent on Windows.
+    import fcntl
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None  # type: ignore[assignment]
+
+
+@contextmanager
+def _locked(handle) -> Iterator[None]:
+    """Hold an exclusive advisory lock on an open file for the block.
+
+    Best effort: on a platform without fcntl, or a filesystem that refuses the
+    lock (some network mounts), the write still proceeds unserialized rather
+    than failing the caller. Logging an event must never break the tool call it
+    is recording.
+    """
+    if fcntl is None:
+        yield
+        return
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    except OSError:
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
 
 
 def prismor_home() -> Path:
@@ -363,16 +395,67 @@ def append_session_event(workspace: Path, session_id: str, event: Dict[str, Any]
     ensure_data_dirs(workspace)
     event = _recloak_event(event)
     log_path = session_log_path(workspace, session_id)
+    # One record = one write, under an exclusive lock.
+    #
+    # Several hook processes can fire for the same event (a hook registered in
+    # both user and project settings, parallel agents sharing a session id) and
+    # all append here at once. Writing the JSON and the "\n" as two calls let a
+    # second writer slip in between them, welding two records onto one line
+    # ({"a":1}{"b":2}) and corrupting the log for every later reader. Records
+    # routinely exceed the pipe-buffer size below which O_APPEND writes are
+    # atomic, so the payload alone can also tear. Build the line first, then
+    # take an advisory lock so cooperating writers serialize.
+    payload = json.dumps(event) + "\n"
     with log_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(event))
-        handle.write("\n")
+        with _locked(handle):
+            handle.write(payload)
+            handle.flush()
     return log_path
+
+
+def _decode_welded_line(line: str) -> List[Dict[str, Any]]:
+    """Split a line holding several concatenated JSON objects.
+
+    Recovers logs written before appends were locked, where interleaved writes
+    produced `{"a":1}{"b":2}` on one line. Junk between objects is skipped
+    rather than raising: a torn record must not cost us the whole session.
+    """
+    decoder = json.JSONDecoder()
+    events: List[Dict[str, Any]] = []
+    idx, end = 0, len(line)
+    while idx < end:
+        try:
+            obj, idx = decoder.raw_decode(line, idx)
+        except json.JSONDecodeError:
+            nxt = line.find("{", idx + 1)
+            if nxt == -1:
+                break
+            idx = nxt
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+        while idx < end and line[idx] in " \t\r\n":
+            idx += 1
+    return events
 
 
 def read_session_events(workspace: Path, session_id: str) -> List[Dict[str, Any]]:
     log_path = session_log_path(workspace, session_id)
     with log_path.open("r", encoding="utf-8") as handle:
-        return [json.loads(line) for line in handle.read().splitlines() if line.strip()]
+        raw = handle.read()
+    events: List[Dict[str, Any]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            # A pre-existing welded or truncated line. Salvage what parses:
+            # this runs inside the hook path, so raising here would fail the
+            # tool call and leave the agent unguarded for the rest of the
+            # session.
+            events.extend(_decode_welded_line(line))
+    return events
 
 
 # Expected column set per managed table. NOT NULL is intentionally omitted —

--- a/tests/test_session_log_concurrency.py
+++ b/tests/test_session_log_concurrency.py
@@ -1,0 +1,85 @@
+"""Session log durability under concurrent writers.
+
+Several hook processes can fire for one tool call (a hook registered in both
+user and project settings, parallel agents sharing a session id) and every one
+of them appends to the same session log. Records regularly exceed the pipe
+buffer below which O_APPEND writes are atomic, so unserialized appends tear and
+weld two records onto one line. A single welded line used to raise
+JSONDecodeError out of read_session_events, which runs in the hook path, so one
+torn write broke every later tool call in that session.
+
+Session logs live under $PRISMOR_HOME, not under the workspace argument, so
+every test here repoints PRISMOR_HOME at a tmp dir to stay off the real one.
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+from prismor.runtime.store import (
+    _decode_welded_line,
+    append_session_event,
+    read_session_events,
+    session_log_path,
+)
+
+# Comfortably past PIPE_BUF, so a bare write() is free to tear.
+BIG = "x" * 200_000
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / "home"))
+    return tmp_path
+
+
+def _spam(args) -> None:
+    home, workspace, tag, count = args
+    import os
+
+    os.environ["PRISMOR_HOME"] = home  # fork copies the parent env; be explicit
+    for i in range(count):
+        append_session_event(Path(workspace), "sess", {"ts": f"{tag}-{i}", "blob": BIG})
+
+
+def test_concurrent_appends_keep_one_record_per_line(home, monkeypatch):
+    ctx = mp.get_context("fork")
+    tags = ("a", "b", "c", "d")
+    per_writer = 8
+    prismor_home = str(home / "home")
+    with ctx.Pool(len(tags)) as pool:
+        pool.map(_spam, [(prismor_home, str(home), t, per_writer) for t in tags])
+
+    log = session_log_path(home, "sess")
+    lines = [ln for ln in log.read_text().splitlines() if ln.strip()]
+    assert len(lines) == len(tags) * per_writer
+    for line in lines:
+        json.loads(line)  # raises if two records were welded together
+
+    events = read_session_events(home, "sess")
+    assert {e["ts"] for e in events} == {
+        f"{t}-{i}" for t in tags for i in range(per_writer)
+    }
+
+
+def test_welded_line_is_recovered_not_raised(home):
+    """Logs written before the lock existed must still be readable."""
+    log = session_log_path(home, "sess")
+    log.parent.mkdir(parents=True, exist_ok=True)
+    welded = json.dumps({"ts": "1"}) + json.dumps({"ts": "2"})
+    log.write_text(json.dumps({"ts": "0"}) + "\n" + welded + "\n")
+
+    assert [e["ts"] for e in read_session_events(home, "sess")] == ["0", "1", "2"]
+
+
+def test_decode_welded_line_skips_junk_between_records():
+    line = json.dumps({"ts": "1"}) + "<torn>" + json.dumps({"ts": "2"})
+    assert [e["ts"] for e in _decode_welded_line(line)] == ["1", "2"]
+
+
+def test_truncated_tail_does_not_lose_earlier_records():
+    line = json.dumps({"ts": "1"}) + '{"ts": "2"'  # writer died mid-record
+    assert [e["ts"] for e in _decode_welded_line(line)] == ["1"]


### PR DESCRIPTION
## The bug

Several hook processes can fire for a single tool call: `hook-dispatch` registered in both user and project settings, or parallel agents sharing a session id. All of them append to the same `$PRISMOR_HOME/sessions/<id>.jsonl`.

`append_session_event` wrote the record in **two** calls:

```python
handle.write(json.dumps(event))
handle.write("\n")
```

A second writer can land between them, welding two records onto one line. Records also routinely exceed the pipe-buffer size below which `O_APPEND` writes are atomic — a `file_read` event carrying a screenshot runs to ~200KB — so the payload alone can tear.

`read_session_events` then did `json.loads` per line and let `JSONDecodeError` escape.

## Why it matters

`read_session_events` runs in the hook path via `evaluate_tool_call`. One welded line fails **every later tool call in that session**:

```
json.decoder.JSONDecodeError: Extra data: line 1 column 210474 (char 210473)
```

The hook exits non-zero, so `evaluate_tool_call` never runs and policy enforcement is silently dropped for the rest of the session. It is self-perpetuating: once a log is torn, only hand-editing it recovers. Found in the wild — 6 session logs on one machine, 27 welded lines, seam visible as `..."path": ".../headline_on.png"}{"ts": "2026-07-15T07:53:47...`.

## The fix

- Build the line first and write it once, under an exclusive `flock`. Locking is best effort: no `fcntl` (Windows) or a mount that refuses the lock falls through to an unserialized write rather than failing the caller, since logging an event must never break the tool call it records.
- On read, salvage what parses instead of raising, so logs torn by older versions stay readable.

## Verification

Reproduced with 4 processes × 8 × 200KB concurrent appends:

| | corrupt lines |
|---|---|
| before | 13/48, 27/32 |
| after | **0** |

`tests/test_session_log_concurrency.py` is load-bearing — reverting just the append to the old two-write form fails it (`assert 27 == 32`).

Full suite on this branch: **23 failed, 964 passed**. Pristine `main`: **23 failed, 960 passed** — same pre-existing failures (they read real `$PRISMOR_HOME` enrollment state), +4 from this PR, no new failures.