### PR TITLE
Enrolled device is org-controlled: signed policy wins over local --mode; enroll offers install

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -136,6 +136,40 @@ def _block_header(finding: Dict[str, Any]) -> str:
     return line + "\n"
 
 
+def _offer_post_enroll_install(workspace: Path) -> None:
+    """After a successful enroll, offer to install the agent hooks so linking a
+    machine and guarding it are one continuous flow. Enforcement is governed by
+    the signed policy from here on (see the enrolled-device mode authority in
+    runtime.evaluate_tool_call), so we install with the safe local default
+    (observe) and the org controls observe/enforce from the console — no further
+    local change. Non-interactive contexts (scripts/CI) just get the next-step
+    hint, never a prompt."""
+    try:
+        from prismor.runtime.setup_wizard import _detect_agents, run_non_interactive
+    except Exception:
+        return
+    det = _detect_agents(workspace)
+    agents = [n for n, ok in det.items() if ok]
+    if not agents:
+        print("\nNext, install the guard into your agent:  prismor setup")
+        return
+    label = ", ".join(agents)
+    if not sys.stdin.isatty():
+        print(f"\nNext, install the guard into {label}:  prismor setup")
+        return
+    try:
+        resp = input(f"\nInstall Prismor into {label} now? [Y/n] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\nSkipped. Install later with:  prismor setup")
+        return
+    if resp in ("", "y", "yes"):
+        run_non_interactive(workspace, mode="observe", agents=agents)
+        print("The org policy now governs observe/enforce for this device — "
+              "change it in the console, no local edits needed.")
+    else:
+        print("Skipped. Install later with:  prismor setup")
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -234,6 +268,14 @@ def main(argv: Optional[List[str]] = None) -> None:
         print(f"Enrolled this machine ({ident.get('label')}) into org: {org}")
         print(f"  device id: {ident.get('device_id')}")
         print("  Telemetry is redacted by default. An admin can enable full capture per org.")
