### PR TITLE
Tag-rule expression language, prismor tags CLI, and MCP _meta auto-tagging

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -117,6 +117,12 @@ Modes (`observe` vs `enforce`): [Prismor](prismor-runtime.md).
 | `prismor policy validate <file>` | — | Static-validate a policy YAML file. |
 | `prismor policy test` | `--file` | Run declarative policy tests (falls back to the bundled OWASP LLM starter pack). |
 | `prismor sandbox <status\|check\|run>` | `--workspace` | Docker-backed command sandbox: show config, check the backend, or run one command isolated. See [Docker sandbox](docker.md). |
+| `prismor tags list` | `--last N`, `--workspace` | Tools seen in recent sessions + resolved tags + which tier resolved them (explicit / `_meta` / default / inference). See [Tool Tags](tool-tags.md). |
+| `prismor tags set <tool> <tag>...` | `--workspace` | Tag a tool or glob in `.prismor/policy.yaml` (`tags rm` removes). |
+| `prismor tags rules [add\|rm]` | `--workspace` | List, add, or remove tag-rule expressions, e.g. `"untrusted_content then critical_action -> block"`. Adds are parse-checked with caret diagnostics. |
+| `prismor tags edit` | `--workspace` | Interactive wizard: tag tools, author rules, flip mode. |
+| `prismor tags lint [file]` | `--workspace` | Validate every rule expression in a policy file. Exit `1` on errors. |
+| `prismor tags test` | `--session <id>`, `--last N`, `--rule "<expr>"`, `--fail-on-hit` | Dry-run tag rules against recorded session logs: prints WOULD BLOCK / WOULD WARN per call, touches no enforcement state. `--rule` adds what-if candidates. |
 
 ### eval-server
 

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -101,6 +101,15 @@ defaults (`mcp__*__send_email`), org tool denies, tool-tag rules pushed from
 the control plane, and the console's tool inventory. One gateway process is
 one Prismor session; the trifecta ledger spans your whole agent session.
 
+## Server-declared tags (`_meta`)
+
+At `tools/list` time the gateway reads tags a server self-declares on each
+tool definition — `_meta.prismor.tags` (also `_meta.tags` or
+`annotations["prismor/tags"]`) — sanitizes them, and stamps them onto every
+call event. They feed tool-tag classification *below* the explicit org map:
+an admin's tag always wins over a server's self-declaration. See
+[Tool Tags](tool-tags.md).
+
 ## Notes
 
 - The gateway config may contain tokens in `env` blocks; `install` writes it

