### PR TITLE
Tag-rule DSL: add 'or' alternation (with > or > then)

### DIFF
--- a/docs/tool-tags.md
+++ b/docs/tool-tags.md
@@ -55,19 +55,31 @@ Disable the tier with `meta_tags_enabled: false`.
 
 ## The rule language
 
-One rule per line. Three keywords. That's the whole grammar:
+One rule per line. Three connectors with fixed precedence
+(`with` binds tightest, then `or`, then `then`):
 
 ```
-rule    :=  TAG ( then|with TAG )*  [ -> block|warn ]
+rule    :=  disj ( then disj )*  [ -> block|warn ]
+disj    :=  conj ( or conj )*
+conj    :=  TAG ( with TAG )*
 ```
 
 - **`with`** — unordered co-occurrence: both tags appearing anywhere in the
   session is enough.
+- **`or`** — alternatives at the same position: any one satisfies that step
+  (e.g. `send_email or post_message` = either critical action).
 - **`then`** — ordered sequence: the left step must occur *before* the right.
 - **`-> block`** (default) or **`-> warn`** — warn logs the finding but never
   blocks, even in enforce mode.
 - The call completing the **final step** is the one blocked/warned.
-- `not`, `or`, `within`, `count` are reserved for future use.
+- `not`, `within`, `count` are reserved for future use.
+
+An `or` rule expands to its **variants** (one alternative per step) and fires
+when any variant completes — so `untrusted_content then send_email or
+post_message` is exactly `untrusted_content then send_email` **and**
+`untrusted_content then post_message` folded into one rule. Every alternative
+must still be a real combination (two tags, or two ordered steps): a bare
+`a or b` is rejected, since it would fire on a single tag.
 
 ```yaml
 settings:
@@ -90,6 +102,8 @@ More examples:
 untrusted_content with critical_action -> block    # either order
 untrusted_content then critical_action -> block    # read first, act later
 untrusted_content with private_data then external_comms -> block
+untrusted_content then send_email or post_message -> block   # either critical action
+secrets_access with external_comms or customer_pii with external_comms -> warn
 customer_pii then external_comms                   # implicit -> block
 ```
 