+        # One continuous flow: link the machine → guard it. Offer to install the
+        # agent hooks now. Enforcement is governed by the signed policy from here
+        # on, so the admin controls observe/enforce from the console with no
+        # further local change.
+        try:
+            _offer_post_enroll_install(workspace)
+        except Exception:
+            pass
         return
 
     if args.command == "enroll-status":

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -441,11 +441,24 @@ def evaluate_tool_call(
     if blocking is None and mode == "enforce" and getattr(engine, "is_legacy_policy", False):
         blocking = legacy_should_block(findings, event, engine.block_categories)
 
-    # Per-agent observe override: if the effective mode was downgraded to observe
-    # (by the agent registry), suppress blocking even when policy findings say enforce.
-    # Kill-switch (agent-control category) is exempt — it always blocks.
-    if blocking is not None and mode == "observe":
-        if blocking.get("category") != "agent-control":
+    # Local dry-run kill switch: a locally-passed observe mode suppresses blocks.
+    # BUT once this machine is ENROLLED the org's signed policy is authoritative —
+    # a local `--mode observe` (the install default) must not veto a block the
+    # admin set to enforce (device_mode / enforce rules / tool_tags). So honor the
+    # observe downgrade only when either (a) the org itself chose observe for this
+    # agent (agent_controls, carried in `_control.mode`), or (b) this machine is
+    # not enrolled (local-only dry run). The agent-control kill switch always
+    # blocks regardless. This is what lets an admin flip a device to enforce from
+    # the console and have it take effect with no local change.
+    if blocking is not None and mode == "observe" and blocking.get("category") != "agent-control":
+        _org_chose_observe = bool(_control is not None and getattr(_control, "mode", None) == "observe")
+        _enrolled = False
+        try:
+            from prismor.runtime.enterprise import identity as _identity
+            _enrolled = _identity.is_enrolled()
+        except Exception:
+            _enrolled = False
+        if _org_chose_observe or not _enrolled:
             blocking = None
 
     # Tamper-evident signed audit trail: one chained + signed record per

--- a/tests/test_tag_rules.py
+++ b/tests/test_tag_rules.py
@@ -349,6 +349,47 @@ def test_e2e_ordered_rule_blocks_in_order_only(tmp_path):
     assert d.blocking["ruleId"].startswith("tag-rule:")
 
 
+def _seq_completes(ws, sid, mode):
+    """Read (untrusted) then send (critical) — the second call completes the
+    ordered rule. Returns the completing call's Decision, run at local `mode`."""
+    evaluate_tool_call(event=_ev("mcp__Gmail__read_email", "tool_result"), workspace=ws,
+                       agent="claude", mode=mode, session_id=sid, persist=True)
+    return evaluate_tool_call(event=_ev("mcp__Gmail__send_email", "network"), workspace=ws,
+                              agent="claude", mode=mode, session_id=sid, persist=True)
+
+
+def test_e2e_enrolled_org_enforce_overrides_local_observe(tmp_path, monkeypatch):
+    # The org set tool_tags to enforce. The device runs the hook with the
+    # install default `--mode observe`. Once ENROLLED, the org's signed policy
+    # is authoritative: the local observe must NOT veto the block.
+    from prismor.runtime.enterprise import identity as _identity
+    monkeypatch.setattr(_identity, "is_enrolled", lambda: True)
+    ws = _ws(tmp_path, "enforce", rules=["untrusted_content then critical_action -> block"], incompatible=[])
+    d = _seq_completes(ws, "s-" + uuid.uuid4().hex, mode="observe")
+    assert d.allow is False and d.blocking["category"] == "lethal_trifecta"
+
+
+def test_e2e_not_enrolled_local_observe_is_dry_run(tmp_path, monkeypatch):
+    # Not enrolled: `--mode observe` is a genuine local dry-run — the finding is
+    # logged but nothing blocks.
+    from prismor.runtime.enterprise import identity as _identity
+    monkeypatch.setattr(_identity, "is_enrolled", lambda: False)
+    ws = _ws(tmp_path, "enforce", rules=["untrusted_content then critical_action -> block"], incompatible=[])
+    d = _seq_completes(ws, "s-" + uuid.uuid4().hex, mode="observe")
+    assert d.allow is True
+    assert any(f.get("category") == "lethal_trifecta" for f in d.findings)
+
+
+def test_e2e_enrolled_org_observe_still_does_not_block(tmp_path, monkeypatch):
+    # Enrolled but the org chose observe for tool_tags — nothing blocks (the
+    # finding mode is observe, so should_block never returns a block anyway).
+    from prismor.runtime.enterprise import identity as _identity
+    monkeypatch.setattr(_identity, "is_enrolled", lambda: True)
+    ws = _ws(tmp_path, "observe", rules=["untrusted_content then critical_action -> block"], incompatible=[])
+    d = _seq_completes(ws, "s-" + uuid.uuid4().hex, mode="observe")
+    assert d.allow is True
+
+
 def test_e2e_warn_rule_never_blocks(tmp_path):
     rules = ["untrusted_content then critical_action -> warn"]
     ws = _ws(tmp_path, "enforce", rules=rules, incompatible=[])


### PR DESCRIPTION
## Why

An enrolled device should be governed **entirely from the console** — the admin flips observe/enforce, the device obeys, no endpoint edits. Today it isn't: the install writes `--mode observe` into the local hook, and that local flag **vetoes every block**, even ones the admin set to enforce. So flipping a device to Enforce in the console does nothing.

## What

**1. Enrolled-device mode authority** (`runtime.evaluate_tool_call`)
`should_block()` correctly returns a block for an enforce finding (e.g. `tool_tags.mode: enforce`), but the code then suppressed it whenever the local `mode == "observe"`. The docstring even says "the control plane can still force enforce" — the code didn't honor it. Now the local observe downgrade applies only when:
- (a) the org itself chose observe for this agent (`agent_controls`, carried in `_control.mode`), **or**
- (b) the machine is **not enrolled** (a genuine local dry-run).

So an admin flipping a device to enforce in the console takes effect on the next call with **zero local change**; the only escape is un-enroll (admin-gated re-enrollment). The agent-control kill switch still always blocks.

**2. `enroll` → install handoff** (`cli._offer_post_enroll_install`)
After a successful `prismor enroll`, if an agent is detected and we're on a TTY, offer to install the hooks right there — linking a machine and guarding it become one continuous flow. Non-interactive contexts just print the next-step hint. Installs with the safe `observe` default; the org governs enforce thereafter (thanks to change #1).

## Tests

Three e2e cases through `evaluate_tool_call`:
- enrolled + local `--mode observe` + org `tool_tags: enforce` → **blocks** (org wins)
- not enrolled + `--mode observe` → **dry-run** (finding logged, not blocked)
- enrolled + org chose `observe` → **no block**

212 pass. The 3 `TestDeviceModeOverride` failures are **pre-existing on origin/main** (the CI/test host is itself enrolled, so `device_mode` leaks into the `_engine()` helper) — unrelated to this change. OSS-safety guard clean.

https://claude.ai/code/session_01FeixdCjd2z9wr7YZxvh1ki