### PR TITLE
fix(cloak): scrub secrets with literal replacement, not sed regex

### DIFF
--- a/prismor/runtime/cloaking/hooks/recloak-mcp.sh
+++ b/prismor/runtime/cloaking/hooks/recloak-mcp.sh
@@ -24,21 +24,20 @@ tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
 response="$(printf '%s' "$input" | jq -r '.tool_response // empty')"
 [[ -n "$response" ]] || exit 0
 
-# Build a sed expression that substitutes every registered secret's real
-# value with its placeholder. Skip missing/empty entries.
-sed_filter=""
+# Replace every registered secret's real value with its placeholder using
+# bash's literal substring substitution (${var//"needle"/repl}). Not sed: the
+# value would be a regex there, so a secret with metacharacters could abort
+# sed ("unterminated substitute pattern") or silently mangle the response.
+# Quoting the needle forces a literal, byte-exact match. Skip missing/empty.
+scrubbed="$response"
 shopt -s nullglob
 for secret_file in "$SECRETS_DIR"/*; do
   [[ -f "$secret_file" ]] || continue
   name="$(basename "$secret_file")"
   real="$(cat "$secret_file")"
   [[ -n "$real" ]] || continue
-  esc_real="$(printf '%s' "$real" | sed 's/[\/&|]/\\&/g')"
-  sed_filter+="s|$esc_real|@@SECRET:$name@@|g;"
+  scrubbed="${scrubbed//"$real"/@@SECRET:$name@@}"
 done
-[[ -n "$sed_filter" ]] || exit 0
-
-scrubbed="$(printf '%s' "$response" | sed -E "$sed_filter")"
 
 # Only mutate if something actually changed — avoids noisy empty mutations.
 if [[ "$scrubbed" != "$response" ]]; then

--- a/prismor/runtime/cloaking/hooks/scrub-stream.sh
+++ b/prismor/runtime/cloaking/hooks/scrub-stream.sh
@@ -44,26 +44,28 @@ _prismor_scrubbable() {
   return 1
 }
 
-# Build a single sed program: real value → placeholder, for each secret.
-# Escape sed's `s|...|...|` delimiters and metacharacters in the real value.
-sed_filter=""
+# Slurp stdin, then replace every registered secret value with its placeholder
+# using bash's literal substring substitution (${var//"needle"/repl}).
+#
+# We deliberately do NOT use sed here. sed treats the value as a regex, so a
+# secret containing regex metacharacters ([ ] ( ) { } . * + ? ^ $ |) either
+# made sed abort with "unterminated substitute pattern" — dropping the whole
+# command's output — or, worse, silently mangled the text. Quoting the needle
+# in ${var//"$real"/...} forces a literal match, immune to any byte a secret
+# key can contain, and it also spans newlines (sed only scrubs line-by-line).
+#
+# The `; printf x` / `%x` dance preserves trailing newlines that command
+# substitution would otherwise strip.
+data="$(cat; printf x)"
+data="${data%x}"
+
 shopt -s nullglob
 for secret_file in "$SECRETS_DIR"/*; do
   [[ -f "$secret_file" ]] || continue
   name="$(basename "$secret_file")"
   real="$(cat "$secret_file")"
   _prismor_scrubbable "$real" || continue
-  esc_real="$(printf '%s' "$real" | sed 's/[\/&|]/\\&/g')"
-  sed_filter+="s|$esc_real|@@SECRET:${name}@@|g;"
+  data="${data//"$real"/@@SECRET:${name}@@}"
 done
 
-if [[ -z "$sed_filter" ]]; then
-  exec cat
-fi
-
-# `sed -E` over the stream. If sed is somehow unavailable, fall back to cat.
-if command -v sed >/dev/null 2>&1; then
-  exec sed -E "$sed_filter"
-else
-  exec cat
-fi
+printf '%s' "$data"

--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -107,6 +107,33 @@ def test_scrub_passthrough_no_secret():
     check("scrub leaves non-secret text unchanged", out == "nothing sensitive here\n", out)
 
 
+def test_scrub_secret_with_regex_metacharacters():
+    # Regression: a secret containing regex metacharacters ([](){}.*+?^$|) used
+    # to be interpolated into a `sed -E` pattern, which aborted with
+    # "unterminated substitute pattern" (dropping ALL output) or silently
+    # mangled the text. Literal substring replacement must handle it exactly.
+    meta = "sk_live_9f8[a|b](c).d*+?e^$again"
+    (_SECRETS / "META").write_text(meta)
+    try:
+        out = run_scrub(f"before {meta} after\n")
+        check(
+            "scrub masks a secret full of regex metacharacters",
+            out == "before @@SECRET:META@@ after\n",
+            repr(out),
+        )
+    finally:
+        (_SECRETS / "META").unlink()
+
+
+def test_scrub_preserves_trailing_and_missing_newline():
+    # The output must be byte-exact: no added or stripped trailing newline.
+    check(
+        "scrub preserves a missing trailing newline",
+        run_scrub("plain text no newline") == "plain text no newline",
+        "trailing newline was altered",
+    )
+
+
 # ── B. decloak.sh output scrubbing (no placeholder) ───────────────────────
 def test_grep_output_scrubbed():
     # Model reads the secret out of a file via grep — never uses a placeholder.
@@ -190,6 +217,8 @@ def test_read_of_clean_file_allowed():
 def main() -> int:
     for fn in [
         test_scrub_masks_secret, test_scrub_passthrough_no_secret,
+        test_scrub_secret_with_regex_metacharacters,
+        test_scrub_preserves_trailing_and_missing_newline,
         test_grep_output_scrubbed, test_source_echo_scrubbed,
         test_no_secret_in_wrapped_command, test_exit_code_preserved,
         test_placeholder_substituted_and_output_scrubbed,


### PR DESCRIPTION
## Problem

The cloaking output scrubbers — `scrub-stream.sh` (every Bash command's stdout/stderr) and `recloak-mcp.sh` (MCP tool responses) — built a `sed -E` program and interpolated each **raw secret value into the pattern side**. sed treats that as a regex, so any secret containing a regex metacharacter (`[ ] ( ) { } . * + ? ^ $ |`) breaks it:

- Quantifier / unbalanced-bracket chars make sed abort with `unterminated substitute pattern`. Because `scrub-stream.sh` is the last stage of the wrapped pipe, **the entire command's output is dropped and every Bash tool call fails** — the agent is effectively bricked until the offending secret is removed.
- The `|` delimiter (and other metachars) could also silently **mangle** output while leaving the secret only partially masked — the opposite of what a scrubber must guarantee. Ironically, the crash message itself leaked a fragment of the raw key, because the scrub aborted before it could redact.

The previous escape (`sed 's/[\/&|]/\\&/g'`) only handled `/ & |`, not the rest of the ERE set — and using the value as a regex at all is the wrong tool for matching arbitrary secret bytes.

## Fix

Replace the sed machinery in both hooks with bash's **literal** substring substitution, `${var//"$real"/@@SECRET:name@@}`. Quoting the needle forces a byte-exact, regex-free match that is immune to any character a key can contain, and it also spans newlines (sed only scrubbed line-by-line). `scrub-stream.sh` now slurps stdin and preserves trailing/absent newlines exactly (`$(cat; printf x)` / `%x`).

No secret value is embedded in any command string; the scrubber still reads the vault itself at runtime.

## Tests

`tests/test_cloak_output_scrub.py` — added:
- `test_scrub_secret_with_regex_metacharacters` — registers `sk_live_9f8[a|b](c).d*+?e^$again` and asserts it is masked exactly (this crashed/mangled before the fix).
- `test_scrub_preserves_trailing_and_missing_newline` — byte-exact output.

All 13 tests pass.

https://claude.ai/code/session_012e9BagLNdAJmD7rv1Fcq8r