--- a/docs/tool-tags.md
+++ b/docs/tool-tags.md
@@ -1,0 +1,177 @@
+# Tool Tags & Tag Rules (policy as code)
+
+Every tool an agent can call — built-in, shell, or MCP — carries zero or more
+**tags** describing what it does: `untrusted_content` (reads
+attacker-influenceable input), `critical_action` (sends / publishes / destroys
+externally), or any tag you define (`private_data`, `external_comms`, …).
+**Tag rules** then declare which tag combinations a single session must never
+complete — the classic "lethal trifecta" (read untrusted content, then act
+externally) is just the default rule.
+
+The call that *completes* a forbidden combination is blocked before it
+executes. Everything is observable first (`mode: observe`), then enforceable.
+
+## How a tool gets its tags (precedence)
+
+| Tier | Source | Who controls it |
+|------|--------|-----------------|
+| 1 | Explicit map — `tool_tags.tags` in policy (exact, glob, or regex) | You / org admin |
+| 2 | Server-declared — `_meta.prismor.tags` on the MCP tool definition, read by `prismor mcp-gateway` | MCP server author |
+| 3 | Built-in defaults — well-known tools (`WebFetch`, `mcp__*__send_email`, …) | Prismor |
+| 4 | Inference — from the event type (`file_write` → critical, `tool_result` → untrusted, …) | Prismor |
+
+The first non-empty tier wins, so an admin's explicit tag always beats a
+server's self-declaration, which beats generic globs. Nothing is ever left
+completely untagged unless you disable tiers 3–4.
+
+Check what resolved where:
+
+```console
+$ prismor tags list
+TOOL                        TAGS                 TIER
+Bash                        critical_action      inference
+WebFetch                    untrusted_content    default
+mcp__crm__read_customers    private_data         _meta
+mcp__Gmail__send_email      critical_action      explicit
+```
+
+### Declaring tags from an MCP server (`_meta`)
+
+If you author an MCP server, self-declare tags on each tool definition and the
+gateway picks them up automatically — no spreadsheet, no manual mapping:
+
+```json
+{
+  "name": "read_customers",
+  "inputSchema": { "type": "object" },
+  "_meta": { "prismor": { "tags": ["private_data"] } }
+}
+```
+
+Also honored: `_meta.tags` and `annotations["prismor/tags"]`. Tags are
+sanitized (lowercase, `[a-z0-9][a-z0-9_.-]*`, max 8) — a server can suggest
+tags but can never override the org map or inject arbitrary strings.
+Disable the tier with `meta_tags_enabled: false`.
+
+## The rule language
+
+One rule per line. Three keywords. That's the whole grammar:
+
+```
+rule    :=  TAG ( then|with TAG )*  [ -> block|warn ]
+```
+
+- **`with`** — unordered co-occurrence: both tags appearing anywhere in the
+  session is enough.
+- **`then`** — ordered sequence: the left step must occur *before* the right.
+- **`-> block`** (default) or **`-> warn`** — warn logs the finding but never
+  blocks, even in enforce mode.
+- The call completing the **final step** is the one blocked/warned.
+- `not`, `or`, `within`, `count` are reserved for future use.
+
+```yaml
+settings:
+  tool_tags:
+    enabled: true
+    mode: enforce            # observe (log only) | enforce (terminal block)
+    tags:
+      mcp__Gmail__read_email: [untrusted_content]
+      mcp__Gmail__send_email: [critical_action]
+      mcp__crm__*: [private_data]
+    rules:
+      - "untrusted_content then critical_action -> block"
+      - "untrusted_content then private_data then external_comms -> block"
+      - "web_read with secrets_access -> warn"
+```
+
+More examples:
+
+```
+untrusted_content with critical_action -> block    # either order
+untrusted_content then critical_action -> block    # read first, act later
+untrusted_content with private_data then external_comms -> block
+customer_pii then external_comms                   # implicit -> block
+```
+
+### `with` vs `then`, concretely
+
+Session: `send_email` (critical) → `read_email` (untrusted) → `send_email`.
+
+- `untrusted_content with critical_action` fires at call **2** — both tags now
+  co-occur, order irrelevant.
+- `untrusted_content then critical_action` allows calls 1–2 and fires at call
+  **3** — the first critical action *after* untrusted content entered the
+  session. Ordered rules cut false positives when a critical-first pattern is
+  normal for your agents.
+
+### Backward compatibility (guaranteed)
+
+The pre-existing form keeps working forever and can be mixed with `rules:`:
+
+```yaml
+    incompatible:                       # same as "a with b -> block"
+      - [untrusted_content, critical_action]
+```
+
+Both compile to the same internal representation. A policy with only
+`incompatible` behaves byte-for-byte as before; if *neither* list is set, the
+default red/blue pair applies. Old runtimes simply ignore an unknown `rules:`
+key — there is no fleet flag day.
+
+## CLI
+
+```console
+$ prismor tags list                  # tools seen + resolved tags + tier
+$ prismor tags set 'mcp__crm__*' private_data
+$ prismor tags rm  'mcp__crm__*'
+$ prismor tags rules                 # active rules (DSL + legacy + default)
+$ prismor tags rules add "untrusted_content then critical_action -> block"
+$ prismor tags rules rm 0
+$ prismor tags edit                  # interactive wizard
+$ prismor tags lint                  # validate every rule expression
+```
+
+Invalid expressions fail with a caret diagnostic:
+
+```console
+$ prismor tags rules add "a then not b"
+invalid rule:
+  a then not b
+         ^ 'not' is reserved for future use
+```
+
+### Test rules against real session logs (dry run)
+
+Before enforcing anything, replay your recorded sessions through a candidate
+ruleset. Nothing is blocked and no enforcement state is touched:
+
+```console
+$ prismor tags test --last 10
+demo-session-1  2 hit(s) in 3 events
+  [  2] WOULD BLOCK mcp__Gmail__send_email
+        rule: untrusted_content then critical_action
+        prior: untrusted_content by 'mcp__Gmail__read_email' at event 0
+
+$ prismor tags test --rule "private_data then external_comms -> warn"   # what-if
+$ prismor tags test --session <id> --fail-on-hit                        # CI gate
+```
+
+Recommended rollout: `mode: observe` → watch findings / `tags test` → tighten
+tags → flip to `enforce`. An enforce block is terminal and non-overridable
+(part of Prismor's safety floor).
+
+## Semantics reference
+
+- Any number of same-tag calls is always allowed; only *completing* a
+  forbidden combination fires.
+- A session that has entered the forbidden state stays restricted — every
+  later call carrying a final-step tag keeps firing.
+- A blocked call never executes, so its tags do not enter the session ledger
+  (one denied call can't "use up" the rule).
+- `warn` rules log a `lethal_trifecta` finding but never block — even under a
+  device-level enforce override.
+- Findings: category `lethal_trifecta`; ruleId `tool-category-crossover`
+  (legacy/default rules) or `tag-rule:<id>` (expression rules). Both are part
+  of the non-overridable enforcement floor.
+- Per-session state lives under the Prismor data dir in `trifecta/<session>.json`;
+  `prismor tags test` uses an in-memory replay ledger and never touches it.

--- a/examples/lethal-trifecta/demo.py
+++ b/examples/lethal-trifecta/demo.py
@@ -33,23 +33,22 @@ GREEN = lambda s: _c("32", s)
 TAGCOL = lambda s: _c("36", s)
 
 
-def make_workspace(mode: str, tags: dict, incompatible: list) -> Path:
+def make_workspace(mode: str, tags: dict, incompatible: list,
+                   rules: list | None = None) -> Path:
     ws = Path(tempfile.mkdtemp(prefix=f"trifecta-{mode}-"))
     (ws / ".prismor").mkdir(parents=True, exist_ok=True)
-    policy = {
-        "version": "1.0",
-        "settings": {
-            "tool_tags": {
-                "enabled": True,
-                "mode": mode,               # observe | enforce
-                "detector": "strict_combination",
-                "defaults_enabled": True,
-                "inference_enabled": True,
-                "tags": tags,               # {} -> rely on built-in defaults
-                "incompatible": incompatible,
-            }
-        },
+    tt = {
+        "enabled": True,
+        "mode": mode,               # observe | enforce
+        "detector": "strict_combination",
+        "defaults_enabled": True,
+        "inference_enabled": True,
+        "tags": tags,               # {} -> rely on built-in defaults
+        "incompatible": incompatible,
     }
+    if rules is not None:
+        tt["rules"] = rules         # tag-rule expressions (policy as code)
+    policy = {"version": "1.0", "settings": {"tool_tags": tt}}
     try:
         import yaml
         (ws / ".prismor" / "policy.yaml").write_text(yaml.safe_dump(policy))
@@ -131,10 +130,27 @@ def main() -> int:
     run_session("5. Same as #1 but OBSERVE-first — logs, does not block",
                 ws_obs, "observe", ["read_email", "send_email"])
 
+    # ORDERED rule (tag-rule expression): critical FIRST is fine; only a
+    # critical action AFTER untrusted content fires.
+    ws_ord = make_workspace(
+        "enforce", {}, [],
+        rules=["untrusted_content then critical_action -> block"])
+    run_session('6. ORDERED rule "untrusted then critical" — send, read, send',
+                ws_ord, "ordered", ["send_email", "read_email", "send_email"])
+
+    # WARN rule: same sequence logs a finding but never blocks, even in enforce.
+    ws_warn = make_workspace(
+        "enforce", {}, [],
+        rules=["untrusted_content then critical_action -> warn"])
+    run_session('7. WARN rule — same sequence, logged but never blocked',
+                ws_warn, "warn", ["read_email", "send_email"])
+
     print(BOLD("\n=== summary ==="))
     print("  same-tag sessions (#2, #3) stay frictionless — no blocks.")
     print("  the call that COMPLETES a forbidden set is blocked (#1 = 2-tag, #4 = 3-tag).")
     print("  observe mode (#5) logs the combination without blocking (safe rollout).")
+    print("  ordered rules (#6) allow critical-first patterns; only untrusted->critical fires.")
+    print("  warn rules (#7) log the finding but never block, even in enforce.")
     return 0
 
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1858,6 +1858,48 @@ def main(argv: Optional[List[str]] = None) -> None:
                     print(f"    {t:8s}  {n}")
             return
 
+    # ── tags subcommands ───────────────────────────────────────────────
+    if args.command == "tags":
+        from prismor.runtime import tags_cli
+
+        tc = getattr(args, "tags_command", None)
+        if tc == "list":
+            tags_cli.tags_list(workspace, last=args.last)
+            return
+        if tc == "set":
+            tags_cli.tags_set(workspace, args.tool, args.tag)
+            return
+        if tc == "rm":
+            tags_cli.tags_rm(workspace, args.tool, args.tag)
+            return
+        if tc == "rules":
+            if args.rules_action == "add":
+                if not args.expr:
+                    print("usage: prismor tags rules add \"<expr>\"")
+                    sys.exit(2)
+                tags_cli.rules_add(workspace, args.expr)
+            elif args.rules_action == "rm":
+                if not args.expr:
+                    print("usage: prismor tags rules rm <index|expr>")
+                    sys.exit(2)
+                tags_cli.rules_rm(workspace, args.expr)
+            else:
+                tags_cli.rules_list(workspace)
+            return
+        if tc == "edit":
+            tags_cli.tags_edit(workspace)
+            return
+        if tc == "lint":
+            tags_cli.tags_lint(workspace, getattr(args, "file", None))
+            return
+        if tc == "test":
+            tags_cli.tags_test(workspace, session=args.session, last=args.last,
+                               extra_rules=args.rule,
+                               fail_on_hit=args.fail_on_hit)
+            return
+        parser.parse_args(["tags", "--help"])
+        return
+
     # ── policy subcommands ─────────────────────────────────────────────
     if args.command == "policy":
         if args.policy_command == "init":
@@ -2368,6 +2410,47 @@ def build_parser() -> argparse.ArgumentParser:
     policy_test = policy_sub.add_parser("test", help="Run declarative policy tests from policy-tests.yaml")
     policy_test.add_argument("--file", help="Path to policy-tests.yaml (default: .prismor/policy-tests.yaml)")
     policy_test.add_argument("--workspace", help="Workspace path")
+
+    # ── tags (tool tags + tag-rule expressions) ────────────────────────
+    tags_parser = subparsers.add_parser(
+        "tags", help="Tag tools/MCPs and write tag-rules (policy as code)")
+    tags_sub = tags_parser.add_subparsers(dest="tags_command")
+
+    tags_list_p = tags_sub.add_parser("list", help="Tools seen in sessions + resolved tags + tier")
+    tags_list_p.add_argument("--last", type=int, default=50, help="How many recent sessions to scan")
+    tags_list_p.add_argument("--workspace", help="Workspace path")
+
+    tags_set_p = tags_sub.add_parser("set", help="Tag a tool (writes .prismor/policy.yaml)")
+    tags_set_p.add_argument("tool", help="Tool name or glob (e.g. mcp__crm__*)")
+    tags_set_p.add_argument("tag", nargs="+", help="One or more tags")
+    tags_set_p.add_argument("--workspace", help="Workspace path")
+
+    tags_rm_p = tags_sub.add_parser("rm", help="Remove a tool's explicit tag mapping")
+    tags_rm_p.add_argument("tool", help="Tool name/glob as written in the policy")
+    tags_rm_p.add_argument("tag", nargs="?", help="Remove only this tag (default: whole mapping)")
+    tags_rm_p.add_argument("--workspace", help="Workspace path")
+
+    tags_rules_p = tags_sub.add_parser("rules", help="List/add/remove tag-rule expressions")
+    tags_rules_p.add_argument("rules_action", nargs="?", default="list",
+                              choices=["list", "add", "rm"])
+    tags_rules_p.add_argument("expr", nargs="?",
+                              help='Rule expression (add) or index/text (rm), e.g. "untrusted_content then critical_action -> block"')
+    tags_rules_p.add_argument("--workspace", help="Workspace path")
+
+    tags_edit_p = tags_sub.add_parser("edit", help="Interactive wizard: tag tools + author rules")
+    tags_edit_p.add_argument("--workspace", help="Workspace path")
+
+    tags_lint_p = tags_sub.add_parser("lint", help="Validate rule expressions in a policy file")
+    tags_lint_p.add_argument("file", nargs="?", help="Policy file (default: .prismor/policy.yaml)")
+    tags_lint_p.add_argument("--workspace", help="Workspace path")
+
+    tags_test_p = tags_sub.add_parser("test", help="Dry-run tag rules against recorded session logs")
+    tags_test_p.add_argument("--session", help="Replay one specific session id")
+    tags_test_p.add_argument("--last", type=int, default=5, help="Replay the N most recent sessions (default 5)")
+    tags_test_p.add_argument("--rule", action="append", default=[],
+                             help="Extra candidate rule expression (repeatable, what-if)")
+    tags_test_p.add_argument("--fail-on-hit", action="store_true", help="Exit 1 if any rule would fire")
+    tags_test_p.add_argument("--workspace", help="Workspace path")
 
     # ── enroll / device identity (enterprise control plane) ─────────────
     enroll_parser = subparsers.add_parser(

--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -97,15 +97,26 @@ settings:
     detector: strict_combination
     defaults_enabled: true  # apply built-in tags for well-known tools
     inference_enabled: true # infer tags for uncategorized tools from event type
+    meta_tags_enabled: true # honor tags MCP servers self-declare in _meta.prismor.tags
     tags: {}                # explicit tool -> tag | [tags] (merge over defaults)
-    incompatible:           # forbidden co-occurrence tag sets; default = the trifecta pair
-      - [untrusted_content, critical_action]
+    rules: []               # tag-rule expressions (policy as code). Grammar:
+                            #   TAG (then|with TAG)* [-> block|warn]
+                            # `with` = unordered co-occurrence; `then` = ordered
+                            # sequence. The call completing the final step is
+                            # blocked/warned. Validate with `prismor tags lint`,
+                            # dry-run against session logs with `prismor tags test`.
+    incompatible:           # legacy forbidden co-occurrence sets — still honored,
+      - [untrusted_content, critical_action]   # same as "a with b -> block"
     # Example:
     #   tags:
     #     mcp__Gmail__read_email: [untrusted_content]
     #     WebFetch: [untrusted_content, network_read]
     #     mcp__Gmail__send_email: [critical_action]
     #     mcp__db__delete: [critical_action, destructive]
+    #   rules:
+    #     - "untrusted_content then critical_action -> block"
+    #     - "untrusted_content then private_data then external_comms -> block"
+    #     - "network_read with destructive -> warn"
     #   incompatible:
     #     - [untrusted_content, critical_action]
     #     - [untrusted_content, destructive]

--- a/prismor/runtime/mcp_gateway.py
+++ b/prismor/runtime/mcp_gateway.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -443,6 +444,44 @@ class _Route:
     upstream: Upstream
     server: str        # real downstream server name (event namespace)
     tool: str          # original un-namespaced tool name
+    # Tags the server self-declares on the tool definition (_meta.prismor.tags,
+    # _meta.tags, or annotations["prismor/tags"]) — consumed by trifecta
+    # classification below the explicit org map (admin always wins).
+    meta_tags: List[str] = field(default_factory=list)
+
+
+_META_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9_.\-]*$")
+_META_TAG_CAP = 8
+
+
+def _extract_meta_tags(tool: Dict[str, Any]) -> List[str]:
+    """Pull self-declared tags off an upstream tool definition, sanitized:
+    lowercase, tag charset only, capped. Untrusted input — never let a server
+    smuggle arbitrary strings into policy findings."""
+    raw: Any = None
+    meta = tool.get("_meta")
+    if isinstance(meta, dict):
+        pris = meta.get("prismor")
+        if isinstance(pris, dict):
+            raw = pris.get("tags")
+        if raw is None:
+            raw = meta.get("tags")
+    if raw is None:
+        ann = tool.get("annotations")
+        if isinstance(ann, dict):
+            raw = ann.get("prismor/tags")
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    out: List[str] = []
+    for item in raw:
+        tag = str(item).strip().lower()
+        if tag and _META_TAG_RE.match(tag) and tag not in out:
+            out.append(tag)
+        if len(out) >= _META_TAG_CAP:
+            break
+    return out
 
 
 class Gateway:
@@ -597,7 +636,8 @@ class Gateway:
                 original = str(tool["name"])
                 exposed = self._client_tool_name(up.spec.name, original)
                 routes[exposed] = _Route(upstream=up, server=up.spec.name,
-                                         tool=original)
+                                         tool=original,
+                                         meta_tags=_extract_meta_tags(tool))
                 entry = dict(tool)
                 entry["name"] = exposed
                 if self.namespace != "none":
@@ -687,17 +727,22 @@ class Gateway:
     # ── event builders ───────────────────────────────────────────────────
 
     def _event_base(self, route: _Route, agent_event: str) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {
+            "cwd": str(self.workspace),
+            # The REAL server name — matches trifecta globs, tool denies,
+            # and control-plane parseToolName. See module docstring.
+            "tool_name": f"mcp__{route.server}__{route.tool}",
+        }
+        if route.meta_tags:
+            # Server-declared tags ride on the event; trifecta consumes them
+            # as a classification tier below the explicit org map.
+            metadata["meta_tags"] = list(route.meta_tags)
         return {
             "ts": datetime.now(timezone.utc).isoformat(),
             "session_id": self.session_id,
             "agent": GATEWAY_AGENT,
             "agent_event": agent_event,
-            "metadata": {
-                "cwd": str(self.workspace),
-                # The REAL server name — matches trifecta globs, tool denies,
-                # and control-plane parseToolName. See module docstring.
-                "tool_name": f"mcp__{route.server}__{route.tool}",
-            },
+            "metadata": metadata,
         }
 
     def _build_call_event(self, route: _Route, arguments: Any) -> Dict[str, Any]:

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1178,9 +1178,8 @@ class PolicyEngine:
         # (swappable); enforcement is here.
         if self.tool_tags.get("enabled") and session_id and self.workspace is not None:
             try:
-                from prismor.runtime.trifecta import (
-                    classify_tool_tags, TagLedger, normalize_incompatible,
-                )
+                from prismor.runtime.trifecta import classify_tool_tags, TagLedger
+                from prismor.runtime.tag_rules import compile_tool_tag_rules
                 _tt_tool = str((event.get("metadata") or {}).get("tool_name") or "")
                 _tags = classify_tool_tags(
                     event, event_type,
@@ -1188,17 +1187,32 @@ class PolicyEngine:
                     self.tool_tags,
                 )
                 if _tags:
-                    _incompat = normalize_incompatible(self.tool_tags.get("incompatible"))
+                    _rules = compile_tool_tag_rules(self.tool_tags)
                     _ledger = TagLedger(self.workspace, session_id)
-                    _done = _ledger.completes(_tags, _incompat, index)
+                    _done = _ledger.completes_rules(_tags, _rules, index)
                     _tt_mode = self.device_mode or str(self.tool_tags.get("mode", "observe")).lower()
+                    if _done is not None and _done.get("action") == "warn":
+                        # A warn rule observes but never blocks — even under a
+                        # device-level enforce override.
+                        _tt_mode = "observe"
                     if _done is not None:
                         _intro = _done.get("introduced_by") or {}
                         _prior = ", ".join(
                             f"{_t} (by '{(_intro.get(_t) or {}).get('tool', '?')}')"
                             for _t in _done["set"] if _t in _intro
                         )
-                        _fid = f"tool-category-crossover-{index}"
+                        # Legacy/default rules keep the historical ruleId; DSL
+                        # rules get a stable per-expression id. Both stay floor-
+                        # protected via category lethal_trifecta.
+                        if _done.get("source") in ("incompatible", "default"):
+                            _rid = "tool-category-crossover"
+                        else:
+                            _rid = f"tag-rule:{_done.get('rule_id', '')}"
+                        _steps = _done.get("steps") or [_done["set"]]
+                        _combo = " then ".join(
+                            "+".join(s) for s in _steps
+                        ) if len(_steps) > 1 else ", ".join(_done["set"])
+                        _fid = f"{_rid}-{index}"
                         _pfx = f"{session_id}:{_fid}" if session_id else _fid
                         findings.append({
                             "id": _pfx,
@@ -1206,14 +1220,15 @@ class PolicyEngine:
                             "category": "lethal_trifecta",
                             "title": (
                                 f"Forbidden tool combination: '{_tt_tool}' completes "
-                                f"tag set [{', '.join(_done['set'])}] in this session"
+                                f"tag sequence [{_combo}] in this session"
                             ),
                             "evidence": (
                                 f"call adds tag(s) {_done['this_call_tags']}; "
                                 f"prior: {_prior or 'n/a'}"
+                                + (f"; rule: {_done['source']}" if _done.get("source") not in ("incompatible", "default") else "")
                             ),
                             "eventIndex": index,
-                            "ruleId": "tool-category-crossover",
+                            "ruleId": _rid,
                             "action": "block",
                             "mode": _tt_mode,
                         })
@@ -2086,5 +2101,27 @@ def validate_policy(path: Path) -> List[str]:
                 re.compile(pattern)
             except re.error as e:
                 errors.append(f"{prefix}.patterns[{j}]: invalid regex: {e}")
+
+    # settings.tool_tags: lint tag-rule expressions + legacy incompatible sets.
+    tt = ((raw.get("settings") or {}).get("tool_tags") or {})
+    if isinstance(tt, dict):
+        from prismor.runtime.tag_rules import ParseError as _TagParseError, compile_rule as _compile_tag_rule
+
+        for i, entry in enumerate(tt.get("rules") or []):
+            prefix = f"settings.tool_tags.rules[{i}]"
+            expr = entry if isinstance(entry, str) else (
+                entry.get("expr") if isinstance(entry, dict) else None)
+            if not isinstance(expr, str):
+                errors.append(f"{prefix}: must be a string or an {{expr, action}} map")
+                continue
+            try:
+                _compile_tag_rule(expr)
+            except _TagParseError as e:
+                errors.append(f"{prefix}: {e.args[0]} in \"{expr}\"")
+            if isinstance(entry, dict) and entry.get("action") not in (None, "block", "warn"):
+                errors.append(f"{prefix}: invalid action '{entry.get('action')}' (block or warn)")
+        for i, s in enumerate(tt.get("incompatible") or []):
+            if not isinstance(s, (list, tuple)) or len({str(t) for t in s}) < 2:
+                errors.append(f"settings.tool_tags.incompatible[{i}]: needs at least 2 distinct tags")
 
     return errors

--- a/prismor/runtime/policy_schema.json
+++ b/prismor/runtime/policy_schema.json
@@ -227,6 +227,95 @@
             },
             "additionalProperties": false
           }
