### PR TITLE
feat(runtime): local pause/resume without uninstalling hooks

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -306,6 +306,54 @@ def main(argv: Optional[List[str]] = None) -> None:
         print("Un-enrolled." if had else "This machine was not enrolled.")
         return
 
+    # ── pause / resume: suspend local screening without uninstalling hooks ──
+    if args.command == "pause":
+        from prismor.runtime import pause as _pause
+        duration_s: Optional[int] = None
+        raw_duration = getattr(args, "duration", None)
+        if raw_duration:
+            try:
+                duration_s = _pause.parse_duration(raw_duration)
+            except ValueError:
+                print(f"  {_color('✗', _RED)} Could not read duration '{raw_duration}'. Use e.g. 30m, 2h, 1d.")
+                return
+            if duration_s <= 0:
+                print(f"  {_color('✗', _RED)} Duration must be positive.")
+                return
+        # Attribute the pause to the enrolled member when we know them.
+        by = ""
+        try:
+            from prismor.runtime.enterprise import identity as _identity
+            ident = _identity.load_identity() or {}
+            by = ident.get("user_id") or ident.get("label") or ""
+        except Exception:
+            pass
+        rec = _pause.set_paused(duration_seconds=duration_s, reason=getattr(args, "reason", "") or "", by=by)
+        # Fire one heartbeat now so the console flips to "paused" within ~30s.
+        try:
+            _pause.beat(agent="claude", state=rec)
+        except Exception:
+            pass
+        print()
+        print(f"  {_color('⏸  Prismor paused', _YELLOW)} — tool calls are no longer screened and enforcement is off.")
+        if rec.get("until"):
+            until_local = datetime.fromtimestamp(float(rec["until"])).strftime("%H:%M")
+            print(f"  {_color('Auto-resumes at ' + until_local, _DIM)} (in {raw_duration}).")
+        else:
+            print(f"  {_color('Stays paused until you run', _DIM)} prismor resume.")
+        print(f"  {_color('Resume anytime:', _GREEN)} prismor resume")
+        print()
+        return
+
+    if args.command == "resume":
+        from prismor.runtime import pause as _pause
+        existed = _pause.clear_paused()
+        if existed:
+            print(f"  {_color('▶  Prismor resumed', _GREEN)} — screening and enforcement are active again.")
+        else:
+            print("  Prismor was not paused.")
+        return
+
     # ── workspace: show/set whether THIS workspace is org-managed or personal ──
     if args.command == "workspace":
         from prismor.runtime.enterprise import workspace_scope as _scope
@@ -878,6 +926,22 @@ def main(argv: Optional[List[str]] = None) -> None:
     # ── hook-dispatch (called by IDE hooks) ────────────────────────────
     if args.command == "hook-dispatch":
         register_workspace(workspace)
+
+        # Locally paused? Don't screen this tool call — allow it straight
+        # through, but emit a lightweight heartbeat so the console shows this
+        # machine as deliberately *paused* rather than silently idle. The pause
+        # self-heals when a `--for` window elapses (checked in active_state()).
+        try:
+            from prismor.runtime import pause as _pause
+            _pstate = _pause.active_state()
+        except Exception:
+            _pstate = None
+        if _pstate is not None:
+            try:
+                _pause.beat(agent=args.agent, state=_pstate)
+            except Exception:
+                pass
+            return
 
         # Keep org-managed policy fresh on the hot path: a cheap, debounced
         # (~30s) version check that pulls the full signed policy only when the
@@ -2252,6 +2316,13 @@ def build_parser() -> argparse.ArgumentParser:
     doctor_parser.add_argument("--json", action="store_true", help="Machine-readable output (exit 0 iff all checks pass)")
 
     subparsers.add_parser("logout", help="Un-enroll this machine (remove device identity + cached remote policy)")
+
+    pause_p = subparsers.add_parser("pause", help="Pause local screening/enforcement without uninstalling the hooks")
+    pause_p.add_argument("--for", dest="duration", metavar="DURATION",
+                         help="Auto-resume after this long, e.g. 30m, 2h, 1d (default: until you run `prismor resume`)")
+    pause_p.add_argument("--reason", help="Why you're pausing — shown in the console next to the device")
+    subparsers.add_parser("resume", help="Resume local screening/enforcement after `prismor pause`")
+
     workspace_p = subparsers.add_parser("workspace", help="Show or set whether this workspace is org-managed or personal")
     workspace_p.add_argument("action", nargs="?", choices=["managed", "personal", "auto"], help="managed = report to org; personal = local-only; auto = let org patterns decide")
     exempt_p = subparsers.add_parser("exempt", help="Request an admin exemption (rule relaxation) for this repo")
