### PR TITLE
fix(runtime): stop concurrent subagents dropping session security state

### DIFF
--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -163,28 +163,47 @@ class _TaintStore:
         except Exception:
             pass
 
-    def _save(self) -> None:
+    def _update(self, **fields: Any) -> None:
+        """Merge ``fields`` into the session's taint file under an exclusive lock.
+
+        Taint is monotonic — it is only ever set, never cleared — so merging
+        with OR/union semantics is safe under concurrency and never resurrects
+        state a writer intended to drop. Concurrent subagents write this file
+        from separate processes; an unlocked read-modify-write silently drops
+        an injection flag, which is a fail-open.
+        """
+        from prismor.runtime.store import locked_json_update
+
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(
-                json.dumps({
-                    "injection_detected": self.injection_detected,
-                    "injection_event_index": self.injection_event_index,
-                    "seen_domains": sorted(self.seen_domains),
-                }, indent=2),
-                encoding="utf-8",
-            )
+            with locked_json_update(self._path) as state:
+                if fields.get("injection_detected"):
+                    state["injection_detected"] = True
+                    index = fields.get("injection_event_index")
+                    prior = state.get("injection_event_index")
+                    if isinstance(index, int) and (
+                        not isinstance(prior, int) or index < prior
+                    ):
+                        state["injection_event_index"] = index
+                domain = fields.get("domain")
+                if domain:
+                    domains = state.get("seen_domains")
+                    if not isinstance(domains, list):
+                        domains = []
+                    if domain not in domains:
+                        domains.append(domain)
+                    state["seen_domains"] = sorted(domains)
         except Exception:
+            # Never break the tool call being screened over a taint write.
             pass
 
     def mark_injection(self, event_index: int) -> None:
         self.injection_detected = True
         self.injection_event_index = event_index
-        self._save()
+        self._update(injection_detected=True, injection_event_index=event_index)
 
     def add_domain(self, domain: str) -> None:
         self.seen_domains.add(domain.lower())
-        self._save()
+        self._update(domain=domain.lower())
 
     def is_new_domain(self, domain: str) -> bool:
         return domain.lower() not in self.seen_domains

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -42,6 +42,57 @@ def _locked(handle) -> Iterator[None]:
             pass
 
 
+@contextmanager
+def locked_json_update(path: Path) -> Iterator[Dict[str, Any]]:
+    """Read-modify-write a small JSON state file atomically, under a lock.
+
+    Yields the decoded dict; whatever the caller leaves in it is written back on
+    a clean exit. The read happens *inside* the lock, so a caller's in-memory
+    copy can never clobber a concurrent writer's committed change — the classic
+    lost update. Subagents make this the common case, not the rare one: every
+    hook invocation is a separate process, and Claude runs subagents
+    concurrently, so several processes race on one session's state file.
+
+    Two properties matter for security state:
+
+    * **No lost updates.** A dropped tag record silently un-taints a session —
+      ``TagLedger.completes`` then sees a clean slate and the forbidden
+      combination is never blocked. That is a fail-*open*.
+    * **No torn reads.** The write goes to a sibling temp file and lands via
+      ``os.replace`` (atomic on POSIX and Windows), so a reader either sees the
+      whole previous version or the whole new one — never a half-written file
+      that ``json.loads`` rejects. Callers treat a corrupt file as empty state,
+      which is also a fail-open, so tearing must be impossible rather than rare.
+
+    The lock is held on a sibling ``.lock`` file rather than on ``path`` itself:
+    ``os.replace`` swaps the inode, so a lock taken on the data file would be
+    dropped by the very write it is meant to serialize.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with open(lock_path, "a+") as lock_handle:
+        with _locked(lock_handle):
+            state: Dict[str, Any] = {}
+            if path.exists():
+                try:
+                    loaded = json.loads(path.read_text(encoding="utf-8"))
+                    if isinstance(loaded, dict):
+                        state = loaded
+                except (json.JSONDecodeError, OSError):
+                    state = {}
+            yield state
+            tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+            try:
+                tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+                os.replace(tmp, path)
+            except OSError:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+                raise
+
+
 def prismor_home() -> Path:
     """Return Prismor's state directory, honoring $PRISMOR_HOME (default ~/.prismor).
 