+        },
+        "tool_tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "observe",
+                "enforce"
+              ]
+            },
+            "detector": {
+              "type": "string"
+            },
+            "defaults_enabled": {
+              "type": "boolean"
+            },
+            "inference_enabled": {
+              "type": "boolean"
+            },
+            "meta_tags_enabled": {
+              "type": "boolean"
+            },
+            "tags": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^[a-z0-9][a-z0-9_.\\-]*$"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9][a-z0-9_.\\-]*$"
+                    },
+                    "minItems": 1
+                  }
+                ]
+              }
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "expr"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "expr": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "block",
+                          "warn"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "incompatible": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9_.\\-]*$"
+                },
+                "minItems": 2
+              }
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/prismor/runtime/tag_rules.py
+++ b/prismor/runtime/tag_rules.py
@@ -1,0 +1,229 @@
+"""Tag-rule expression language — policy-as-code over tool tags.
+
+A tiny, dependency-free rule DSL for ``settings.tool_tags.rules``. One rule per
+line-string; three keywords; whitespace-tokenized:
+
+    rule      := seq [ "->" action ]
+    seq       := term ( ("then" | "with") term )*
+    term      := TAG                      # [a-z0-9][a-z0-9_.-]*
+    action    := "block" | "warn"         # omitted -> "block"
+
+Semantics:
+  * ``with`` groups adjacent terms into one unordered step (all tags must
+    co-occur in the session — exactly the legacy ``incompatible`` semantics).
+  * ``then`` separates ordered steps: every tag of step N must have occurred
+    before the occurrences satisfying step N+1.
+  * The call that satisfies the *final* step is the one blocked/warned.
+
+Examples:
+    untrusted_content with critical_action -> block
+    untrusted_content then critical_action -> block
+    untrusted_content then private_data then external_comms -> block
+    web_read with secrets_access -> warn
+    customer_pii then external_comms          (implicit -> block)
+
+``not``, ``or``, ``within`` and ``count`` are reserved for future grammar
+growth and raise a ParseError today.
+
+Legacy compatibility: :func:`compile_tool_tag_rules` is the single funnel that
+compiles both the new ``rules:`` strings and the legacy ``incompatible:`` lists
+into one internal representation (:class:`CompiledRule`), so existing policies
+keep working byte-for-byte.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from prismor.runtime.trifecta import DEFAULT_INCOMPATIBLE, _as_list
+
+ACTIONS = ("block", "warn")
+CONNECTORS = ("then", "with")
+RESERVED = ("not", "or", "within", "count")
+_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9_.\-]*$")
+
+
+class ParseError(ValueError):
+    """Raised on an invalid rule expression. Carries ``pos`` (0-based char
+    offset into the source string) for caret diagnostics."""
+
+    def __init__(self, message: str, expr: str = "", pos: int = 0) -> None:
+        super().__init__(message)
+        self.expr = expr
+        self.pos = pos
+
+    def caret(self) -> str:
+        """Two-line diagnostic: the expression and a caret under the error."""
+        return f"{self.expr}\n{' ' * self.pos}^ {self.args[0]}"
+
+
+@dataclass
+class CompiledRule:
+    """Internal representation shared by DSL rules and legacy incompatible sets."""
+
+    steps: List[Set[str]]  # ordered steps; each step is an unordered tag set
+    action: str = "block"  # "block" | "warn"
+    source: str = ""  # original expression, or "incompatible" for legacy rows
+    rule_id: str = field(default="")
+
+    def __post_init__(self) -> None:
+        if not self.rule_id:
+            norm = ";".join(",".join(sorted(s)) for s in self.steps) + "|" + self.action
+            self.rule_id = hashlib.sha256(norm.encode("utf-8")).hexdigest()[:10]
+
+    @property
+    def ordered(self) -> bool:
+        return len(self.steps) > 1
+
+    @property
+    def all_tags(self) -> Set[str]:
+        out: Set[str] = set()
+        for s in self.steps:
+            out |= s
+        return out
+
+
+def _tokenize(expr: str) -> List[Tuple[str, int]]:
+    """Split on whitespace, keeping each token's start offset."""
+    toks: List[Tuple[str, int]] = []
+    for m in re.finditer(r"\S+", expr):
+        toks.append((m.group(0), m.start()))
+    return toks
+
+
+def compile_rule(expr: str) -> CompiledRule:
+    """Compile one rule expression string into a :class:`CompiledRule`."""
+    if not isinstance(expr, str):
+        raise ParseError("rule must be a string", str(expr), 0)
+    toks = _tokenize(expr)
+    if not toks:
+        raise ParseError("empty rule", expr, 0)
+
+    # Optional trailing "-> action".
+    action = "block"
+    if any(t == "->" for t, _ in toks):
+        arrow_i = next(i for i, (t, _) in enumerate(toks) if t == "->")
+        tail = toks[arrow_i + 1 :]
+        if arrow_i != len(toks) - 2 or not tail:
+            pos = toks[arrow_i][1]
+            raise ParseError("'->' must be followed by exactly one action", expr, pos)
+        act_tok, act_pos = tail[0]
+        if act_tok not in ACTIONS:
+            raise ParseError(
+                f"unknown action '{act_tok}' (expected {' or '.join(ACTIONS)})",
+                expr, act_pos,
+            )
+        action = act_tok
+        toks = toks[:arrow_i]
+        if not toks:
+            raise ParseError("rule has no tags before '->'", expr, 0)
+
+    # seq := term ( connector term )*
+    steps: List[Set[str]] = []
+    current: Set[str] = set()
+    expect_term = True
+    for tok, pos in toks:
+        if expect_term:
+            low = tok.lower()
+            if low in RESERVED:
+                raise ParseError(
+                    f"'{tok}' is reserved for future use", expr, pos
+                )
+            if low in CONNECTORS or tok == "->":
+                raise ParseError(f"expected a tag, got '{tok}'", expr, pos)
+            if not _TAG_RE.match(tok):
+                raise ParseError(
+                    f"invalid tag '{tok}' (allowed: [a-z0-9][a-z0-9_.-]*)",
+                    expr, pos,
+                )
+            current.add(tok)
+            expect_term = False
+        else:
+            if tok == "then":
+                steps.append(current)
+                current = set()
+                expect_term = True
+            elif tok == "with":
+                expect_term = True
+            else:
+                raise ParseError(
+                    f"expected 'then', 'with' or '->', got '{tok}'", expr, pos
+                )
+    if expect_term:
+        # Trailing connector like "a then".
+        tok, pos = toks[-1]
+        raise ParseError(f"dangling '{tok}' at end of rule", expr, pos)
+    steps.append(current)
+
+    if len(steps) == 1 and len(steps[0]) < 2:
+        raise ParseError(
+            "a rule needs at least two tags (a single tag can never be a "
+            "combination)", expr, 0,
+        )
+    return CompiledRule(steps=steps, action=action, source=expr.strip())
+
+
+def lint_rules(exprs: List[str]) -> List[Tuple[str, ParseError]]:
+    """Validate rule strings; return (expr, error) pairs for the invalid ones."""
+    errors: List[Tuple[str, ParseError]] = []
+    for expr in exprs:
+        try:
+            compile_rule(expr)
+        except ParseError as e:
+            errors.append((expr, e))
+    return errors
+
+
+def _coerce_rule_entry(entry: Any) -> Optional[CompiledRule]:
+    """Compile one ``rules:`` entry — a DSL string or an {expr, action} map."""
+    if isinstance(entry, str):
+        return compile_rule(entry)
+    if isinstance(entry, dict):
+        expr = entry.get("expr")
+        if not isinstance(expr, str):
+            raise ParseError("rule map needs an 'expr' string", str(entry), 0)
+        rule = compile_rule(expr)
+        act = entry.get("action")
+        if act in ACTIONS and act != rule.action:
+            # Explicit map action overrides the expression's (or the default).
+            rule = CompiledRule(steps=rule.steps, action=act, source=rule.source)
+        return rule
+    raise ParseError("rule must be a string or an {expr, action} map", str(entry), 0)
+
+
+def compile_tool_tag_rules(tt: Optional[Dict[str, Any]]) -> List[CompiledRule]:
+    """Compile ``settings.tool_tags`` (both ``rules`` and legacy ``incompatible``)
+    into one rule list. Invalid DSL entries are skipped (policy loading must not
+    crash the engine); use :func:`lint_rules` to surface them. Falls back to the
+    default red/blue pair only when both lists yield nothing — mirroring
+    ``normalize_incompatible``."""
+    tt = tt or {}
+    out: List[CompiledRule] = []
+
+    raw_rules = tt.get("rules")
+    if isinstance(raw_rules, (list, tuple)):
+        for entry in raw_rules:
+            try:
+                rule = _coerce_rule_entry(entry)
+            except ParseError:
+                continue
+            if rule is not None:
+                out.append(rule)
+
+    raw_incompat = tt.get("incompatible")
+    if isinstance(raw_incompat, (list, tuple)):
+        for item in raw_incompat:
+            tags = {str(t) for t in _as_list(item)}
+            if len(tags) >= 2:  # single-tag "set" can never be a combination
+                out.append(
+                    CompiledRule(steps=[tags], action="block", source="incompatible")
+                )
+
+    if not out:
+        out = [
+            CompiledRule(steps=[set(s)], action="block", source="default")
+            for s in DEFAULT_INCOMPATIBLE
+        ]
+    return out

