### PR TITLE
release: v1.34.0 — 5 coding agents + 8 framework adapters

### DIFF
--- a/.github/workflows/release-adapters.yml
+++ b/.github/workflows/release-adapters.yml
@@ -5,11 +5,16 @@ name: Release Adapters
 #
 # PyPI side (trusted publishing, no tokens): each package needs a (pending)
 # publisher on pypi.org pointing at this repo + this workflow file + the
-# `pypi` environment: prismor-langchain, prismor-crewai,
-# prismor-openai, prismor-browser-use.
+# `pypi` environment: prismor-langchain, prismor-crewai, prismor-openai,
+# prismor-browser-use, prismor-pydantic-ai, prismor-autogen-core,
+# prismor-agno, prismor-semantic-kernel, prismor-google-adk, prismor-beeai,
+# prismor-claude-agent-sdk. A package whose trusted publisher isn't set up
+# yet just fails that one matrix leg (fail-fast: false) — it doesn't block
+# the others.
 #
 # npm side: set an automation token as the NPM_TOKEN repo secret; the job
-# skips cleanly when it's absent.
+# skips cleanly when it's absent. Publishes prismor-vercel and
+# prismor-mastra.
 
 on:
   workflow_dispatch:
@@ -28,7 +33,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        adapter: [langchain, crewai, openai-agents, browser-use]
+        adapter:
+          [
+            langchain,
+            crewai,
+            openai-agents,
+            browser-use,
+            pydantic-ai,
+            autogen-core,
+            agno,
+            semantic-kernel,
+            google-adk,
+            beeai,
+            claude-agent-sdk,
+          ]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter: [vercel-ai, mastra]
     steps:
       - uses: actions/checkout@v4
 
@@ -65,9 +87,9 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Build and publish prismor
+      - name: Build and publish ${{ matrix.adapter }}
         if: env.NPM_TOKEN != ''
-        working-directory: adapters/vercel-ai
+        working-directory: adapters/${{ matrix.adapter }}
         run: |
           npm install
           npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.34.0] — 2026-07-23
+
+### Added
+
+- **5 new shipped coding-agent integrations: Crush, OpenHands, Qwen Code, Continue CLI, and Goose.** Each verified live against a real install, not just docs — surfaced several discrepancies between what each agent's own docs describe and what actually dispatches (Crush only fires `PreToolUse`, deny reason comes from stderr; OpenHands' shell tool is `terminal` with an `event_type` field instead of `hook_event_name`; Qwen Code's shell tool is `run_shell_command` with a nested `hookSpecificOutput.permissionDecision` deny envelope; Continue CLI hooks did not fire at all in headless `cn -p` mode, shipped with a prominent warning; Goose's shell tool is `shell`, not `developer__shell` as goose's own docs example shows). Plus accurate `roadmap` registry entries for 7 more coding agents not previously catalogued here (Pi Agent, Amazon Q Developer CLI, Amp, Auggie CLI, Kimi Code, Devin CLI) and Warp (sweep-only). (#212)
+- **8 new framework adapter packages, each individually live-verified against a real model-backed agent run before shipping:** `prismor-pydantic-ai`, `prismor-autogen-core`, `prismor-agno`, `prismor-semantic-kernel`, `prismor-google-adk`, `prismor-mastra` (npm), `prismor-beeai`, and `prismor-claude-agent-sdk`. Every one denies a destructive tool call and allows a benign one before its policy engine call returns — see each package's README for the exact hook mechanism. The Mastra adapter was rewritten mid-development after its originally-planned `processOutputStep` + `abort()` hook was found live-tested to not actually block tool execution; it now wraps `tool.execute` directly instead, which is reliable. The Claude Code Agent SDK adapter required a discriminating test methodology (a benign-framed `.claude/settings.json` write, since naive destructive commands trigger Claude's own alignment refusal independent of any hook) — that test also caught a real bug where the adapter's default hook matcher never fired for custom MCP tools. (#213)
+
 ## [1.33.0] — 2026-07-23
 
 ### Added

--- a/adapters/mastra/package.json
+++ b/adapters/mastra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prismor-mastra",
   "version": "0.1.0",
-  "description": "Prismor for Mastra — policy-controlled tool calls via an output-step processor and the Prismor eval-server",
+  "description": "Prismor for Mastra — policy-controlled tool calls via a wrapped execute function and the Prismor eval-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.33.0"
+__version__ = "1.34.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
## Summary

- Bumps `prismor` to 1.34.0 and adds a CHANGELOG entry covering the coding-agent (#212) and framework-adapter (#213) work already merged into `main`.
- Wires the 7 new Python adapter packages (`pydantic-ai`, `autogen-core`, `agno`, `semantic-kernel`, `google-adk`, `beeai`, `claude-agent-sdk`) and `prismor-mastra` into `.github/workflows/release-adapters.yml`, which previously only knew about the original 4 adapters. Without this, pushing an `adapters-v*` tag would silently skip publishing every adapter shipped since.
- Fixes a stale package description in `adapters/mastra/package.json` left over from before the `processOutputStep` → `execute`-wrapping correction.

## Release plan (for after merge)

1. Merge this PR.
2. Tag `main` `v1.34.0` and push the tag → triggers `.github/workflows/release.yml` (publishes `prismor` + the `immunity-agent` redirect shim to PyPI, creates a GitHub Release).
3. Tag `main` `adapters-v1.34.0` and push the tag → triggers `.github/workflows/release-adapters.yml` (publishes the 11 PyPI adapter packages + 2 npm packages).
4. **Prerequisite for step 3 to fully succeed:** each new PyPI adapter package (`prismor-pydantic-ai`, `prismor-autogen-core`, `prismor-agno`, `prismor-semantic-kernel`, `prismor-google-adk`, `prismor-beeai`, `prismor-claude-agent-sdk`) needs a pending trusted-publisher configured on pypi.org pointing at this repo + `release-adapters.yml` + the `pypi` environment, same as the original 4. `fail-fast: false` means an unconfigured package fails only its own matrix leg, not the others.

## Test plan

- [x] `python3 -m pytest tests/test_hooks.py tests/test_hooks_extended.py tests/test_hook_coverage.py -q` → 114 passed
- [x] `bash scripts/verify_registry.sh` → registry schema valid, coverage matrix in sync