--- a/prismor/runtime/tag_rules.py
+++ b/prismor/runtime/tag_rules.py
@@ -1,29 +1,37 @@
 """Tag-rule expression language — policy-as-code over tool tags.
 
 A tiny, dependency-free rule DSL for ``settings.tool_tags.rules``. One rule per
-line-string; three keywords; whitespace-tokenized:
+line-string; whitespace-tokenized; three connectors with fixed precedence
+(``with`` binds tightest, then ``or``, then ``then``):
 
-    rule      := seq [ "->" action ]
-    seq       := term ( ("then" | "with") term )*
-    term      := TAG                      # [a-z0-9][a-z0-9_.-]*
+    rule      := disj ( "then" disj )* [ "->" action ]
+    disj      := conj ( "or" conj )*
+    conj      := TAG ( "with" TAG )*      # TAG = [a-z0-9][a-z0-9_.-]*
     action    := "block" | "warn"         # omitted -> "block"
 
 Semantics:
-  * ``with`` groups adjacent terms into one unordered step (all tags must
-    co-occur in the session — exactly the legacy ``incompatible`` semantics).
-  * ``then`` separates ordered steps: every tag of step N must have occurred
-    before the occurrences satisfying step N+1.
+  * ``with`` groups adjacent tags into one unordered conjunction — all must
+    co-occur in the session (exactly the legacy ``incompatible`` semantics).
+  * ``or`` offers alternative conjunctions at the same position — any one of
+    them satisfies that step.
+  * ``then`` separates ordered steps: some alternative of step N must be
+    satisfied by occurrences before those satisfying step N+1.
   * The call that satisfies the *final* step is the one blocked/warned.
+
+An ``or`` rule is compiled to its **variants** — the cross-product of one
+alternative per step — each an ordinary ``or``-free step sequence. The rule
+fires when *any* variant is completed, so alternation reuses the exact
+ordered-subsequence matcher and adds no new matching semantics.
 
 Examples:
     untrusted_content with critical_action -> block
     untrusted_content then critical_action -> block
-    untrusted_content then private_data then external_comms -> block
-    web_read with secrets_access -> warn
+    untrusted_content then send_email or post_message -> block
+    secrets_access with external_comms or customer_pii with external_comms -> warn
     customer_pii then external_comms          (implicit -> block)
 
-``not``, ``or``, ``within`` and ``count`` are reserved for future grammar
-growth and raise a ParseError today.
+``not``, ``within`` and ``count`` are reserved for future grammar growth and
+raise a ParseError today.
 
 Legacy compatibility: :func:`compile_tool_tag_rules` is the single funnel that
 compiles both the new ``rules:`` strings and the legacy ``incompatible:`` lists
@@ -33,6 +41,7 @@ keep working byte-for-byte.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -40,8 +49,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from prismor.runtime.trifecta import DEFAULT_INCOMPATIBLE, _as_list
 
 ACTIONS = ("block", "warn")
-CONNECTORS = ("then", "with")
-RESERVED = ("not", "or", "within", "count")
+CONNECTORS = ("then", "with", "or")
+RESERVED = ("not", "within", "count")
 _TAG_RE = re.compile(r"^[a-z0-9][a-z0-9_.\-]*$")
 
 
@@ -59,29 +68,53 @@ class ParseError(ValueError):
         return f"{self.expr}\n{' ' * self.pos}^ {self.args[0]}"
 
 
+def _variants_signature(variants: List[List[Set[str]]]) -> str:
+    """Order-insensitive (within a step's alternatives, and across variants)
+    signature of a rule's variants — the stable basis for ``rule_id``."""
+    per_variant = [
+        ";".join(",".join(sorted(s)) for s in variant) for variant in variants
+    ]
+    return "&".join(sorted(per_variant))
+
+
 @dataclass
 class CompiledRule:
-    """Internal representation shared by DSL rules and legacy incompatible sets."""
+    """Internal representation shared by DSL rules and legacy incompatible sets.
 
-    steps: List[Set[str]]  # ordered steps; each step is an unordered tag set
+    ``steps`` is the primary (first) variant — a flat ordered list of unordered
+    tag sets, unchanged from before, so display/legacy consumers keep working.
+    ``variants`` holds every ``or``-free step sequence the rule expands to (just
+    ``[steps]`` for a rule without ``or``); the matcher fires on any of them."""
+
+    steps: List[Set[str]]  # primary variant: ordered steps, each an unordered tag set
     action: str = "block"  # "block" | "warn"
     source: str = ""  # original expression, or "incompatible" for legacy rows
     rule_id: str = field(default="")
+    variants: List[List[Set[str]]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        if not self.variants:
+            self.variants = [self.steps]
+        if not self.steps and self.variants:
+            self.steps = self.variants[0]
         if not self.rule_id:
-            norm = ";".join(",".join(sorted(s)) for s in self.steps) + "|" + self.action
+            norm = _variants_signature(self.variants) + "|" + self.action
             self.rule_id = hashlib.sha256(norm.encode("utf-8")).hexdigest()[:10]
 
     @property
     def ordered(self) -> bool:
-        return len(self.steps) > 1
+        return any(len(v) > 1 for v in self.variants)
+
+    @property
+    def has_alternatives(self) -> bool:
+        return len(self.variants) > 1
 
     @property
     def all_tags(self) -> Set[str]:
         out: Set[str] = set()
-        for s in self.steps:
-            out |= s
+        for variant in self.variants:
+            for s in variant:
+                out |= s
         return out
 
 
@@ -120,17 +153,17 @@ def compile_rule(expr: str) -> CompiledRule:
         if not toks:
             raise ParseError("rule has no tags before '->'", expr, 0)
 
-    # seq := term ( connector term )*
-    steps: List[Set[str]] = []
-    current: Set[str] = set()
+    # Parse into steps, each a list of alternative conjunctions (tag sets):
+    #   step_alts : List[step]        step : List[alt]        alt : Set[tag]
+    step_alts: List[List[Set[str]]] = []
+    cur_alts: List[Set[str]] = []  # alternatives collected in the current step
+    cur_set: Set[str] = set()  # tags of the current conjunction
     expect_term = True
     for tok, pos in toks:
         if expect_term:
             low = tok.lower()
             if low in RESERVED:
-                raise ParseError(
-                    f"'{tok}' is reserved for future use", expr, pos
-                )
+                raise ParseError(f"'{tok}' is reserved for future use", expr, pos)
             if low in CONNECTORS or tok == "->":
                 raise ParseError(f"expected a tag, got '{tok}'", expr, pos)
             if not _TAG_RE.match(tok):
@@ -138,31 +171,58 @@ def compile_rule(expr: str) -> CompiledRule:
                     f"invalid tag '{tok}' (allowed: [a-z0-9][a-z0-9_.-]*)",
                     expr, pos,
                 )
-            current.add(tok)
+            cur_set.add(tok)
             expect_term = False
         else:
-            if tok == "then":
-                steps.append(current)
-                current = set()
+            low = tok.lower()
+            if low == "with":
+                expect_term = True  # another tag in the same conjunction
+            elif low == "or":
+                cur_alts.append(cur_set)  # close this conjunction, start another
+                cur_set = set()
                 expect_term = True
-            elif tok == "with":
+            elif low == "then":
+                cur_alts.append(cur_set)  # close the step and start the next
+                step_alts.append(cur_alts)
+                cur_alts = []
+                cur_set = set()
                 expect_term = True
             else:
                 raise ParseError(
-                    f"expected 'then', 'with' or '->', got '{tok}'", expr, pos
+                    f"expected 'then', 'with', 'or' or '->', got '{tok}'", expr, pos
                 )
     if expect_term:
-        # Trailing connector like "a then".
+        # Trailing connector like "a then" / "a or".
         tok, pos = toks[-1]
         raise ParseError(f"dangling '{tok}' at end of rule", expr, pos)
-    steps.append(current)
+    cur_alts.append(cur_set)
+    step_alts.append(cur_alts)
 
-    if len(steps) == 1 and len(steps[0]) < 2:
-        raise ParseError(
-            "a rule needs at least two tags (a single tag can never be a "
-            "combination)", expr, 0,
-        )
-    return CompiledRule(steps=steps, action=action, source=expr.strip())
+    # Expand to variants: one alternative chosen per step. Dedup identical
+    # variants (repeated alternatives) so rule_id stays stable.
+    seen_sig: Set[str] = set()
+    variants: List[List[Set[str]]] = []
+    for combo in itertools.product(*step_alts):
+        variant = [set(s) for s in combo]
+        sig = ";".join(",".join(sorted(s)) for s in variant)
+        if sig in seen_sig:
+            continue
+        seen_sig.add(sig)
+        variants.append(variant)
+
+    # Every variant must be a real combination — a single tag (one step, one
+    # tag) can never be a "combination", so reject rules any alternative of
+    # which would fire on one tag alone.
+    for variant in variants:
+        if len(variant) == 1 and len(variant[0]) < 2:
+            raise ParseError(
+                "a rule needs at least two tags (a single tag can never be a "
+                "combination)", expr, 0,
+            )
+
+    return CompiledRule(
+        steps=variants[0], action=action, source=expr.strip(), variants=variants
+    )
 
 
 def lint_rules(exprs: List[str]) -> List[Tuple[str, ParseError]]:
@@ -188,7 +248,10 @@ def _coerce_rule_entry(entry: Any) -> Optional[CompiledRule]:
         act = entry.get("action")
         if act in ACTIONS and act != rule.action:
             # Explicit map action overrides the expression's (or the default).
-            rule = CompiledRule(steps=rule.steps, action=act, source=rule.source)
+            rule = CompiledRule(
+                steps=rule.steps, action=act, source=rule.source,
+                variants=rule.variants,
+            )
         return rule
     raise ParseError("rule must be a string or an {expr, action} map", str(entry), 0)
 

--- a/prismor/runtime/tags_cli.py
+++ b/prismor/runtime/tags_cli.py
@@ -280,8 +280,8 @@ def rules_add(workspace: Path, expr: str) -> None:
         return
     lst.append(expr.strip())
     _save_policy_file(workspace, data)
-    steps = " -> ".join("+".join(sorted(s)) for s in rule.steps)
-    print(f"{_c('added', _GREEN)} [{rule.action}] {steps}")
+    # Echo the source so `or` alternatives show; steps is only the first variant.
+    print(f"{_c('added', _GREEN)} [{rule.action}] {rule.source}")
     _org_managed_hint(workspace)
 
 

--- a/prismor/runtime/trifecta.py
+++ b/prismor/runtime/trifecta.py
@@ -291,65 +291,75 @@ class TagLedger:
         occurrences after the cursor plus this call's ``new_tags``, and this
         call must contribute at least one final-step tag (it is the call that
         gets blocked). Occurrences at index >= ``current_index`` never count as
-        prior (same re-record contract as :meth:`completes`)."""
+        prior (same re-record contract as :meth:`completes`).
+
+        A rule with ``or`` alternatives carries ``.variants`` — each an
+        ``or``-free step sequence. The rule fires when *any* variant completes,
+        so alternation reuses this exact matcher per variant with no new
+        semantics; the winning variant's steps are what the finding reports."""
         best: Optional[Dict[str, Any]] = None
         for rule in rules:
-            steps = getattr(rule, "steps", None)
-            if not steps:
-                continue
-            final = steps[-1]
-            if not (final & new_tags):
-                continue
-            # Walk the non-final steps as an ordered subsequence over hist.
-            cursor = -1
-            ok = True
-            for step in steps[:-1]:
-                step_pos = cursor
-                for tag in step:
-                    nxt = self._first_after(tag, cursor, current_index)
-                    if nxt is None:
-                        ok = False
-                        break
-                    step_pos = max(step_pos, nxt)
-                if not ok:
-                    break
-                cursor = step_pos
-            if not ok:
-                continue
-            # Final step: every tag covered by this call or a prior occurrence
-            # after the cursor.
-            for tag in final:
-                if tag in new_tags:
+            variants = getattr(rule, "variants", None)
+            if not variants:
+                steps = getattr(rule, "steps", None)
+                variants = [steps] if steps else []
+            for steps in variants:
+                if not steps:
                     continue
-                if self._first_after(tag, cursor, current_index) is None:
-                    ok = False
-                    break
-            if not ok:
-                continue
-            all_tags = set()
-            for s in steps:
-                all_tags |= s
-            introduced = {
-                t: self.seen[t]
-                for t in all_tags
-                if t in self.seen
-                and isinstance(self.seen[t], dict)
-                and self.seen[t].get("index", -1) < current_index
-            }
-            cand = {
-                "set": sorted(all_tags),
-                "steps": [sorted(s) for s in steps],
-                "this_call_tags": sorted(final & new_tags),
-                "introduced_by": introduced,
-                "rule_id": getattr(rule, "rule_id", ""),
-                "action": getattr(rule, "action", "block"),
-                "source": getattr(rule, "source", ""),
-            }
-            # Prefer block over warn; among equals, the largest set for the
-            # clearest message.
-            if best is None or _rule_pref(cand) > _rule_pref(best):
-                best = cand
+                cand = self._variant_completes(steps, new_tags, current_index)
+                if cand is None:
+                    continue
+                cand["rule_id"] = getattr(rule, "rule_id", "")
+                cand["action"] = getattr(rule, "action", "block")
+                cand["source"] = getattr(rule, "source", "")
+                # Prefer block over warn; among equals, the largest set for the
+                # clearest message.
+                if best is None or _rule_pref(cand) > _rule_pref(best):
+                    best = cand
         return best
+
+    def _variant_completes(
+        self, steps: List[Set[str]], new_tags: Set[str], current_index: int
+    ) -> Optional[Dict[str, Any]]:
+        """Match one ``or``-free step sequence against the ledger. Returns a
+        partial candidate dict (without ``rule_id``/``action``/``source``) when
+        the current call completes it, else ``None``."""
+        final = steps[-1]
+        if not (final & new_tags):
+            return None
+        # Walk the non-final steps as an ordered subsequence over hist.
+        cursor = -1
+        for step in steps[:-1]:
+            step_pos = cursor
+            for tag in step:
+                nxt = self._first_after(tag, cursor, current_index)
+                if nxt is None:
+                    return None
+                step_pos = max(step_pos, nxt)
+            cursor = step_pos
+        # Final step: every tag covered by this call or a prior occurrence
+        # after the cursor.
+        for tag in final:
+            if tag in new_tags:
+                continue
+            if self._first_after(tag, cursor, current_index) is None:
+                return None
+        all_tags: Set[str] = set()
+        for s in steps:
+            all_tags |= s
+        introduced = {
+            t: self.seen[t]
+            for t in all_tags
+            if t in self.seen
+            and isinstance(self.seen[t], dict)
+            and self.seen[t].get("index", -1) < current_index
+        }
+        return {
+            "set": sorted(all_tags),
+            "steps": [sorted(s) for s in steps],
+            "this_call_tags": sorted(final & new_tags),
+            "introduced_by": introduced,
+        }
 
     def _first_after(
         self, tag: str, after: int, current_index: int

--- a/tests/fixtures/tag_rule_golden.json
+++ b/tests/fixtures/tag_rule_golden.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Golden vectors for the tag-rule DSL. Asserted by BOTH the Python parser tests (prismor/runtime/tag_rules.py) and the TS parser tests (prismor-web lib/tag-expr.ts) to prevent drift. steps = ordered list of sorted tag arrays.",
+  "_comment": "Golden vectors for the tag-rule DSL. Asserted by BOTH the Python parser tests (prismor/runtime/tag_rules.py) and the TS parser tests (prismor-web lib/tag-expr.ts) to prevent drift. steps = the primary variant (ordered list of sorted tag arrays). variants (when present) = every or-free step sequence the rule expands to; each variant is a list of sorted-tag-array steps. Precedence: with > or > then.",
   "valid": [
     {"expr": "untrusted_content with critical_action -> block",
      "steps": [["critical_action", "untrusted_content"]], "action": "block"},
@@ -18,7 +18,19 @@
     {"expr": "a then a",
      "steps": [["a"], ["a"]], "action": "block"},
     {"expr": "x.y-z_1 with b2 -> block",
-     "steps": [["b2", "x.y-z_1"]], "action": "block"}
+     "steps": [["b2", "x.y-z_1"]], "action": "block"},
+    {"expr": "untrusted_content then send_email or post_message -> block",
+     "steps": [["untrusted_content"], ["send_email"]], "action": "block",
+     "variants": [[["untrusted_content"], ["send_email"]], [["untrusted_content"], ["post_message"]]]},
+    {"expr": "a with b or c with d -> warn",
+     "steps": [["a", "b"]], "action": "warn",
+     "variants": [[["a", "b"]], [["c", "d"]]]},
+    {"expr": "a or b then c",
+     "steps": [["a"], ["c"]], "action": "block",
+     "variants": [[["a"], ["c"]], [["b"], ["c"]]]},
+    {"expr": "untrusted_content with private_data or secrets_access then external_comms -> block",
+     "steps": [["private_data", "untrusted_content"], ["external_comms"]], "action": "block",
+     "variants": [[["private_data", "untrusted_content"], ["external_comms"]], [["secrets_access"], ["external_comms"]]]}
   ],
   "invalid": [
     "",
@@ -35,6 +47,8 @@
     "_lead then b",
     "a then not b",
     "a or b",
+    "a or",
+    "or b",
     "a within b",
     "a count b",
     "->",

--- a/tests/test_tag_rules.py
+++ b/tests/test_tag_rules.py
@@ -77,7 +77,7 @@ def test_invalid_rules_raise(expr):
         compile_rule(expr)
 
 
-@pytest.mark.parametrize("kw", ["not", "or", "within", "count"])
+@pytest.mark.parametrize("kw", ["not", "within", "count"])
 def test_reserved_keywords_rejected(kw):
     with pytest.raises(ParseError) as ei:
         compile_rule(f"a then {kw} b")
@@ -392,6 +392,96 @@ def test_e2e_legacy_policy_unchanged_behavior(tmp_path):
     assert d.blocking["id"].startswith(sid)
 
 
+# ── or / alternation ─────────────────────────────────────────────────────────
+
+def test_or_expands_to_variants():
+    r = compile_rule("untrusted_content then send_email or post_message -> block")
+    variants = [[sorted(s) for s in v] for v in r.variants]
+    assert variants == [
+        [["untrusted_content"], ["send_email"]],
+        [["untrusted_content"], ["post_message"]],
+    ]
+    assert r.has_alternatives and r.ordered
+    # primary steps is variants[0], so display/legacy consumers keep working
+    assert [sorted(s) for s in r.steps] == [["untrusted_content"], ["send_email"]]
+
+
+def test_or_precedence_with_binds_tighter_than_or():
+    # "a with b or c with d" == "(a with b) or (c with d)"
+    r = compile_rule("a with b or c with d -> warn")
+    variants = [[sorted(s) for s in v] for v in r.variants]
+    assert variants == [[["a", "b"]], [["c", "d"]]]
+
+
+def test_or_precedence_then_binds_loosest():
+    # "a or b then c" == "(a or b) then c"
+    r = compile_rule("a or b then c")
+    variants = [[sorted(s) for s in v] for v in r.variants]
+    assert variants == [[["a"], ["c"]], [["b"], ["c"]]]
+
+
+def test_or_single_tag_alternatives_rejected():
+    # every variant would fire on one tag alone — not a combination
+    with pytest.raises(ParseError):
+        compile_rule("a or b")
+
+
+def test_or_dangling_rejected():
+    with pytest.raises(ParseError):
+        compile_rule("a or")
+    with pytest.raises(ParseError):
+        compile_rule("or b")
+
+
+def test_or_duplicate_alternatives_deduped():
+    r = compile_rule("a with b or a with b -> block")
+    variants = [[sorted(s) for s in v] for v in r.variants]
+    assert variants == [[["a", "b"]]]
+
+
+def test_or_rule_id_order_insensitive_across_alternatives():
+    a = compile_rule("secrets_access with x or customer_pii with x -> block")
+    b = compile_rule("customer_pii with x or secrets_access with x -> block")
+    assert a.rule_id == b.rule_id
+
+
+def test_or_ledger_fires_on_either_alternative(tmp_path):
+    rule = compile_rule("untrusted_content then send_email or post_message -> block")
+    # variant via post_message
+    led = _led(tmp_path)
+    led.record({UNTRUSTED}, 0, "read_email")
+    done = led.completes_rules({"post_message"}, [rule], 1)
+    assert done is not None
+    assert done["steps"] == [["untrusted_content"], ["post_message"]]
+    assert done["rule_id"] == rule.rule_id
+    # variant via send_email
+    led2 = _led(tmp_path)
+    led2.record({UNTRUSTED}, 0, "read_email")
+    done2 = led2.completes_rules({"send_email"}, [rule], 1)
+    assert done2 is not None
+    assert done2["steps"] == [["untrusted_content"], ["send_email"]]
+
+
+def test_or_ledger_does_not_fire_without_a_matching_alternative(tmp_path):
+    rule = compile_rule("untrusted_content then send_email or post_message -> block")
+    led = _led(tmp_path)
+    led.record({UNTRUSTED}, 0, "read_email")
+    # a critical tag that is neither alternative
+    assert led.completes_rules({"delete_repo"}, [rule], 1) is None
+
+
+def test_or_ledger_respects_order_per_variant(tmp_path):
+    # (a or b) then c: c first, then a — must NOT fire (a must precede c)
+    rule = compile_rule("a or b then c")
+    led = _led(tmp_path)
+    led.record({"c"}, 0, "t0")
+    led.record({"a"}, 1, "t1")
+    assert led.completes_rules({"c"}, [rule], 2) is not None  # c(0) a(1) c(2): a then c ✓
+    led2 = _led(tmp_path)
+    led2.record({"c"}, 0, "t0")
+    assert led2.completes_rules({"a"}, [rule], 1) is None  # only c before, a completes nothing
+
+
 # ── golden vectors (shared with the TS parser in prismor-web) ────────────────
 
 def test_golden_vectors():
@@ -403,6 +493,9 @@ def test_golden_vectors():
         r = compile_rule(case["expr"])
         assert [sorted(s) for s in r.steps] == case["steps"], case["expr"]
         assert r.action == case["action"], case["expr"]
+        if "variants" in case:
+            got = [[sorted(s) for s in v] for v in r.variants]
+            assert got == case["variants"], case["expr"]
     for expr in golden["invalid"]:
         with pytest.raises(ParseError):
             compile_rule(expr)


### PR DESCRIPTION
## What

Adds an `or` connector to the tag-rule DSL so one rule can offer **alternative** conjunctions at any step:

```
untrusted_content then send_email or post_message -> block
secrets_access with external_comms or customer_pii with external_comms -> warn
(a or b) then c        # precedence: with > or > then
```

## How it stays simple and safe

An `or` rule compiles to its **variants** — the cross-product of one alternative per step, each an ordinary `or`-free step sequence. The matcher fires when **any** variant completes, so alternation reuses the exact ordered-subsequence ledger algorithm and introduces **no new matching semantics**.

- `CompiledRule` gains a `variants` field; `.steps` remains the primary variant, so every existing display/legacy consumer (policy_engine title render, tags CLI, finding dicts) is untouched, and for an `or`-free rule `variants == [steps]` — **byte-identical `rule_id` and behavior** to before.
- Every alternative must still be a real combination — a bare `a or b` (would fire on one tag) is rejected.
- `or` removed from the reserved set; `not`, `within`, `count` stay reserved.

## Tests

- Runtime: 254 tests green (parser precedence/dedup/order-insensitive rule_id, ledger either-alternative firing + per-variant ordering, plus the full engine/floor suites unchanged). OSS-safety guard clean.
- Golden vectors gain `or` cases with a `variants` field — **shared with the prismor-web TS parser** (ported in a companion PR) to prevent drift.

The web side (TS parser parity, the visual `or` builder, and an in-app LLM rule generator) lands in a companion prismor-web PR.

https://claude.ai/code/session_01FeixdCjd2z9wr7YZxvh1ki