--- a/prismor/runtime/tags_cli.py
+++ b/prismor/runtime/tags_cli.py
@@ -1,0 +1,531 @@
+"""`prismor tags` — manage tool tags + tag-rule expressions (policy as code).
+
+Subcommands:
+    list                     tools seen in recorded sessions + resolved tags + tier
+    set <tool> <tag>...      write an explicit tag mapping into .prismor/policy.yaml
+    rm <tool> [<tag>]        remove an explicit mapping (or one tag of it)
+    rules [list]             show active rules (DSL + legacy incompatible)
+    rules add "<expr>"       add a rule expression (parse-checked first)
+    rules rm <n|expr>        remove a rule by index (from `rules list`) or text
+    edit                     interactive wizard over tools + rules
+    lint [file]              validate every rule expression; exit 1 on errors
+    test [--session|--last]  dry-run rules against recorded session logs
+
+The heavy lifting (parsing, classification, ledger) lives in ``tag_rules`` and
+``trifecta``; this module is UX only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from prismor.runtime.tag_rules import (
+    CompiledRule, ParseError, compile_rule, compile_tool_tag_rules, lint_rules,
+)
+from prismor.runtime.trifecta import (
+    TOOL_TAG_DEFAULTS, TagLedger, _matches, _tool_name, classify_tool_tags,
+)
+
+# ── small output helpers (match cli.py's ANSI style, no deps) ────────────────
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_CYAN = "\033[36m"
+
+
+def _c(text: str, color: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"{color}{text}{_RESET}"
+
+
+def _print_parse_error(err: ParseError) -> None:
+    print(_c("invalid rule:", _RED))
+    print(f"  {err.expr}")
+    print(f"  {' ' * err.pos}{_c('^ ' + str(err.args[0]), _RED)}")
+
+
+# ── policy file plumbing ─────────────────────────────────────────────────────
+
+def _policy_path(workspace: Path) -> Path:
+    return workspace / ".prismor" / "policy.yaml"
+
+
+def _load_policy_file(workspace: Path) -> Dict[str, Any]:
+    import yaml
+
+    path = _policy_path(workspace)
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_policy_file(workspace: Path, data: Dict[str, Any]) -> None:
+    import yaml
+
+    path = _policy_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data.setdefault("version", "1.0")
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _tt_block(data: Dict[str, Any]) -> Dict[str, Any]:
+    settings = data.setdefault("settings", {})
+    if not isinstance(settings, dict):
+        settings = {}
+        data["settings"] = settings
+    tt = settings.setdefault("tool_tags", {})
+    if not isinstance(tt, dict):
+        tt = {}
+        settings["tool_tags"] = tt
+    return tt
+
+
+def _effective_tool_tags(workspace: Path) -> Dict[str, Any]:
+    """The merged tool_tags settings the engine actually uses (defaults +
+    project override + org remote policy)."""
+    try:
+        from prismor.runtime.policy_engine import PolicyEngine
+
+        return PolicyEngine(workspace=workspace).tool_tags or {}
+    except Exception:
+        return {}
+
+
+def _org_managed_hint(workspace: Path) -> None:
+    """If this device is enrolled, local edits may be overridden by org policy."""
+    try:
+        from prismor.runtime.enterprise.identity import load_identity
+
+        if load_identity() is not None:
+            print(_c(
+                "note: this device is org-enrolled — org policy is authoritative; "
+                "manage org-wide tags in the Prismor console (Tag Studio).", _DIM))
+    except Exception:
+        pass
+
+
+# ── session log scanning ─────────────────────────────────────────────────────
+
+def _recent_sessions(workspace: Path, limit: int) -> List[Tuple[str, Path]]:
+    from prismor.runtime.store import get_sessions_dir
+
+    sdir = get_sessions_dir(workspace)
+    if not sdir.exists():
+        return []
+    files = sorted(sdir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime,
+                   reverse=True)
+    return [(p.stem, p) for p in files[:limit]]
+
+
+def _session_events(workspace: Path, session_id: str) -> List[Dict[str, Any]]:
+    from prismor.runtime.store import read_session_events
+
+    try:
+        return read_session_events(workspace, session_id)
+    except FileNotFoundError:
+        return []
+
+
+def _resolve_with_tier(
+    event: Dict[str, Any], event_type: str, tt: Dict[str, Any]
+) -> Tuple[Set[str], str]:
+    """Classify like ``classify_tool_tags`` but also report WHICH tier won."""
+    tool = _tool_name(event)
+    mapping = tt.get("tags") or {}
+    if isinstance(mapping, dict):
+        explicit: Set[str] = set()
+        for pat, val in mapping.items():
+            if pat == tool or _matches(tool, pat, "auto"):
+                explicit |= set(val if isinstance(val, list) else [val])
+        if explicit:
+            return explicit, "explicit"
+    if tt.get("meta_tags_enabled", True):
+        mt = (event.get("metadata") or {}).get("meta_tags")
+        if isinstance(mt, (list, tuple)) and mt:
+            return {str(t) for t in mt if t}, "_meta"
+    if tt.get("defaults_enabled", True):
+        d: Set[str] = set()
+        for matcher, match_type, deftags in TOOL_TAG_DEFAULTS:
+            if _matches(tool, matcher, match_type):
+                d |= set(deftags)
+        if d:
+            return d, "default"
+    tags = classify_tool_tags(event, event_type, set(), {
+        **tt, "tags": {}, "defaults_enabled": False, "meta_tags_enabled": False,
+    })
+    if tags:
+        return tags, "inference"
+    return set(), "-"
+
+
+# ── subcommand: list ─────────────────────────────────────────────────────────
+
+def tags_list(workspace: Path, last: int = 50) -> None:
+    tt = _effective_tool_tags(workspace)
+    seen: Dict[str, Tuple[Set[str], str]] = {}
+    for sid, _ in _recent_sessions(workspace, last):
+        for ev in _session_events(workspace, sid):
+            tool = _tool_name(ev)
+            if not tool or tool in seen:
+                continue
+            etype = str(ev.get("type") or "")
+            seen[tool] = _resolve_with_tier(ev, etype, tt)
+    if not seen:
+        print("no tools recorded yet — run some agent sessions first")
+        return
+    print(_c(f"{'TOOL':44s} {'TAGS':34s} TIER", _BOLD))
+    for tool in sorted(seen):
+        tags, tier = seen[tool]
+        tag_s = ", ".join(sorted(tags)) if tags else _c("(untagged)", _DIM)
+        tier_c = {"explicit": _GREEN, "_meta": _CYAN,
+                  "default": _YELLOW}.get(tier, _DIM)
+        print(f"{tool:44s} {tag_s:34s} {_c(tier, tier_c)}")
+    enabled = "enabled" if tt.get("enabled") else "disabled"
+    print(_c(f"\ntool_tags: {enabled}, mode={tt.get('mode', 'observe')}", _DIM))
+
+
+# ── subcommands: set / rm ────────────────────────────────────────────────────
+
+def tags_set(workspace: Path, tool: str, tags: List[str]) -> None:
+    bad = [t for t in tags if not _valid_tag(t)]
+    if bad:
+        print(_c(f"invalid tag(s): {', '.join(bad)} "
+                 f"(allowed: [a-z0-9][a-z0-9_.-]*)", _RED))
+        sys.exit(1)
+    data = _load_policy_file(workspace)
+    tt = _tt_block(data)
+    m = tt.setdefault("tags", {})
+    existing = m.get(tool)
+    merged = sorted(set(
+        (existing if isinstance(existing, list) else [existing] if existing else [])
+    ) | set(tags))
+    m[tool] = merged
+    _save_policy_file(workspace, data)
+    print(f"{_c('tagged', _GREEN)} {tool} -> [{', '.join(merged)}]")
+    _org_managed_hint(workspace)
+
+
+def _valid_tag(tag: str) -> bool:
+    import re
+
+    return bool(re.match(r"^[a-z0-9][a-z0-9_.\-]*$", tag))
+
+
+def tags_rm(workspace: Path, tool: str, tag: Optional[str]) -> None:
+    data = _load_policy_file(workspace)
+    tt = _tt_block(data)
+    m = tt.get("tags") or {}
+    if tool not in m:
+        print(_c(f"no explicit mapping for '{tool}' in {_policy_path(workspace)}",
+                 _YELLOW))
+        sys.exit(1)
+    if tag is None:
+        del m[tool]
+        print(f"{_c('removed', _GREEN)} mapping for {tool}")
+    else:
+        cur = m[tool] if isinstance(m[tool], list) else [m[tool]]
+        cur = [t for t in cur if t != tag]
+        if cur:
+            m[tool] = cur
+        else:
+            del m[tool]
+        print(f"{_c('removed', _GREEN)} tag '{tag}' from {tool}")
+    _save_policy_file(workspace, data)
+
+
+# ── subcommand: rules ────────────────────────────────────────────────────────
+
+def _active_rules(tt: Dict[str, Any]) -> List[CompiledRule]:
+    return compile_tool_tag_rules(tt)
+
+
+def rules_list(workspace: Path) -> None:
+    tt = _effective_tool_tags(workspace)
+    rules = _active_rules(tt)
+    print(_c(f"{'#':>2s}  {'RULE':56s} {'ACTION':7s} SOURCE", _BOLD))
+    for i, r in enumerate(rules):
+        if r.source in ("incompatible", "default"):
+            expr = " with ".join(sorted(r.steps[0]))
+            src = "legacy" if r.source == "incompatible" else "default"
+        else:
+            expr = r.source
+            src = "rule"
+        act_c = _RED if r.action == "block" else _YELLOW
+        print(f"{i:2d}  {expr:56s} {_c(r.action, act_c):16s} {_c(src, _DIM)}")
+    print(_c("\nadd:  prismor tags rules add \"untrusted_content then "
+             "critical_action -> block\"", _DIM))
+
+
+def rules_add(workspace: Path, expr: str) -> None:
+    try:
+        rule = compile_rule(expr)
+    except ParseError as err:
+        _print_parse_error(err)
+        sys.exit(1)
+    data = _load_policy_file(workspace)
+    tt = _tt_block(data)
+    lst = tt.setdefault("rules", [])
+    if expr.strip() in [str(e).strip() for e in lst]:
+        print(_c("rule already present", _YELLOW))
+        return
+    lst.append(expr.strip())
+    _save_policy_file(workspace, data)
+    steps = " -> ".join("+".join(sorted(s)) for s in rule.steps)
+    print(f"{_c('added', _GREEN)} [{rule.action}] {steps}")
+    _org_managed_hint(workspace)
+
+
+def rules_rm(workspace: Path, which: str) -> None:
+    data = _load_policy_file(workspace)
+    tt = _tt_block(data)
+    lst = tt.get("rules") or []
+    removed = None
+    if which.isdigit():
+        # index into the ACTIVE rule listing = local rules come first there
+        # only if they are the workspace's; safer: index into the local list.
+        i = int(which)
+        if 0 <= i < len(lst):
+            removed = lst.pop(i)
+    else:
+        for i, e in enumerate(lst):
+            e_str = e if isinstance(e, str) else str((e or {}).get("expr", ""))
+            if e_str.strip() == which.strip():
+                removed = lst.pop(i)
+                break
+    if removed is None:
+        print(_c(f"no local rule matching '{which}' in {_policy_path(workspace)} "
+                 "(org/default rules can't be removed here)", _YELLOW))
+        sys.exit(1)
+    _save_policy_file(workspace, data)
+    print(f"{_c('removed', _GREEN)} {removed}")
+
+
+# ── subcommand: lint ─────────────────────────────────────────────────────────
+
+def tags_lint(workspace: Path, file: Optional[str]) -> None:
+    import yaml
+
+    path = Path(file) if file else _policy_path(workspace)
+    if not path.exists():
+        print(_c(f"no policy file at {path}", _YELLOW))
+        sys.exit(1)
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        print(_c(f"YAML error: {exc}", _RED))
+        sys.exit(1)
+    tt = ((data.get("settings") or {}).get("tool_tags") or {})
+    exprs: List[str] = []
+    for entry in tt.get("rules") or []:
+        if isinstance(entry, str):
+            exprs.append(entry)
+        elif isinstance(entry, dict) and isinstance(entry.get("expr"), str):
+            exprs.append(entry["expr"])
+        else:
+            print(_c(f"bad rule entry (not a string or {{expr}} map): {entry!r}",
+                     _RED))
+            sys.exit(1)
+    errors = lint_rules(exprs)
+    for _, err in errors:
+        _print_parse_error(err)
+    ok = len(exprs) - len(errors)
+    # Legacy list sanity too.
+    legacy = tt.get("incompatible") or []
+    bad_legacy = [s for s in legacy
+                  if not isinstance(s, (list, tuple)) or len(set(s)) < 2]
+    for s in bad_legacy:
+        print(_c(f"legacy incompatible entry needs >=2 tags: {s!r}", _RED))
+    if errors or bad_legacy:
+        print(_c(f"\n{len(errors) + len(bad_legacy)} error(s), {ok} rule(s) OK",
+                 _RED))
+        sys.exit(1)
+    print(_c(f"all good: {ok} rule expression(s), "
+             f"{len(legacy)} legacy set(s)", _GREEN))
+
+
+# ── subcommand: test (log replay) ────────────────────────────────────────────
+
+class _ReplayLedger(TagLedger):
+    """In-memory ledger for dry-runs: never reads or writes the real
+    per-session ledger files under /trifecta/."""
+
+    def _load(self) -> None:  # pragma: no cover - trivially empty
+        pass
+
+    def _save(self) -> None:
+        pass
+
+
+def tags_test(
+    workspace: Path,
+    session: Optional[str] = None,
+    last: int = 5,
+    extra_rules: Optional[List[str]] = None,
+    fail_on_hit: bool = False,
+) -> None:
+    tt = dict(_effective_tool_tags(workspace))
+    if extra_rules:
+        errors = lint_rules(extra_rules)
+        if errors:
+            for _, err in errors:
+                _print_parse_error(err)
+            sys.exit(1)
+        tt["rules"] = list(tt.get("rules") or []) + list(extra_rules)
+    rules = compile_tool_tag_rules(tt)
+
+    if session:
+        sessions = [(session, None)]
+    else:
+        sessions = _recent_sessions(workspace, last)
+        if not sessions:
+            print("no recorded sessions to replay")
+            return
+
+    total_hits = 0
+    for sid, _path in sessions:
+        events = _session_events(workspace, sid)
+        if not events:
+            continue
+        ledger = _ReplayLedger(workspace, sid)
+        hits: List[Dict[str, Any]] = []
+        for idx, ev in enumerate(events):
+            etype = str(ev.get("type") or "")
+            tool = _tool_name(ev)
+            tags = classify_tool_tags(ev, etype, set(), tt)
+            if not tags:
+                continue
+            done = ledger.completes_rules(tags, rules, idx)
+            if done is not None:
+                hits.append({"index": idx, "tool": tool, "done": done})
+                if done.get("action") == "block":
+                    # a blocked call would not have executed: don't record
+                    continue
+            ledger.record(tags, idx, tool)
+        label = _c(sid[:24], _BOLD)
+        if not hits:
+            print(f"{label}  {_c('clean', _GREEN)} ({len(events)} events)")
+            continue
+        total_hits += len(hits)
+        print(f"{label}  {len(hits)} hit(s) in {len(events)} events")
+        for h in hits:
+            d = h["done"]
+            verdict = ("WOULD BLOCK" if d.get("action") == "block"
+                       else "WOULD WARN")
+            v_c = _RED if d.get("action") == "block" else _YELLOW
+            steps = d.get("steps") or [d["set"]]
+            combo = " then ".join("+".join(s) for s in steps)
+            print(f"  [{h['index']:3d}] {_c(verdict, v_c)} {h['tool']}")
+            print(f"        rule: {combo}"
+                  + (f"  ({d['source']})" if d.get("source") else ""))
+            intro = d.get("introduced_by") or {}
+            for t, info in sorted(intro.items()):
+                print(_c(f"        prior: {t} by '{info.get('tool', '?')}' "
+                         f"at event {info.get('index')}", _DIM))
+    if total_hits:
+        print(_c(f"\n{total_hits} total hit(s) — dry run only, nothing was "
+                 "blocked", _BOLD))
+    if fail_on_hit and total_hits:
+        sys.exit(1)
+
+
+# ── subcommand: edit (interactive wizard) ────────────────────────────────────
+
+def tags_edit(workspace: Path) -> None:
+    """Line-based interactive wizard: tag tools, add/remove rules, flip mode.
+    Works in any terminal (no raw-tty requirement)."""
+    data = _load_policy_file(workspace)
+    tt_local = _tt_block(data)
+    dirty = False
+    while True:
+        tt = _effective_tool_tags(workspace)
+        # merge unsaved local edits over the effective view for display
+        merged = {**tt, **{k: v for k, v in tt_local.items() if v not in (None, {})}}
+        print()
+        print(_c("── prismor tags: interactive ──", _BOLD))
+        enabled = "on" if merged.get("enabled") else "off"
+        print(f"  tool_tags: {enabled}, mode={merged.get('mode', 'observe')}"
+              + (_c("  (unsaved changes)", _YELLOW) if dirty else ""))
+        print("""  [1] list tools + tags     [4] add rule expression
+  [2] tag a tool            [5] remove local rule
+  [3] list rules            [6] toggle enabled / mode
+  [s] save & exit           [q] quit without saving""")
+        try:
+            choice = input("> ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if choice == "1":
+            tags_list(workspace)
+        elif choice == "2":
+            tool = input("tool name (or glob, e.g. mcp__crm__*): ").strip()
+            raw = input("tags (space-separated): ").strip()
+            tags = [t for t in raw.split() if t]
+            if not tool or not tags:
+                print(_c("need a tool and at least one tag", _YELLOW))
+                continue
+            bad = [t for t in tags if not _valid_tag(t)]
+            if bad:
+                print(_c(f"invalid tag(s): {', '.join(bad)}", _RED))
+                continue
+            m = tt_local.setdefault("tags", {})
+            m[tool] = sorted(set(
+                (m.get(tool) if isinstance(m.get(tool), list) else [])) | set(tags))
+            dirty = True
+            print(f"{_c('staged', _GREEN)} {tool} -> {m[tool]}")
+        elif choice == "3":
+            rules_list(workspace)
+        elif choice == "4":
+            expr = input("rule (e.g. untrusted_content then critical_action"
+                         " -> block): ").strip()
+            try:
+                rule = compile_rule(expr)
+            except ParseError as err:
+                _print_parse_error(err)
+                continue
+            tt_local.setdefault("rules", []).append(expr)
+            dirty = True
+            print(f"{_c('staged', _GREEN)} [{rule.action}] {expr}")
+        elif choice == "5":
+            lst = tt_local.get("rules") or []
+            if not lst:
+                print(_c("no local rules", _YELLOW))
+                continue
+            for i, e in enumerate(lst):
+                print(f"  [{i}] {e}")
+            which = input("remove #: ").strip()
+            if which.isdigit() and 0 <= int(which) < len(lst):
+                removed = lst.pop(int(which))
+                dirty = True
+                print(f"{_c('staged removal', _GREEN)} {removed}")
+        elif choice == "6":
+            cur_e = bool(tt_local.get("enabled",
+                                      _effective_tool_tags(workspace).get("enabled")))
+            ans = input(f"enabled? [y/n] (now {'y' if cur_e else 'n'}): ").strip().lower()
+            if ans in ("y", "n"):
+                tt_local["enabled"] = ans == "y"
+                dirty = True
+            mode = input("mode [observe/enforce] (empty = keep): ").strip().lower()
+            if mode in ("observe", "enforce"):
+                tt_local["mode"] = mode
+                dirty = True
+        elif choice == "s":
+            _save_policy_file(workspace, data)
+            print(_c(f"saved {_policy_path(workspace)}", _GREEN))
+            _org_managed_hint(workspace)
+            return
+        elif choice == "q":
+            if dirty:
+                ans = input("discard unsaved changes? [y/N]: ").strip().lower()
+                if ans != "y":
+                    continue
+            return

--- a/prismor/runtime/trifecta.py
+++ b/prismor/runtime/trifecta.py
@@ -122,8 +122,10 @@ def classify_tool_tags(
 ) -> Set[str]:
     """Return the set of tags for a tool call.
 