@@ -3129,6 +3200,22 @@ def _print_status_overview(workspace: Path) -> None:
         print(f"  {_color('Hooks:', _GREEN)}       {', '.join(agents_with_hooks)}  ({mode_str})")
     else:
         print(f"  {_color('Hooks:', _GREEN)}       {_color('not installed', _YELLOW)}")
+
+    # Paused? Local screening is suspended without uninstalling the hooks.
+    try:
+        from prismor.runtime import pause as _pause
+        _pstate = _pause.active_state()
+    except Exception:
+        _pstate = None
+    if _pstate is not None:
+        if _pstate.get("until"):
+            _until = datetime.fromtimestamp(float(_pstate["until"])).strftime("%H:%M")
+            _pmsg = f"yes — auto-resumes {_until}"
+        else:
+            _pmsg = "yes — run `prismor resume` to re-enable"
+        if _pstate.get("reason"):
+            _pmsg += f"  ({_pstate['reason']})"
+        print(f"  {_color('Paused:', _YELLOW)}      {_color(_pmsg, _YELLOW)}")
 
     # Cloaking — lazy import so the cloaking subsystem stays optional
     cloak_state = "unknown"

--- a/prismor/runtime/pause.py
+++ b/prismor/runtime/pause.py
@@ -1,0 +1,189 @@
+"""Local pause/resume for the Prismor runtime.
+
+`prismor pause` suspends local screening and enforcement WITHOUT uninstalling
+the hooks. The hook dispatcher short-circuits to "allow" for every tool call,
+but keeps emitting a lightweight heartbeat so the control plane shows the
+machine as *paused* — a deliberate, attributable, time-boxed state — rather
+than letting it silently go idle, which is the failure mode of just deleting
+the hooks (indistinguishable from a closed laptop).
+
+State lives in a single JSON marker at ``~/.prismor/pause.json``, mirroring the
+revocation-marker pattern in ``enterprise/identity.py``. A ``--for`` window
+makes the pause self-expire (checked on the hot path in :func:`active_state`),
+so protection heals itself even if ``prismor resume`` is never run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_SCHEMA = "prismor.runtime.pause.v1"
+
+# Don't upload a paused heartbeat more than once per this many seconds, so a
+# burst of tool calls while paused doesn't hammer the control plane. Matches
+# the ~30s policy-refresh debounce cadence.
+_BEAT_DEBOUNCE_SECONDS = 30.0
+
+
+def prismor_home() -> Path:
+    """Return the Prismor home dir, honoring $PRISMOR_HOME (default ~/.prismor)."""
+    return Path(os.environ.get("PRISMOR_HOME", str(Path.home() / ".prismor")))
+
+
+def pause_path() -> Path:
+    return prismor_home() / "pause.json"
+
+
+def parse_duration(text: str) -> int:
+    """Parse a human duration into seconds: ``30m`` / ``2h`` / ``90s`` / ``1d``.
+    A bare number is read as minutes. Raises ``ValueError`` on anything else."""
+    s = (text or "").strip().lower()
+    if not s:
+        raise ValueError("empty duration")
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    if s[-1] in units:
+        value = float(s[:-1])  # raises ValueError on garbage like "abcm"
+        return int(value * units[s[-1]])
+    return int(float(s) * 60)  # bare number = minutes
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def set_paused(duration_seconds: Optional[int] = None, reason: str = "", by: str = "") -> Dict[str, Any]:
+    """Write the pause marker. ``duration_seconds=None`` pauses indefinitely.
+    Returns the record written."""
+    now = _now()
+    record: Dict[str, Any] = {
+        "schema": _SCHEMA,
+        "paused": True,
+        "at": now,
+        "until": (now + duration_seconds) if duration_seconds else None,
+        "reason": (reason or "")[:300],
+        "by": (by or "")[:120],
+        "last_beat": 0.0,
+    }
+    home = prismor_home()
+    home.mkdir(parents=True, exist_ok=True)
+    path = pause_path()
+    path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return record
+
+
+def clear_paused() -> bool:
+    """Remove the pause marker (resume). Returns True if one existed. Never raises."""
+    path = pause_path()
+    try:
+        if path.exists():
+            path.unlink()
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def _read_raw() -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(pause_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) and data.get("paused") else None
+    except (OSError, ValueError):
+        return None
+
+
+def active_state() -> Optional[Dict[str, Any]]:
+    """The pause record if this machine is currently paused, else None.
+
+    If a ``--for`` window has elapsed the marker is cleared (auto-resume) and
+    None is returned, so the caller falls through to normal screening. Never
+    raises."""
+    rec = _read_raw()
+    if rec is None:
+        return None
+    until = rec.get("until")
+    if until is not None:
+        try:
+            if _now() >= float(until):
+                clear_paused()
+                return None
+        except (TypeError, ValueError):
+            pass
+    return rec
+
+
+def is_paused() -> bool:
+    return active_state() is not None
+
+
+def beat(agent: Optional[str] = None, state: Optional[Dict[str, Any]] = None) -> bool:
+    """Emit a debounced "paused" heartbeat so the control plane keeps this
+    device's ``lastSeenAt`` fresh and flags it as paused. No-op when not
+    enrolled, inside the debounce window, or on any error. Returns True iff it
+    uploaded a record."""
+    rec = state or active_state()
+    if rec is None:
+        return False
+    now = _now()
+    try:
+        last_beat = float(rec.get("last_beat") or 0)
+    except (TypeError, ValueError):
+        last_beat = 0.0
+    if now - last_beat < _BEAT_DEBOUNCE_SECONDS:
+        return False
+
+    # Gate on enrollment before any network work — a personal (unenrolled)
+    # machine reports nowhere, so there's nothing to heartbeat.
+    try:
+        from prismor.runtime.enterprise import identity as _identity
+        if not _identity.is_enrolled():
+            return False
+    except Exception:
+        return False
+
+    until = rec.get("until")
+    record = {
+        "schema": "prismor.runtime.telemetry.v1",
+        "event_id": "evt_" + uuid.uuid4().hex,
+        "ts": _iso(now),
+        "type": "paused_heartbeat",
+        "verdict": "observed",
+        "title": "Prismor paused locally",
+        "agent": agent or None,
+        "count": 1,
+        "redacted": True,
+        "detail": {
+            "paused": True,
+            "pausedAt": _iso(float(rec.get("at") or now)),
+            "pausedUntil": _iso(float(until)) if until else None,
+            "reason": rec.get("reason") or None,
+        },
+    }
+    try:
+        from prismor.runtime.sinks import upload_telemetry
+        upload_telemetry([record])
+    except Exception:
+        return False
+
+    # Note the beat so the next tool calls stay debounced. Best-effort: a write
+    # failure just means we heartbeat again sooner, which is harmless.
+    try:
+        rec["last_beat"] = now
+        path = pause_path()
+        path.write_text(json.dumps(rec, indent=2), encoding="utf-8")
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return True

--- a/tests/test_pause.py
+++ b/tests/test_pause.py
@@ -1,0 +1,114 @@
+"""Tests for local pause/resume (prismor/runtime/pause.py)."""
+
+import os
+import sys
+import time
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime import pause
+
+
+class TestParseDuration(unittest.TestCase):
+    def test_units(self):
+        self.assertEqual(pause.parse_duration("90s"), 90)
+        self.assertEqual(pause.parse_duration("30m"), 1800)
+        self.assertEqual(pause.parse_duration("2h"), 7200)
+        self.assertEqual(pause.parse_duration("1d"), 86400)
+
+    def test_bare_number_is_minutes(self):
+        self.assertEqual(pause.parse_duration("5"), 300)
+
+    def test_fractional(self):
+        self.assertEqual(pause.parse_duration("1.5h"), 5400)
+
+    def test_garbage_raises(self):
+        for bad in ("", "abc", "10x", "m"):
+            with self.assertRaises(ValueError):
+                pause.parse_duration(bad)
+
+
+class TestPauseState(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._env = patch.dict(os.environ, {"PRISMOR_HOME": self._tmp})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
+    def test_not_paused_initially(self):
+        self.assertIsNone(pause.active_state())
+        self.assertFalse(pause.is_paused())
+
+    def test_pause_indefinite_roundtrip(self):
+        rec = pause.set_paused(reason="cloak debug")
+        self.assertTrue(pause.is_paused())
+        st = pause.active_state()
+        self.assertEqual(st["reason"], "cloak debug")
+        self.assertIsNone(st["until"])
+        self.assertTrue(pause.pause_path().exists())
+
+    def test_resume_is_idempotent(self):
+        pause.set_paused()
+        self.assertTrue(pause.clear_paused())
+        self.assertFalse(pause.clear_paused())
+        self.assertFalse(pause.is_paused())
+
+    def test_for_window_auto_expires(self):
+        pause.set_paused(duration_seconds=1)
+        self.assertTrue(pause.is_paused())
+        time.sleep(1.2)
+        # active_state() clears the marker once the window has elapsed.
+        self.assertIsNone(pause.active_state())
+        self.assertFalse(pause.pause_path().exists())
+
+    def test_corrupt_marker_reads_as_not_paused(self):
+        pause.pause_path().parent.mkdir(parents=True, exist_ok=True)
+        pause.pause_path().write_text("{not json", encoding="utf-8")
+        self.assertIsNone(pause.active_state())
+
+    def test_reason_is_truncated(self):
+        rec = pause.set_paused(reason="x" * 500)
+        self.assertLessEqual(len(rec["reason"]), 300)
+
+
+class TestBeatGating(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._env = patch.dict(os.environ, {"PRISMOR_HOME": self._tmp})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
+    def test_beat_noops_when_not_paused(self):
+        self.assertFalse(pause.beat(agent="claude"))
+
+    def test_beat_noops_when_not_enrolled(self):
+        rec = pause.set_paused()
+        # Not enrolled → no device to attribute the heartbeat to → no upload.
+        with patch("prismor.runtime.enterprise.identity.is_enrolled", return_value=False):
+            self.assertFalse(pause.beat(agent="claude", state=rec))
+
+    def test_beat_uploads_once_then_debounces(self):
+        rec = pause.set_paused()
+        uploads = []
+        with patch("prismor.runtime.enterprise.identity.is_enrolled", return_value=True), \
+             patch("prismor.runtime.sinks.upload_telemetry", side_effect=lambda recs, **k: uploads.append(recs)):
+            self.assertTrue(pause.beat(agent="claude", state=rec))
+            # Re-read state from disk: last_beat was persisted, so a second
+            # call within the debounce window uploads nothing.
+            self.assertFalse(pause.beat(agent="claude"))
+        self.assertEqual(len(uploads), 1)
+        sent = uploads[0][0]
+        self.assertEqual(sent["type"], "paused_heartbeat")
+        self.assertTrue(sent["detail"]["paused"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Today the only way to turn Prismor off locally is `uninstall-hooks` — which is a blunt instrument:

- it also strips secret cloaking,
- and the device then **silently goes idle**, indistinguishable in the console from a closed laptop.

So "someone disabled protection" and "someone shut their laptop" look identical. This adds a **pause** that is installed-but-inert, reversible, time-boxed, and **visible**.

## What

```
prismor pause [--for 30m|2h|1d] [--reason "..."]
prismor resume
```

- **Pause suspends screening/enforcement without uninstalling.** The `hook-dispatch` path short-circuits to *allow* the moment a pause marker is present (before any policy pull / evaluation), so no tool call is screened while paused.
- **Still visible.** While paused, the dispatcher emits a lightweight **`paused_heartbeat`** telemetry event (debounced ~30s) so the control plane keeps `lastSeenAt` fresh and can render the device as **paused** rather than idle. The heartbeat carries `pausedAt` / `pausedUntil` / `reason`.
- **Self-healing.** `--for` sets an expiry; `active_state()` clears the marker once the window elapses (checked on the hot path), so protection comes back on its own even if `resume` is never run.
- **Loud, not silent.** `pause` prints exactly what's off and how/when it resumes; `prismor status` gains a `Paused:` line.
- **Attributable.** Records who paused (enrolled member) + reason.

State is a single 0600 JSON marker at `~/.prismor/pause.json`, mirroring the existing revocation-marker pattern in `enterprise/identity.py`.

## Files

- `prismor/runtime/pause.py` — new module (marker read/write, duration parsing, `active_state`/`is_paused`, debounced `beat`)
- `prismor/runtime/cli.py` — hook-dispatch short-circuit; `pause`/`resume` commands + subparsers; `Paused:` line in `status`
- `tests/test_pause.py` — 13 tests

## Tests

`tests/test_pause.py` — 13 passing. Manually verified the core invariant: a command blocked in enforce mode (exit 2) passes through while paused (exit 0), and is blocked again after `resume` — including auto-heal after a `--for` window expires. (Pre-existing `TestCliAnalyze` failures on `main` are unrelated to this change.)

## Companion

The prismor-web PR renders the new `paused` device status (distinct pill + tooltip, derived from the heartbeat's `pausedAt`/`pausedUntil`).