--- a/prismor/runtime/tags_cli.py
+++ b/prismor/runtime/tags_cli.py
@@ -362,8 +362,10 @@ class _ReplayLedger(TagLedger):
     def _load(self) -> None:  # pragma: no cover - trivially empty
         pass
 
-    def _save(self) -> None:
-        pass
+    def _commit(self, new_tags, index: int, tool: str) -> None:
+        # Persistence seam: apply to the in-memory view only, so a replay can
+        # never write into (or be polluted by) real enforcement state.
+        self._apply(new_tags, index, tool)
 
 
 def tags_test(

--- a/prismor/runtime/trifecta.py
+++ b/prismor/runtime/trifecta.py
@@ -361,17 +361,74 @@ class TagLedger:
                 return idx
         return None
 
-    def record(self, new_tags: Set[str], index: int, tool: str) -> None:
-        changed = False
-        for tag in new_tags:
-            if tag not in self.seen:
-                self.seen[tag] = {"index": index, "tool": tool}
-                changed = True
-            h = self.hist.setdefault(tag, [])
-            if index not in h and len(h) < self._HIST_CAP:
-                import bisect
+    def _apply(self, new_tags: Set[str], index: int, tool: str) -> None:
+        """Mutate the in-memory view only. The persistence seam for subclasses
+        that must not touch the real ledger files (see ``tags_cli._ReplayLedger``)."""
+        import bisect
 
-                bisect.insort(h, index)
-                changed = True
-        if changed:
-            self._save()
+        for tag in new_tags:
+            prior = self.seen.get(tag)
+            if not isinstance(prior, dict) or index < prior.get("index", 1 << 62):
+                self.seen[tag] = {"index": index, "tool": tool}
+            indexes = self.hist.setdefault(tag, [])
+            if index not in indexes and len(indexes) < self._HIST_CAP:
+                bisect.insort(indexes, index)
+
+    def record(self, new_tags: Set[str], index: int, tool: str) -> None:
+        """Record ``new_tags`` for this session, in memory and on disk."""
+        if not new_tags:
+            return
+        self._commit(new_tags, index, tool)
+
+    def _commit(self, new_tags: Set[str], index: int, tool: str) -> None:
+        """Persist ``new_tags`` to the session's ledger file.
+
+        The read-modify-write happens inside an exclusive lock and lands
+        atomically, so concurrent subagents cannot drop each other's records.
+        Merging into the file's *current* contents rather than writing this
+        process's in-memory view is the part that matters: the in-memory copy
+        was loaded before the race and may already be stale.
+        """
+        from prismor.runtime.store import locked_json_update
+
+        try:
+            with locked_json_update(self._path) as state:
+                seen = state.get("seen")
+                if not isinstance(seen, dict):
+                    seen = {}
+                hist = state.get("hist")
+                if not isinstance(hist, dict):
+                    hist = {}
+                for tag in new_tags:
+                    prior = seen.get(tag)
+                    if not isinstance(prior, dict) or index < prior.get("index", 1 << 62):
+                        seen[tag] = {"index": index, "tool": tool}
+                    indexes = hist.get(tag)
+                    if not isinstance(indexes, list):
+                        indexes = []
+                    if index not in indexes and len(indexes) < self._HIST_CAP:
+                        import bisect
+
+                        bisect.insort(indexes, index)
+                    hist[tag] = indexes
+                state["seen"] = seen
+                state["hist"] = hist
+                # Keep the in-memory view consistent with what was committed, so
+                # a caller that records then re-checks sees the merged truth.
+                s = state.get("seen")
+                if isinstance(s, dict):
+                    for tag, info in s.items():
+                        if not isinstance(info, dict):
+                            continue
+                        prior = self.seen.get(tag)
+                        if prior is None or info.get("index", 1 << 62) < prior.get("index", 1 << 62):
+                            self.seen[tag] = info
+                h = state.get("hist")
+                if isinstance(h, dict):
+                    for tag, indexes in h.items():
+                        if isinstance(indexes, (list, tuple)):
+                            merged = set(self.hist.get(tag, ())) | {int(i) for i in indexes}
+                            self.hist[tag] = sorted(merged)[: self._HIST_CAP]
+        except Exception:
+            # Never break the tool call being screened over a ledger write.
+            pass

--- a/tests/test_ledger_concurrency.py
+++ b/tests/test_ledger_concurrency.py
@@ -1,0 +1,136 @@
+"""Concurrent writers must not drop session security state.
+
+Every hook invocation is a separate process, and an agent that spawns
+subagents runs several of them at once, so multiple processes race on one
+session's tag ledger and taint file. The failure mode is a fail-*open*: a
+dropped tag record silently un-taints the session, ``TagLedger.completes``
+then sees a clean slate, and the forbidden tool combination is never blocked.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from multiprocessing import Process
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from prismor.runtime.policy_engine import _TaintStore  # noqa: E402
+from prismor.runtime.trifecta import (  # noqa: E402
+    CRITICAL,
+    UNTRUSTED,
+    TagLedger,
+    normalize_incompatible,
+)
+
+SESSION = "sess"
+INCOMPATIBLE = normalize_incompatible(None)  # the default red/blue pair
+
+
+def _record_worker(home: str, tag: str, index: int, tool: str, barrier: str) -> None:
+    """Runs in a child process, mimicking one hook invocation."""
+    os.environ["PRISMOR_HOME"] = home
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from prismor.runtime.trifecta import TagLedger as Ledger
+
+    while not Path(barrier).exists():  # collide the writes as hard as possible
+        pass
+    Ledger(Path(home), SESSION).record({tag}, index, tool)
+
+
+class _HomeIsolated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+        self._prior = os.environ.get("PRISMOR_HOME")
+        os.environ["PRISMOR_HOME"] = str(self.home)
+
+    def tearDown(self) -> None:
+        if self._prior is None:
+            os.environ.pop("PRISMOR_HOME", None)
+        else:
+            os.environ["PRISMOR_HOME"] = self._prior
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def run_concurrently(self, specs) -> None:
+        barrier = self.home / "GO"
+        procs = [
+            Process(target=_record_worker, args=(str(self.home), tag, idx, tool, str(barrier)))
+            for tag, idx, tool in specs
+        ]
+        for p in procs:
+            p.start()
+        barrier.write_text("go")
+        for p in procs:
+            p.join()
+
+
+class ConcurrentLedgerWrites(_HomeIsolated):
+    def test_no_lost_updates_under_concurrent_writers(self):
+        n = 12
+        self.run_concurrently([(f"tag{i}", i, f"tool{i}") for i in range(n)])
+        ledger = TagLedger(self.home, SESSION)
+        missing = {f"tag{i}" for i in range(n)} - set(ledger.seen)
+        self.assertEqual(missing, set(), f"lost {len(missing)} concurrent records")
+
+    def test_ledger_file_never_tears(self):
+        self.run_concurrently([(f"tag{i}", i, f"tool{i}") for i in range(12)])
+        path = self.home / "trifecta" / f"{SESSION}.json"
+        # A torn file is swallowed by the loader's except-and-continue, which
+        # resets the session to clean state — so it must be impossible, not rare.
+        json.loads(path.read_text(encoding="utf-8"))
+
+    def test_concurrent_writers_do_not_open_the_trifecta_gate(self):
+        """One subagent fetches untrusted content while others write
+        concurrently; a later critical action must still be blocked."""
+        specs = [(UNTRUSTED, 0, "WebFetch")]
+        specs += [(f"noise{i}", i + 1, f"tool{i}") for i in range(11)]
+        self.run_concurrently(specs)
+        done = TagLedger(self.home, SESSION).completes(
+            {CRITICAL}, INCOMPATIBLE, current_index=99
+        )
+        self.assertIsNotNone(done, "forbidden combination was not detected")
+
+    def test_record_still_updates_the_in_memory_view(self):
+        ledger = TagLedger(self.home, SESSION)
+        ledger.record({UNTRUSTED}, 0, "WebFetch")
+        self.assertIn(UNTRUSTED, ledger.seen)
+        self.assertEqual(ledger.hist[UNTRUSTED], [0])
+        # …and a re-read sees the same committed state.
+        self.assertIn(UNTRUSTED, TagLedger(self.home, SESSION).seen)
+
+    def test_earliest_introduction_wins(self):
+        """`seen` answers "who first tainted this session", so a later writer
+        must not overwrite an earlier index."""
+        TagLedger(self.home, SESSION).record({UNTRUSTED}, 5, "late")
+        TagLedger(self.home, SESSION).record({UNTRUSTED}, 1, "early")
+        ledger = TagLedger(self.home, SESSION)
+        self.assertEqual(ledger.seen[UNTRUSTED]["index"], 1)
+        self.assertEqual(ledger.seen[UNTRUSTED]["tool"], "early")
+
+
+class ConcurrentTaintWrites(_HomeIsolated):
+    def test_injection_flag_survives_and_is_monotonic(self):
+        store = _TaintStore(self.home, SESSION)
+        store.mark_injection(3)
+        self.assertTrue(_TaintStore(self.home, SESSION).injection_detected)
+
+    def test_domains_accumulate_rather_than_replace(self):
+        _TaintStore(self.home, SESSION).add_domain("a.example")
+        # A second store loaded before the first wrote would, unlocked, clobber
+        # the first domain with only its own.
+        _TaintStore(self.home, SESSION).add_domain("b.example")
+        seen = _TaintStore(self.home, SESSION).seen_domains
+        self.assertEqual(seen, {"a.example", "b.example"})
+
+    def test_taint_file_is_valid_json(self):
+        _TaintStore(self.home, SESSION).mark_injection(1)
+        path = self.home / "taint" / f"{SESSION}.json"
+        json.loads(path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`TagLedger` and `_TaintStore` persist per-session state with an **unlocked read-modify-write**: load the file, mutate an in-memory copy, write the whole thing back.

Every hook invocation is a separate process, and an agent that spawns subagents runs several at once — so those processes race.

It fails **open**:

- A lost tag record silently un-taints the session. `TagLedger.completes()` then sees a clean slate and the forbidden tool combination is never blocked.
- A torn write is worse: the loader catches the `JSONDecodeError` and continues with empty state, so a half-written file also reads as "nothing has happened yet".

## Measured

One subagent doing a `WebFetch` while eleven others wrote concurrently, then a critical action:

| | before | after |
|---|---|---|
| lethal-trifecta block failed to fire | **10 of 30 runs (33%)** | 0 of 30 |
| lost records, 12 concurrent writers (5 runs) | 11, 12, 9, 12, 12 of 12 | 12/12 every run |

## The fix

`store.locked_json_update()` — read-modify-write inside an exclusive lock, committed via `os.replace` so a reader sees the whole old or whole new file, never a torn one.

The lock lives on a sibling `.lock` file because `os.replace` swaps the inode; a lock taken on the data file would be dropped by the very write it is meant to serialize.

Both stores now merge into the file's **current** contents rather than writing a copy that was loaded before the race.

`TagLedger` gains an `_apply`/`_commit` seam so `tags_cli._ReplayLedger` can keep dry-runs in memory — it previously isolated itself by overriding `_save()`, which this change routes around. Without the seam, `tags test` would write into real enforcement state.

Taint is monotonic (only ever set, never cleared), so OR/union merge semantics are safe and never resurrect state a writer meant to drop.

## Tests

New `tests/test_ledger_concurrency.py` (8 tests). Reverting only the fix and keeping the tests, `test_concurrent_writers_do_not_open_the_trifecta_gate` and `test_earliest_introduction_wins` fail.

Note the multiprocess race tests are probabilistic by nature — they are regression guards, not proofs; the deterministic ordering/merge assertions are the reliable signal.

Full suite: **22 failed / 1120 passed** with this change, **22 failed / 1112 passed** on clean `main` — same 22 pre-existing failures, zero regressions, +8 tests. (The 4 adapter suites are excluded in both runs; they fail to import in a bare env.)

## Not in this PR

`main` has **no subagent attribution at all** — no `subagent_id` promotion, no `subagent_spawn` classification, no `Task|Agent` in the hook matcher, no subagent fields in telemetry. Meanwhile prismor-web `main` already has the `subagentId`/`subagentType` columns, the `@@index([orgId, subagentId, ts])`, and `EventInspector` rendering for them, so that half is currently dead code.

This PR is deliberately scoped to the concurrency fail-open, which stands on its own. Per-subagent *scoping* of taint and tags needs the attribution to exist first.