-    Resolution: explicit org map → built-in defaults → event/finding inference.
-    Each tier unions all matching entries; the first non-empty tier wins.
+    Resolution: explicit org map → server-declared ``_meta`` tags → built-in
+    defaults → event/finding inference. Each tier unions all matching entries;
+    the first non-empty tier wins (the org admin always beats a server's
+    self-declaration, which beats generic globs).
     """
     tt = tt_settings or {}
     tool_name = _tool_name(event)
@@ -139,6 +141,15 @@ def classify_tool_tags(
                 tags |= set(_as_list(val))
     if tags:
         return tags
+
+    # 1.5. Server-declared tags (MCP `_meta.prismor.tags`), stamped onto the
+    # event by the gateway at tools/list time. Already sanitized there.
+    if tt.get("meta_tags_enabled", True):
+        meta_tags = (event.get("metadata") or {}).get("meta_tags")
+        if isinstance(meta_tags, (list, tuple)):
+            tags |= {str(t) for t in meta_tags if t}
+        if tags:
+            return tags
 
     # 2. Built-in defaults.
     if tt.get("defaults_enabled", True):
@@ -163,11 +174,21 @@ def classify_tool_tags(
     return tags
 
 
+def _rule_pref(match: Dict[str, Any]) -> tuple:
+    """Ordering key for competing rule matches: block beats warn, then the
+    larger tag set wins (clearest finding message)."""
+    return (1 if match.get("action") == "block" else 0, len(match.get("set") or ()))
+
+
 class TagLedger:
     """Per-session record of which tags a session has used and the tool that
     first introduced each. Persisted across hook invocations (each hook call is a
     separate process) as JSON under the central data dir, like ``_TaintStore``.
     """
+
+    # Cap per-tag occurrence history so a chatty session can't grow the ledger
+    # file unboundedly. 256 indexes per tag is far beyond any real rule depth.
+    _HIST_CAP = 256
 
     def __init__(self, workspace: Path, session_id: str) -> None:
         safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in session_id)
@@ -176,6 +197,9 @@ class TagLedger:
         self._path = get_data_dir(workspace) / "trifecta" / f"{safe}.json"
         # tag -> {"index": int, "tool": str}  (first call that introduced the tag)
         self.seen: Dict[str, Dict[str, Any]] = {}
+        # tag -> sorted [indexes] of every recorded occurrence (capped). Needed
+        # for ordered ("then") rules; ``seen`` alone only knows first occurrence.
+        self.hist: Dict[str, List[int]] = {}
         self._load()
 
     def _load(self) -> None:
@@ -186,14 +210,29 @@ class TagLedger:
             s = data.get("seen")
             if isinstance(s, dict):
                 self.seen = s
+            h = data.get("hist")
+            if isinstance(h, dict):
+                self.hist = {
+                    t: sorted(int(i) for i in v)
+                    for t, v in h.items()
+                    if isinstance(v, (list, tuple))
+                }
         except Exception:
             pass
+        # Pre-hist ledger files: synthesize history from first-seen so ordered
+        # rules degrade to first-seen semantics instead of crashing/missing.
+        for tag, info in self.seen.items():
+            if tag not in self.hist and isinstance(info, dict):
+                idx = info.get("index")
+                if isinstance(idx, int):
+                    self.hist[tag] = [idx]
 
     def _save(self) -> None:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             self._path.write_text(
-                json.dumps({"seen": self.seen}, indent=2), encoding="utf-8"
+                json.dumps({"seen": self.seen, "hist": self.hist}, indent=2),
+                encoding="utf-8",
             )
         except Exception:
             pass
@@ -234,11 +273,105 @@ class TagLedger:
                     best = cand
         return best
 
+    def completes_rules(
+        self,
+        new_tags: Set[str],
+        rules: List[Any],
+        current_index: int = 1 << 62,
+    ) -> Optional[Dict[str, Any]]:
+        """Generalized :meth:`completes` over compiled tag rules (see
+        ``tag_rules.CompiledRule``: ``.steps`` is an ordered list of unordered
+        tag sets, plus ``.action``/``.rule_id``/``.source``).
+
+        A single-step rule reduces exactly to :meth:`completes` — including the
+        "already-complete sets keep the session restricted" property. For
+        ordered (multi-step) rules a greedy subsequence cursor walks ``hist``:
+        each non-final step must be fully covered by occurrences strictly after
+        the previous step's position; the final step must be covered by prior
+        occurrences after the cursor plus this call's ``new_tags``, and this
+        call must contribute at least one final-step tag (it is the call that
+        gets blocked). Occurrences at index >= ``current_index`` never count as
+        prior (same re-record contract as :meth:`completes`)."""
+        best: Optional[Dict[str, Any]] = None
+        for rule in rules:
+            steps = getattr(rule, "steps", None)
+            if not steps:
+                continue
+            final = steps[-1]
+            if not (final & new_tags):
+                continue
+            # Walk the non-final steps as an ordered subsequence over hist.
+            cursor = -1
+            ok = True
+            for step in steps[:-1]:
+                step_pos = cursor
+                for tag in step:
+                    nxt = self._first_after(tag, cursor, current_index)
+                    if nxt is None:
+                        ok = False
+                        break
+                    step_pos = max(step_pos, nxt)
+                if not ok:
+                    break
+                cursor = step_pos
+            if not ok:
+                continue
+            # Final step: every tag covered by this call or a prior occurrence
+            # after the cursor.
+            for tag in final:
+                if tag in new_tags:
+                    continue
+                if self._first_after(tag, cursor, current_index) is None:
+                    ok = False
+                    break
+            if not ok:
+                continue
+            all_tags = set()
+            for s in steps:
+                all_tags |= s
+            introduced = {
+                t: self.seen[t]
+                for t in all_tags
+                if t in self.seen
+                and isinstance(self.seen[t], dict)
+                and self.seen[t].get("index", -1) < current_index
+            }
+            cand = {
+                "set": sorted(all_tags),
+                "steps": [sorted(s) for s in steps],
+                "this_call_tags": sorted(final & new_tags),
+                "introduced_by": introduced,
+                "rule_id": getattr(rule, "rule_id", ""),
+                "action": getattr(rule, "action", "block"),
+                "source": getattr(rule, "source", ""),
+            }
+            # Prefer block over warn; among equals, the largest set for the
+            # clearest message.
+            if best is None or _rule_pref(cand) > _rule_pref(best):
+                best = cand
+        return best
+
+    def _first_after(
+        self, tag: str, after: int, current_index: int
+    ) -> Optional[int]:
+        """Smallest recorded occurrence index of ``tag`` with
+        ``after < index < current_index``, else None."""
+        for idx in self.hist.get(tag, ()):  # sorted ascending
+            if idx > after and idx < current_index:
+                return idx
+        return None
+
     def record(self, new_tags: Set[str], index: int, tool: str) -> None:
         changed = False
         for tag in new_tags:
             if tag not in self.seen:
                 self.seen[tag] = {"index": index, "tool": tool}
+                changed = True
+            h = self.hist.setdefault(tag, [])
+            if index not in h and len(h) < self._HIST_CAP:
+                import bisect
+
+                bisect.insort(h, index)
                 changed = True
         if changed:
             self._save()

--- a/tests/fixtures/tag_rule_golden.json
+++ b/tests/fixtures/tag_rule_golden.json
@@ -1,0 +1,43 @@
+{
+  "_comment": "Golden vectors for the tag-rule DSL. Asserted by BOTH the Python parser tests (prismor/runtime/tag_rules.py) and the TS parser tests (prismor-web lib/tag-expr.ts) to prevent drift. steps = ordered list of sorted tag arrays.",
+  "valid": [
+    {"expr": "untrusted_content with critical_action -> block",
+     "steps": [["critical_action", "untrusted_content"]], "action": "block"},
+    {"expr": "untrusted_content then critical_action -> block",
+     "steps": [["untrusted_content"], ["critical_action"]], "action": "block"},
+    {"expr": "untrusted_content then private_data then external_comms -> block",
+     "steps": [["untrusted_content"], ["private_data"], ["external_comms"]], "action": "block"},
+    {"expr": "web_read with secrets_access -> warn",
+     "steps": [["secrets_access", "web_read"]], "action": "warn"},
+    {"expr": "untrusted_content with private_data then external_comms -> block",
+     "steps": [["private_data", "untrusted_content"], ["external_comms"]], "action": "block"},
+    {"expr": "customer_pii then external_comms",
+     "steps": [["customer_pii"], ["external_comms"]], "action": "block"},
+    {"expr": "  a_tag   then    b_tag  ->  warn ",
+     "steps": [["a_tag"], ["b_tag"]], "action": "warn"},
+    {"expr": "a then a",
+     "steps": [["a"], ["a"]], "action": "block"},
+    {"expr": "x.y-z_1 with b2 -> block",
+     "steps": [["b2", "x.y-z_1"]], "action": "block"}
+  ],
+  "invalid": [
+    "",
+    "   ",
+    "just_one_tag",
+    "a then",
+    "a with -> block",
+    "then a",
+    "a b",
+    "a then b -> explode",
+    "a -> block then b",
+    "a then b ->",
+    "A_Tag then b",
+    "_lead then b",
+    "a then not b",
+    "a or b",
+    "a within b",
+    "a count b",
+    "->",
+    "-> block"
+  ]
+}

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -411,3 +411,57 @@ def test_stable_session_id(tmp_path):
     g2 = Gateway(specs, workspace=tmp_path)
     g2.close()
     assert g2.session_id.startswith("mcp-") and g2.session_id != "hosted-alice"
+
+
+# ── _meta self-declared tags (trifecta auto-tagging) ─────────────────────────
+
+def test_extract_meta_tags_precedence_and_sanitization():
+    from prismor.runtime.mcp_gateway import _extract_meta_tags
+    # _meta.prismor.tags wins over _meta.tags and annotations
+    t = {"name": "x",
+         "_meta": {"prismor": {"tags": ["untrusted_content"]}, "tags": ["other"]},
+         "annotations": {"prismor/tags": ["nope"]}}
+    assert _extract_meta_tags(t) == ["untrusted_content"]
+    # fallbacks in order
+    assert _extract_meta_tags({"name": "x", "_meta": {"tags": "solo_tag"}}) == ["solo_tag"]
+    assert _extract_meta_tags(
+        {"name": "x", "annotations": {"prismor/tags": ["a_tag"]}}) == ["a_tag"]
+    # sanitization: lowercase, charset filter, dedupe, cap 8
+    dirty = {"name": "x", "_meta": {"prismor": {"tags": [
+        "UPPER", "ok_tag", "ok_tag", "bad tag!", "<script>", ""] + [f"t{i}" for i in range(10)]}}}
+    got = _extract_meta_tags(dirty)
+    assert "upper" in got and "ok_tag" in got
+    assert len(got) <= 8 and all(" " not in g and "<" not in g for g in got)
+    # absent -> empty
+    assert _extract_meta_tags({"name": "x"}) == []
+
+
+def test_meta_tags_flow_into_call_events(tmp_path, monkeypatch):
+    up = FakeUpstream(
+        UpstreamSpec(name="crm", command=["true"], transport="stdio"),
+        tools=[{"name": "read_customers", "description": "d",
+                "inputSchema": {"type": "object"},
+                "_meta": {"prismor": {"tags": ["private_data"]}}}])
+    gateway, sent = make_gateway(tmp_path, monkeypatch, [up])
+    list_tools(gateway, sent)
+    assert gateway._routes["crm__read_customers"].meta_tags == ["private_data"]
+    calls = []
+    allow_all(monkeypatch, calls)
+    gateway._handle_tools_call("C", {"name": "crm__read_customers", "arguments": {}})
+    ev = calls[0]["event"]
+    assert ev["metadata"]["meta_tags"] == ["private_data"]
+    assert ev["metadata"]["tool_name"] == "mcp__crm__read_customers"
+
+
+def test_meta_tags_classification_tier():
+    from prismor.runtime.trifecta import classify_tool_tags
+    ev = {"type": "tool_result", "metadata": {
+        "tool_name": "mcp__crm__read_customers", "meta_tags": ["private_data"]}}
+    # _meta beats built-in defaults and inference
+    assert classify_tool_tags(ev, "tool_result", set(), {}) == {"private_data"}
+    # explicit org map beats _meta
+    tt = {"tags": {"mcp__crm__read_customers": ["untrusted_content"]}}
+    assert classify_tool_tags(ev, "tool_result", set(), tt) == {"untrusted_content"}
+    # disabled -> falls through to inference (tool_result -> untrusted)
+    tt2 = {"meta_tags_enabled": False, "defaults_enabled": False}
+    assert classify_tool_tags(ev, "tool_result", set(), tt2) == {"untrusted_content"}

--- a/tests/test_tag_rules.py
+++ b/tests/test_tag_rules.py
@@ -1,0 +1,408 @@
+"""Tag-rule DSL — parser, IR, legacy compile parity, and ordered-ledger tests."""
+import json
+import uuid
+
+import pytest
+
+from prismor.runtime.tag_rules import (
+    CompiledRule, ParseError, compile_rule, compile_tool_tag_rules, lint_rules,
+)
+from prismor.runtime.trifecta import UNTRUSTED, CRITICAL, TagLedger
+
+
+# ── parser: valid expressions ─────────────────────────────────────────────────
+
+def test_with_rule_parses():
+    r = compile_rule("untrusted_content with critical_action -> block")
+    assert r.steps == [{UNTRUSTED, CRITICAL}]
+    assert r.action == "block" and not r.ordered
+
+
+def test_then_rule_parses():
+    r = compile_rule("untrusted_content then critical_action -> block")
+    assert r.steps == [{UNTRUSTED}, {CRITICAL}]
+    assert r.ordered
+
+
+def test_three_step_rule():
+    r = compile_rule("untrusted_content then private_data then external_comms -> block")
+    assert r.steps == [{"untrusted_content"}, {"private_data"}, {"external_comms"}]
+
+
+def test_warn_action():
+    assert compile_rule("web_read with secrets_access -> warn").action == "warn"
+
+
+def test_mixed_with_then():
+    r = compile_rule("untrusted_content with private_data then external_comms -> block")
+    assert r.steps == [{"untrusted_content", "private_data"}, {"external_comms"}]
+
+
+def test_implicit_block_action():
+    r = compile_rule("customer_pii then external_comms")
+    assert r.action == "block"
+
+
+def test_extra_whitespace_ok():
+    r = compile_rule("  a_tag   then    b_tag  ->  warn ")
+    assert r.steps == [{"a_tag"}, {"b_tag"}] and r.action == "warn"
+
+
+def test_rule_id_stable_and_order_insensitive_within_step():
+    a = compile_rule("x with y -> block")
+    b = compile_rule("y with x -> block")
+    assert a.rule_id == b.rule_id  # normalized form sorts within a step
+    c = compile_rule("x then y -> block")
+    assert c.rule_id != a.rule_id  # ordered is a different rule
+
+
+# ── parser: invalid expressions ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("expr", [
+    "",                                   # empty
+    "   ",                                # whitespace only
+    "just_one_tag",                       # single tag can't be a combination
+    "a then",                             # dangling connector
+    "a with -> block",                    # connector then arrow
+    "then a",                             # leading connector
+    "a b",                                # two terms w/o connector
+    "a then b -> explode",                # unknown action
+    "a -> block then b",                  # arrow not at end
+    "a then b ->",                        # arrow without action
+    "A_Tag then b",                       # uppercase not in charset
+    "_lead then b",                       # bad leading char
+])
+def test_invalid_rules_raise(expr):
+    with pytest.raises(ParseError):
+        compile_rule(expr)
+
+
+@pytest.mark.parametrize("kw", ["not", "or", "within", "count"])
+def test_reserved_keywords_rejected(kw):
+    with pytest.raises(ParseError) as ei:
+        compile_rule(f"a then {kw} b")
+    assert "reserved" in str(ei.value)
+
+
+def test_parse_error_caret_position():
+    with pytest.raises(ParseError) as ei:
+        compile_rule("a then b -> explode")
+    err = ei.value
+    assert err.pos == "a then b -> explode".index("explode")
+    caret = err.caret()
+    assert caret.splitlines()[1].index("^") == err.pos
+
+
+def test_single_tag_multi_step_allowed():
+    # "a then a" is two steps of one tag each — legal (needs 2 occurrences).
+    r = compile_rule("a then a")
+    assert r.steps == [{"a"}, {"a"}]
+
+
+def test_lint_rules_collects_errors():
+    errs = lint_rules(["a with b", "bad ->", "x then y -> warn", "not a"])
+    assert len(errs) == 2
+    assert errs[0][0] == "bad ->"
+
+
+# ── compile_tool_tag_rules: backward compat funnel ────────────────────────────
+
+def test_legacy_incompatible_compiles_to_single_step_block():
+    tt = {"incompatible": [["a", "b"], ["c", "d", "e"]]}
+    rules = compile_tool_tag_rules(tt)
+    assert [r.steps for r in rules] == [[{"a", "b"}], [{"c", "d", "e"}]]
+    assert all(r.action == "block" and r.source == "incompatible" for r in rules)
+
+
+def test_legacy_single_tag_sets_dropped_like_normalize():
+    tt = {"incompatible": [["a"]]}
+    rules = compile_tool_tag_rules(tt)
+    # drops <2-tag sets, then falls back to the default red/blue pair
+    assert [r.steps for r in rules] == [[{UNTRUSTED, CRITICAL}]]
+    assert rules[0].source == "default"
+
+
+def test_empty_settings_default_pair():
+    rules = compile_tool_tag_rules({})
+    assert [r.steps for r in rules] == [[{UNTRUSTED, CRITICAL}]]
+    rules = compile_tool_tag_rules(None)
+    assert [r.steps for r in rules] == [[{UNTRUSTED, CRITICAL}]]
+
+
+def test_rules_and_incompatible_merge():
+    tt = {
+        "rules": ["p then q -> warn"],
+        "incompatible": [["a", "b"]],
+    }
+    rules = compile_tool_tag_rules(tt)
+    assert len(rules) == 2
+    assert rules[0].steps == [{"p"}, {"q"}] and rules[0].action == "warn"
+    assert rules[1].steps == [{"a", "b"}] and rules[1].action == "block"
+
+
+def test_rule_map_entries_and_action_override():
+    tt = {"rules": [{"expr": "a with b", "action": "warn"}]}
+    rules = compile_tool_tag_rules(tt)
+    assert rules[0].action == "warn" and rules[0].steps == [{"a", "b"}]
+
+
+def test_invalid_rule_entries_skipped_not_fatal():
+    tt = {"rules": ["bad ->", 42, "a with b"], "incompatible": []}
+    rules = compile_tool_tag_rules(tt)
+    assert len(rules) == 1 and rules[0].steps == [{"a", "b"}]
+
+
+# ── ledger: completes_rules (ordered semantics) ───────────────────────────────
+
+def _led(tmp_path):
+    return TagLedger(tmp_path, "s-" + uuid.uuid4().hex)
+
+
+def test_single_step_rule_matches_legacy_completes(tmp_path):
+    led = _led(tmp_path)
+    rule = compile_rule("a with b")
+    assert led.completes_rules({"a"}, [rule], 0) is None
+    led.record({"a"}, 0, "tA")
+    done = led.completes_rules({"b"}, [rule], 1)
+    assert done and done["set"] == ["a", "b"] and done["this_call_tags"] == ["b"]
+    assert done["introduced_by"]["a"]["tool"] == "tA"
+    assert done["action"] == "block" and done["rule_id"] == rule.rule_id
+
+
+def test_ordered_fires_only_in_order(tmp_path):
+    rule = compile_rule("a then b")
+    # b first, then a: the "a" call must NOT fire (b hasn't followed a)
+    led = _led(tmp_path)
+    led.record({"b"}, 0, "tB")
+    assert led.completes_rules({"a"}, [rule], 1) is None
+    # a first, then b: the "b" call fires
+    led2 = _led(tmp_path)
+    led2.record({"a"}, 0, "tA")
+    done = led2.completes_rules({"b"}, [rule], 1)
+    assert done and done["steps"] == [["a"], ["b"]]
+
+
+def test_unordered_fires_either_order(tmp_path):
+    rule = compile_rule("a with b")
+    led = _led(tmp_path)
+    led.record({"b"}, 0, "tB")
+    assert led.completes_rules({"a"}, [rule], 1) is not None
+
+
+def test_multi_step_b_a_b_c_case(tmp_path):
+    # Session b(0), a(1), b(2): call c(3) completes "a then b then c" even
+    # though first-seen(b) < first-seen(a). This is why hist exists.
+    rule = compile_rule("a then b then c")
+    led = _led(tmp_path)
+    led.record({"b"}, 0, "t0")
+    led.record({"a"}, 1, "t1")
+    led.record({"b"}, 2, "t2")
+    done = led.completes_rules({"c"}, [rule], 3)
+    assert done and done["set"] == ["a", "b", "c"]
+
+
+def test_multi_step_missing_middle_occurrence(tmp_path):
+    # Session b(0), a(1): no b AFTER a, so "a then b then c" must not fire on c.
+    rule = compile_rule("a then b then c")
+    led = _led(tmp_path)
+    led.record({"b"}, 0, "t0")
+    led.record({"a"}, 1, "t1")
+    assert led.completes_rules({"c"}, [rule], 2) is None
+
+
+def test_mixed_with_then(tmp_path):
+    rule = compile_rule("a with b then c")
+    led = _led(tmp_path)
+    led.record({"a"}, 0, "t0")
+    assert led.completes_rules({"c"}, [rule], 1) is None  # b never occurred
+    led.record({"b"}, 1, "t1")
+    done = led.completes_rules({"c"}, [rule], 2)
+    assert done and done["this_call_tags"] == ["c"]
+
+
+def test_final_step_requires_this_call_contribution(tmp_path):
+    # All tags already seen, but this call carries no final-step tag -> no fire.
+    rule = compile_rule("a then b")
+    led = _led(tmp_path)
+    led.record({"a"}, 0, "t0")
+    led.record({"b"}, 1, "t1")
+    assert led.completes_rules({"x"}, [rule], 2) is None
+    # ...but a call re-carrying the final tag keeps the session restricted.
+    assert led.completes_rules({"b"}, [rule], 2) is not None
+
+
+def test_rerecord_current_index_not_prior(tmp_path):
+    # The pre-pass may have recorded this call's own tag at current_index; it
+    # must count as new, not prior (mirrors legacy completes contract).
+    rule = compile_rule("a then b")
+    led = _led(tmp_path)
+    led.record({"a"}, 0, "t0")
+    led.record({"b"}, 1, "t1")  # pre-pass re-record of the current call
+    done = led.completes_rules({"b"}, [rule], 1)
+    assert done is not None
+    # And b's prior occurrence alone (at idx>=current) can't satisfy "a then b"
+    led2 = _led(tmp_path)
+    led2.record({"b"}, 0, "t0")
+    assert led2.completes_rules({"b"}, [compile_rule("a then b")], 0) is None
+
+
+def test_same_tag_two_steps_needs_two_occurrences(tmp_path):
+    rule = compile_rule("a then a")
+    led = _led(tmp_path)
+    assert led.completes_rules({"a"}, [rule], 0) is None  # first occurrence only
+    led.record({"a"}, 0, "t0")
+    assert led.completes_rules({"a"}, [rule], 1) is not None
+
+
+def test_block_preferred_over_warn(tmp_path):
+    warn = compile_rule("a with b -> warn")
+    block = compile_rule("a with b -> block")
+    led = _led(tmp_path)
+    led.record({"a"}, 0, "t0")
+    done = led.completes_rules({"b"}, [warn, block], 1)
+    assert done["action"] == "block"
+
+
+def test_hist_persists_across_instances(tmp_path):
+    sid = "s-" + uuid.uuid4().hex
+    led = TagLedger(tmp_path, sid)
+    led.record({"b"}, 0, "t0")
+    led.record({"a"}, 1, "t1")
+    led.record({"b"}, 2, "t2")
+    led2 = TagLedger(tmp_path, sid)  # fresh load (separate process in real use)
+    assert led2.hist["b"] == [0, 2]
+    done = led2.completes_rules({"c"}, [compile_rule("a then b then c")], 3)
+    assert done is not None
+
+
+def test_pre_hist_ledger_file_degrades_gracefully(tmp_path):
+    # A ledger written by an older runtime has "seen" but no "hist".
+    import json
+    sid = "s-" + uuid.uuid4().hex
+    led = TagLedger(tmp_path, sid)
+    led.record({"a"}, 0, "t0")
+    # strip hist to simulate the old on-disk shape
+    data = json.loads(led._path.read_text())
+    del data["hist"]
+    led._path.write_text(json.dumps(data))
+    led2 = TagLedger(tmp_path, sid)
+    assert led2.hist == {"a": [0]}  # synthesized from seen
+    done = led2.completes_rules({"b"}, [compile_rule("a then b")], 1)
+    assert done is not None
+
+
+def test_legacy_completes_unchanged_shape(tmp_path):
+    # completes() (legacy API) still works and ignores hist entirely.
+    led = _led(tmp_path)
+    led.record({"a"}, 0, "t0")
+    done = led.completes({"b"}, [{"a", "b"}], 1)
+    assert done and set(done.keys()) == {"set", "this_call_tags", "introduced_by"}
+
+
+# ── end-to-end: DSL rules through evaluate_tool_call ─────────────────────────
+
+from prismor.runtime.runtime import evaluate_tool_call
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / "home"))
+
+
+def _ev(tool, etype):
+    return {"type": etype, "agent_event": "PreToolUse",
+            "metadata": {"tool_name": tool}}
+
+
+def _ws(tmp_path, mode, rules=None, incompatible=None, tags=None):
+    import yaml
+    ws = tmp_path / f"ws-{uuid.uuid4().hex[:6]}"
+    (ws / ".prismor").mkdir(parents=True)
+    tt = {"enabled": True, "mode": mode,
+          "tags": tags or {"mcp__Gmail__read_email": ["untrusted_content"],
+                           "mcp__Gmail__send_email": ["critical_action"]}}
+    if rules is not None:
+        tt["rules"] = rules
+    if incompatible is not None:
+        tt["incompatible"] = incompatible
+    policy = {"version": "1.0", "settings": {"tool_tags": tt}}
+    (ws / ".prismor" / "policy.yaml").write_text(yaml.safe_dump(policy))
+    return ws
+
+
+def _call(ws, sid, tool, etype="network"):
+    return evaluate_tool_call(event=_ev(tool, etype), workspace=ws, agent="claude",
+                              mode="enforce", session_id=sid, persist=True)
+
+
+def test_e2e_ordered_rule_blocks_in_order_only(tmp_path):
+    rules = ["untrusted_content then critical_action -> block"]
+    # critical FIRST is fine under an ordered rule (unordered would block it
+    # on a later untrusted call; ordered requires untrusted BEFORE critical)
+    ws = _ws(tmp_path, "enforce", rules=rules, incompatible=[])
+    sid = "s-" + uuid.uuid4().hex
+    assert _call(ws, sid, "mcp__Gmail__send_email", "network").allow is True
+    assert _call(ws, sid, "mcp__Gmail__read_email", "tool_result").allow is True
+    # now untrusted has occurred -> a NEW critical call completes the sequence
+    d = _call(ws, sid, "mcp__Gmail__send_email", "network")
+    assert d.allow is False and d.blocking["category"] == "lethal_trifecta"
+    assert d.blocking["ruleId"].startswith("tag-rule:")
+
+
+def test_e2e_warn_rule_never_blocks(tmp_path):
+    rules = ["untrusted_content then critical_action -> warn"]
+    ws = _ws(tmp_path, "enforce", rules=rules, incompatible=[])
+    sid = "s-" + uuid.uuid4().hex
+    assert _call(ws, sid, "mcp__Gmail__read_email", "tool_result").allow is True
+    d = _call(ws, sid, "mcp__Gmail__send_email", "network")
+    assert d.allow is True  # warn logs but never blocks, even in enforce
+    assert any(f.get("category") == "lethal_trifecta" for f in d.findings)
+
+
+def test_e2e_rules_and_legacy_incompatible_merge(tmp_path):
+    tags = {"mcp__web__fetch": ["untrusted_content"],
+            "mcp__crm__read": ["private_data"],
+            "mcp__x__post": ["external_comms"],
+            "mcp__Gmail__send_email": ["critical_action"],
+            "mcp__Gmail__read_email": ["untrusted_content"]}
+    ws = _ws(tmp_path, "enforce", tags=tags,
+             rules=["untrusted_content then private_data then external_comms -> block"],
+             incompatible=[["untrusted_content", "critical_action"]])
+    sid = "s-" + uuid.uuid4().hex
+    # legacy pair still enforced
+    assert _call(ws, sid, "mcp__Gmail__read_email", "tool_result").allow is True
+    d = _call(ws, sid, "mcp__Gmail__send_email", "network")
+    assert d.allow is False and d.blocking["ruleId"] == "tool-category-crossover"
+    # DSL 3-step enforced in a fresh session
+    sid2 = "s-" + uuid.uuid4().hex
+    assert _call(ws, sid2, "mcp__web__fetch", "tool_result").allow is True
+    assert _call(ws, sid2, "mcp__crm__read", "tool_result").allow is True
+    d2 = _call(ws, sid2, "mcp__x__post", "network")
+    assert d2.allow is False and d2.blocking["ruleId"].startswith("tag-rule:")
+
+
+def test_e2e_legacy_policy_unchanged_behavior(tmp_path):
+    # A policy with ONLY the legacy incompatible key behaves exactly as before.
+    ws = _ws(tmp_path, "enforce", incompatible=[["untrusted_content", "critical_action"]])
+    sid = "s-" + uuid.uuid4().hex
+    assert _call(ws, sid, "mcp__Gmail__read_email", "tool_result").allow is True
+    d = _call(ws, sid, "mcp__Gmail__send_email", "network")
+    assert d.allow is False
+    assert d.blocking["ruleId"] == "tool-category-crossover"
+    assert d.blocking["id"].startswith(sid)
+
+
+# ── golden vectors (shared with the TS parser in prismor-web) ────────────────
+
+def test_golden_vectors():
+    import pathlib
+    golden = json.loads(
+        (pathlib.Path(__file__).parent / "fixtures" / "tag_rule_golden.json")
+        .read_text())
+    for case in golden["valid"]:
+        r = compile_rule(case["expr"])
+        assert [sorted(s) for s in r.steps] == case["steps"], case["expr"]
+        assert r.action == case["action"], case["expr"]
+    for expr in golden["invalid"]:
+        with pytest.raises(ParseError):
+            compile_rule(expr)

--- a/tests/test_tags_cli.py
+++ b/tests/test_tags_cli.py
@@ -1,0 +1,182 @@
+"""`prismor tags` CLI — lint exit codes, replay dry-run, policy-file edits."""
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+
+from prismor.runtime import tags_cli
+from prismor.runtime.store import append_session_event, get_data_dir
+from prismor.runtime.trifecta import TagLedger
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / "home"))
+
+
+def _ws(tmp_path, tt):
+    ws = tmp_path / f"ws-{uuid.uuid4().hex[:6]}"
+    (ws / ".prismor").mkdir(parents=True)
+    (ws / ".prismor" / "policy.yaml").write_text(
+        yaml.safe_dump({"version": "1.0", "settings": {"tool_tags": tt}}))
+    return ws
+
+
+def _seed_session(ws, sid, tools):
+    for tool, etype in tools:
+        append_session_event(ws, sid, {
+            "type": etype, "agent_event": "PreToolUse",
+            "metadata": {"tool_name": tool}})
+
+
+TT = {
+    "enabled": True, "mode": "observe",
+    "tags": {"mcp__Gmail__read_email": ["untrusted_content"],
+             "mcp__Gmail__send_email": ["critical_action"]},
+    "rules": ["untrusted_content then critical_action -> block"],
+}
+
+
+def test_lint_ok_and_fail(tmp_path, capsys):
+    ws = _ws(tmp_path, TT)
+    tags_cli.tags_lint(ws, None)  # no exit -> ok
+    assert "all good" in capsys.readouterr().out
+    bad = _ws(tmp_path, {**TT, "rules": ["a then"]})
+    with pytest.raises(SystemExit) as ei:
+        tags_cli.tags_lint(bad, None)
+    assert ei.value.code == 1
+    out = capsys.readouterr().out
+    assert "dangling" in out and "^" in out  # caret diagnostic
+
+
+def test_lint_flags_bad_legacy_sets(tmp_path, capsys):
+    ws = _ws(tmp_path, {**TT, "rules": [], "incompatible": [["only_one"]]})
+    with pytest.raises(SystemExit):
+        tags_cli.tags_lint(ws, None)
+    assert ">=2 tags" in capsys.readouterr().out
+
+
+def test_test_replay_reports_hits_and_never_writes_ledger(tmp_path, capsys):
+    ws = _ws(tmp_path, TT)
+    sid = "replay-" + uuid.uuid4().hex[:8]
+    _seed_session(ws, sid, [
+        ("mcp__Gmail__read_email", "tool_result"),
+        ("mcp__Gmail__send_email", "network"),
+    ])
+    tags_cli.tags_test(ws, session=sid)
+    out = capsys.readouterr().out
+    assert "WOULD BLOCK" in out and "mcp__Gmail__send_email" in out
+    assert "dry run only" in out
+    # the replay must NOT create a real ledger file
+    trifecta_dir = get_data_dir(ws) / "trifecta"
+    assert not any(sid in p.name for p in trifecta_dir.glob("*")) \
+        if trifecta_dir.exists() else True
+
+
+def test_test_clean_session(tmp_path, capsys):
+    ws = _ws(tmp_path, TT)
+    sid = "clean-" + uuid.uuid4().hex[:8]
+    _seed_session(ws, sid, [("mcp__Gmail__read_email", "tool_result")])
+    tags_cli.tags_test(ws, session=sid)
+    assert "clean" in capsys.readouterr().out
+
+
+def test_test_fail_on_hit_exit_code(tmp_path):
+    ws = _ws(tmp_path, TT)
+    sid = "hit-" + uuid.uuid4().hex[:8]
+    _seed_session(ws, sid, [
+        ("mcp__Gmail__read_email", "tool_result"),
+        ("mcp__Gmail__send_email", "network"),
+    ])
+    with pytest.raises(SystemExit) as ei:
+        tags_cli.tags_test(ws, session=sid, fail_on_hit=True)
+    assert ei.value.code == 1
+
+
+def test_test_extra_rule_what_if(tmp_path, capsys):
+    # Base policy has NO rules and NO incompatible -> falls back to default
+    # pair, but tags map only tags read_email; what-if adds an ordered rule.
+    tt = {"enabled": True, "mode": "observe",
+          "tags": {"mcp__a__read": ["src_a"], "mcp__b__write": ["dst_b"]},
+          "rules": [], "incompatible": []}
+    ws = _ws(tmp_path, tt)
+    sid = "whatif-" + uuid.uuid4().hex[:8]
+    _seed_session(ws, sid, [("mcp__a__read", "tool_result"),
+                            ("mcp__b__write", "network")])
+    tags_cli.tags_test(ws, session=sid, extra_rules=["src_a then dst_b -> warn"])
+    out = capsys.readouterr().out
+    assert "WOULD WARN" in out
+
+
+def test_test_invalid_extra_rule_exits(tmp_path, capsys):
+    ws = _ws(tmp_path, TT)
+    with pytest.raises(SystemExit) as ei:
+        tags_cli.tags_test(ws, extra_rules=["bad ->"])
+    assert ei.value.code == 1
+
+
+def test_set_and_rm_roundtrip(tmp_path, capsys):
+    ws = _ws(tmp_path, dict(TT))
+    tags_cli.tags_set(ws, "mcp__crm__*", ["private_data", "pii"])
+    data = yaml.safe_load((ws / ".prismor" / "policy.yaml").read_text())
+    assert data["settings"]["tool_tags"]["tags"]["mcp__crm__*"] == \
+        ["pii", "private_data"]
+    tags_cli.tags_rm(ws, "mcp__crm__*", "pii")
+    data = yaml.safe_load((ws / ".prismor" / "policy.yaml").read_text())
+    assert data["settings"]["tool_tags"]["tags"]["mcp__crm__*"] == ["private_data"]
+    tags_cli.tags_rm(ws, "mcp__crm__*", None)
+    data = yaml.safe_load((ws / ".prismor" / "policy.yaml").read_text())
+    assert "mcp__crm__*" not in data["settings"]["tool_tags"]["tags"]
+
+
+def test_set_rejects_invalid_tag(tmp_path):
+    ws = _ws(tmp_path, dict(TT))
+    with pytest.raises(SystemExit):
+        tags_cli.tags_set(ws, "x", ["BAD TAG"])
+
+
+def test_rules_add_parse_check_and_rm(tmp_path, capsys):
+    ws = _ws(tmp_path, dict(TT))
+    with pytest.raises(SystemExit):
+        tags_cli.rules_add(ws, "a then not b")
+    tags_cli.rules_add(ws, "p with q -> warn")
+    data = yaml.safe_load((ws / ".prismor" / "policy.yaml").read_text())
+    assert "p with q -> warn" in data["settings"]["tool_tags"]["rules"]
+    tags_cli.rules_rm(ws, "p with q -> warn")
+    data = yaml.safe_load((ws / ".prismor" / "policy.yaml").read_text())
+    assert "p with q -> warn" not in data["settings"]["tool_tags"]["rules"]
+
+
+def test_rules_rm_missing_exits(tmp_path):
+    ws = _ws(tmp_path, dict(TT))
+    with pytest.raises(SystemExit):
+        tags_cli.rules_rm(ws, "no such rule")
+
+
+def test_list_reports_tiers(tmp_path, capsys):
+    ws = _ws(tmp_path, TT)
+    sid = "list-" + uuid.uuid4().hex[:8]
+    _seed_session(ws, sid, [
+        ("mcp__Gmail__read_email", "tool_result"),  # explicit
+        ("WebFetch", "network"),                    # default
+        ("Bash", "shell"),                          # inference
+    ])
+    tags_cli.tags_list(ws)
+    out = capsys.readouterr().out
+    assert "explicit" in out and "default" in out and "inference" in out
+    assert "untrusted_content" in out
+
+
+def test_replay_ledger_isolated_from_real(tmp_path):
+    # A real enforcement ledger must be invisible to the replay (and vice versa).
+    ws = _ws(tmp_path, TT)
+    sid = "iso-" + uuid.uuid4().hex[:8]
+    real = TagLedger(ws, sid)
+    real.record({"critical_action"}, 0, "someTool")
+    replay = tags_cli._ReplayLedger(ws, sid)
+    assert replay.seen == {} and replay.hist == {}
+    replay.record({"untrusted_content"}, 5, "x")
+    real2 = TagLedger(ws, sid)  # reload the real one
+    assert "untrusted_content" not in real2.seen


### PR DESCRIPTION
## What

Policy-as-code over tool tags — a tiny rule expression language for the tool-combination governance layer, a full `prismor tags` CLI family, and automatic tagging from MCP server metadata.

```yaml
settings:
  tool_tags:
    enabled: true
    mode: enforce
    rules:
      - "untrusted_content then critical_action -> block"   # ordered
      - "untrusted_content then private_data then external_comms -> block"
      - "web_read with secrets_access -> warn"              # log-only
    incompatible:                                           # legacy — still works
      - [untrusted_content, critical_action]
```

**Grammar** (3 keywords, whitespace-tokenized): `TAG (then|with TAG)* [-> block|warn]`
- `with` — unordered co-occurrence (exactly today's `incompatible` semantics)
- `then` — ordered: step N must occur before step N+1; the call completing the **final step** is blocked
- `-> warn` — logs the finding but never blocks, even under a device enforce override
- `not` / `or` / `within` / `count` reserved for future growth (parse error today)

**Backward compatible by construction**: both `rules:` and legacy `incompatible:` compile to one internal representation; a policy with only `incompatible` behaves byte-for-byte as before, and older runtimes ignore the unknown `rules:` key.

## Key pieces

- **`tag_rules.py`** — stdlib parser with caret diagnostics, `CompiledRule` IR, single backward-compat compile funnel
- **Ledger ordered matching** — `TagLedger` gains a capped per-tag occurrence history; first-seen-only indexing provably under-detects 3+-step sequences (session `b,a,b,c` contains `a→b→c`). Old ledger files load unchanged and degrade to first-seen semantics
- **MCP `_meta` auto-tagging** — the gateway reads `_meta.prismor.tags` (fallbacks `_meta.tags`, `annotations["prismor/tags"]`) off tool definitions, sanitized; classification precedence: **explicit org map > `_meta` > built-in defaults > inference**
- **`prismor tags` CLI** — `list` (tools + resolved tags + resolving tier), `set/rm`, `rules add/rm` (parse-checked), `edit` (interactive wizard), `lint`, and **`test`**: replays recorded session logs through a candidate ruleset and prints WOULD BLOCK / WOULD WARN per call — dry-run only, via an in-memory ledger that never touches enforcement state (`--rule` what-ifs, `--fail-on-hit` for CI)
- **`policy validate`** now lints rule expressions and legacy sets
- **Docs**: new `docs/tool-tags.md` + CLI-reference and gateway sections

## Safety properties preserved

- DSL findings keep category `lethal_trifecta` → still on the non-overridable enforcement floor
- Blocked calls still never enter the ledger (no one-denied-call bypass)
- A completed forbidden set still keeps the session restricted
- `_meta` tags are sanitized (charset, cap 8) and always lose to the org's explicit map — a server can suggest, never override

## Testing

- `tests/test_tag_rules.py` — parser (valid/invalid/reserved/caret), IR, legacy-compile parity, ordered-ledger semantics incl. the `b,a,b,c` multi-step case, e2e enforce/warn through `evaluate_tool_call`, golden vectors
- `tests/test_tags_cli.py` — lint exit codes, log-replay hits, replay-ledger isolation, policy-file round-trips
- Gateway `_meta` extraction/sanitization/precedence tests
- Golden vectors (`tests/fixtures/tag_rule_golden.json`) shared with the control-plane TS parser port to prevent drift
- `examples/lethal-trifecta/demo.sh` scenarios 6–7: ordered rule allows critical-first and fires only on untrusted→critical; warn never blocks in enforce
- **Full suite failure set is identical to the origin/main baseline** (23 pre-existing env-dependent failures, verified by diffing sorted failure lists) — zero regressions

https://claude.ai/code/session_01FeixdCjd2z9wr7YZxvh1ki