### PR TITLE
release: v1.34.1 — bundle 7 new framework adapters into prismor

### DIFF
--- a/.github/workflows/release-adapters.yml
+++ b/.github/workflows/release-adapters.yml
@@ -1,20 +1,23 @@
 name: Release Adapters
 
-# Publishes the framework adapter packages. Separate from the main Release
-# workflow so an unconfigured publisher can never block a runtime release.
-#
-# PyPI side (trusted publishing, no tokens): each package needs a (pending)
-# publisher on pypi.org pointing at this repo + this workflow file + the
-# `pypi` environment: prismor-langchain, prismor-crewai, prismor-openai,
-# prismor-browser-use, prismor-pydantic-ai, prismor-autogen-core,
-# prismor-agno, prismor-semantic-kernel, prismor-google-adk, prismor-beeai,
-# prismor-claude-agent-sdk. A package whose trusted publisher isn't set up
-# yet just fails that one matrix leg (fail-fast: false) — it doesn't block
-# the others.
+# Publishes the framework adapter packages that are NOT part of the main
+# `prismor` wheel — i.e. the TypeScript/npm ones. Every Python framework
+# adapter (langchain, crewai, openai-agents, browser-use, pydantic-ai,
+# autogen-core, agno, semantic-kernel, google-adk, beeai,
+# claude-agent-sdk) ships *inside* the main `prismor` package instead —
+# see pyproject.toml's `packages` / `force-include` / optional-dependencies
+# — so `pip install "prismor[beeai]"` is the only install path; there is no
+# separate `prismor-beeai` PyPI package, deliberately. (An earlier version
+# of this workflow tried to publish standalone PyPI packages for every
+# adapter and failed uniformly with PyPI's "non-user identities cannot
+# create new projects" error — because none of those package names were
+# ever meant to have a real PyPI project behind them; the READMEs always
+# documented the `prismor[...]` extras path, not a standalone install.)
 #
 # npm side: set an automation token as the NPM_TOKEN repo secret; the job
 # skips cleanly when it's absent. Publishes prismor-vercel and
-# prismor-mastra.
+# prismor-mastra — genuinely separate packages since a Python wheel can't
+# bundle TypeScript.
 
 on:
   workflow_dispatch:
@@ -24,48 +27,8 @@ on:
 
 permissions:
   contents: read
-  id-token: write # OIDC for PyPI trusted publishing
 
 jobs:
-  pypi:
-    runs-on: ubuntu-latest
-    environment: pypi
-    strategy:
-      fail-fast: false
-      matrix:
-        adapter:
-          [
-            langchain,
-            crewai,
-            openai-agents,
-            browser-use,
-            pydantic-ai,
-            autogen-core,
-            agno,
-            semantic-kernel,
-            google-adk,
-            beeai,
-            claude-agent-sdk,
-          ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Build ${{ matrix.adapter }} adapter
-        run: |
-          pip install build
-          python -m build "adapters/${{ matrix.adapter }}" --outdir dist-adapter
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist-adapter
-          skip-existing: true
-
   npm:
     runs-on: ubuntu-latest
     env:

--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -236,8 +236,8 @@ telemetry scope to the end-user.
 ### OpenAI Agents SDK
 
 - **Surface:** in-process tool wrapper / guardrail (`surface: sdk`).
-- **Package:** [`adapters/openai-agents/`](adapters/openai-agents/) →
-  `prismor-openai`. `prismor_guard(tool, subject="user:alice")`.
+- **Package:** [`adapters/openai-agents/`](adapters/openai-agents/), bundled in
+  `pip install "prismor[openai-agents]"`. `from prismor.openai import prismor_guard`.
 - **Blocking:** raises `PrismorBlocked` before the tool runs; `mode="observe"` is log-only.
 - **Per-user:** `subject` → policy + IAM (`user:<id>` / `team:<id>` profiles) + telemetry.
 - **Code:** `adapters/openai-agents/prismor_openai/__init__.py`,
@@ -247,8 +247,9 @@ telemetry scope to the end-user.
 ### LangChain / LangGraph
 
 - **Surface:** in-process tool wrapper + optional callback handler (`surface: sdk`).
-- **Package:** [`adapters/langchain/`](adapters/langchain/) → `prismor-langchain`.
-  `guard_tools([...], subject="user:alice")`; or `PrismorCallbackHandler(...)` for capture.
+- **Package:** [`adapters/langchain/`](adapters/langchain/), bundled in
+  `pip install "prismor[langchain]"`. `from prismor.langchain import guard_tools`;
+  or `PrismorCallbackHandler(...)` for capture.
 - **Blocking:** wraps each tool's `func`/`coroutine`; denied call returns a denial
   string (or raises with `raise_on_block=True`). `mode="observe"` is log-only.
 - **Verified:** live against a LangGraph `create_react_agent` — `rm -rf /` and
@@ -258,8 +259,8 @@ telemetry scope to the end-user.
 ### CrewAI
 
 - **Surface:** in-process tool wrapper (`surface: sdk`).
-- **Package:** [`adapters/crewai/`](adapters/crewai/) → `prismor-crewai`.
-  `guard_tools([...], subject="user:alice")`.
+- **Package:** [`adapters/crewai/`](adapters/crewai/), bundled in
+  `pip install "prismor[crewai]"`. `from prismor.crewai import guard_tools`.
 - **Blocking:** wraps each tool's `func`/`_run`/`run`; denied call returns a
   denial string (or raises). `mode="observe"` is log-only.
 - **Verified:** live against a `Crew` with a shell tool — `rm -rf /` blocked
@@ -269,8 +270,8 @@ telemetry scope to the end-user.
 ### Pydantic AI
 
 - **Surface:** in-process `WrapperToolset` (`surface: sdk`).
-- **Package:** [`adapters/pydantic-ai/`](adapters/pydantic-ai/) → `prismor-pydantic-ai`.
-  `guard_toolsets([toolset], subject="user:alice", mode="enforce")`.
+- **Package:** [`adapters/pydantic-ai/`](adapters/pydantic-ai/), bundled in
+  `pip install "prismor[pydantic-ai]"`. `from prismor.pydantic_ai import guard_toolsets`.
 - **Hook:** `PrismorToolset(WrapperToolset)` overrides `call_tool(name, tool_args, ctx, tool)` —
   the single choke point every tool call passes through (plain functions, MCP-server
   tools, or any composed toolset). Not calling `super().call_tool(...)` means the
@@ -287,8 +288,9 @@ telemetry scope to the end-user.
 ### AutoGen (Microsoft) — Core runtime
 
 - **Surface:** in-process `InterventionHandler` (`surface: sdk`).
-- **Package:** [`adapters/autogen-core/`](adapters/autogen-core/) → `prismor-autogen-core`.
-  `PrismorInterventionHandler(subject="user:alice", mode="enforce")` passed to
+- **Package:** [`adapters/autogen-core/`](adapters/autogen-core/), bundled in
+  `pip install "prismor[autogen-core]"`. `from prismor.autogen_core import
+  PrismorInterventionHandler`, passed to
   `SingleThreadedAgentRuntime(intervention_handlers=[...])`.
 - **Hook:** overrides `on_send(message, *, message_context, recipient)` — the
   real per-message gate every `autogen-core` `AgentRuntime.send_message` call
@@ -313,7 +315,8 @@ telemetry scope to the end-user.
 ### Agno
 
 - **Surface:** in-process `tool_hooks` chain (`surface: sdk`).
-- **Package:** [`adapters/agno/`](adapters/agno/) → `prismor-agno`.
+- **Package:** [`adapters/agno/`](adapters/agno/), bundled in
+  `pip install "prismor[agno]"`. `from prismor.agno import prismor_tool_hook`;
   `Agent(tools=[...], tool_hooks=[prismor_tool_hook])`, or
   `make_tool_hook(subject="user:alice", mode="enforce")` to customize.
 - **Hook:** `tool_hooks` list on `Agent`/`Team` — distinct from the singular
@@ -337,7 +340,8 @@ telemetry scope to the end-user.
 ### Semantic Kernel (Microsoft)
 
 - **Surface:** in-process filter middleware (`surface: sdk`).
-- **Package:** [`adapters/semantic-kernel/`](adapters/semantic-kernel/) → `prismor-semantic-kernel`.
+- **Package:** [`adapters/semantic-kernel/`](adapters/semantic-kernel/), bundled in
+  `pip install "prismor[semantic-kernel]"`. `from prismor.semantic_kernel import make_filter`;
   `kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, make_filter(subject="user:alice", mode="enforce"))`.
 - **Hook:** `filter_fn(context, next)` wraps the actual invocation — every
   registered filter composes into one middleware stack whose innermost link
@@ -359,7 +363,8 @@ telemetry scope to the end-user.
 ### Google Agent Development Kit (ADK)
 
 - **Surface:** in-process `before_tool_callback` (`surface: sdk`).
-- **Package:** [`adapters/google-adk/`](adapters/google-adk/) → `prismor-google-adk`.
+- **Package:** [`adapters/google-adk/`](adapters/google-adk/), bundled in
+  `pip install "prismor[google-adk]"`. `from prismor.google_adk import make_before_tool_callback`;
   `LlmAgent(before_tool_callback=make_before_tool_callback(subject="user:alice", mode="enforce"))`.
 - **Hook:** `before_tool_callback(tool, args, tool_context)` on `LlmAgent`
   (or as a `BasePlugin` method — plugin-level callbacks take precedence
@@ -407,9 +412,9 @@ telemetry scope to the end-user.
 ### BeeAI Framework (IBM Research / Linux Foundation)
 
 - **Surface:** in-process tool wrapper (`surface: sdk`).
-- **Package:** [`adapters/beeai/`](adapters/beeai/) → `prismor-beeai`.
-  `guard_tool(tool, subject="user:alice", mode="enforce")` /
-  `guard_tools([...])`.
+- **Package:** [`adapters/beeai/`](adapters/beeai/), bundled in
+  `pip install "prismor[beeai]"`. `from prismor.beeai import guard_tool`;
+  `guard_tool(tool, subject="user:alice", mode="enforce")` / `guard_tools([...])`.
 - **Hook:** subscribes a blocking listener to a `Tool`'s `Emitter`
   `"start"` event — `emitter.on("start", handler, EmitterOptions(is_blocking=True))`
   — which `Tool.run()` awaits *before* calling `self._run(...)`.
@@ -433,8 +438,9 @@ telemetry scope to the end-user.
 ### Claude Code Agent SDK
 
 - **Surface:** in-process hooks (`surface: sdk`).
-- **Package:** [`adapters/claude-agent-sdk/`](adapters/claude-agent-sdk/) →
-  `prismor-claude-agent-sdk`. `prismor_hook_matcher(mode="enforce",
+- **Package:** [`adapters/claude-agent-sdk/`](adapters/claude-agent-sdk/), bundled
+  in `pip install "prismor[claude-agent-sdk]"`. `from prismor.claude_agent_sdk
+  import prismor_hook_matcher`; `prismor_hook_matcher(mode="enforce",
   subject="user:alice")` passed into `ClaudeAgentOptions(hooks={"PreToolUse": [...]})`.
 - **Hook:** the exact same `PreToolUse` hooks system the Claude Code CLI
   itself uses, exposed programmatically — `HookMatcher(matcher=None,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.34.1] — 2026-07-24
+
+### Fixed
+
+- **The 7 new framework adapters (pydantic-ai, autogen-core, agno, semantic-kernel, google-adk, beeai, claude-agent-sdk) are now bundled into the main `prismor` package instead of being separate PyPI distributions.** Attempting to publish them as standalone `prismor-<name>` packages in 1.34.0 failed uniformly — including for the pre-existing `prismor-langchain`/`prismor-crewai`/`prismor-openai`/`prismor-browser-use` packages — because none of those were ever real PyPI projects; every adapter's own README already documented `pip install "prismor[<name>]"`, not a standalone install. Extended `pyproject.toml`'s `packages`/`force-include`/optional-dependencies the same way the original 4 already worked, so `pip install "prismor[beeai]"` etc. now actually installs the adapter (via `from prismor.beeai import guard_tool`). `.github/workflows/release-adapters.yml` no longer tries to publish standalone Python packages to PyPI — it only publishes the genuinely-separate npm packages (`prismor-vercel`, `prismor-mastra`), which can't be bundled into a Python wheel.
+
 ## [1.34.0] — 2026-07-23
 
 ### Added

--- a/adapters/agno/README.md
+++ b/adapters/agno/README.md
@@ -20,7 +20,7 @@ message-list state, it does not swallow exceptions).
 ## Install
 
 ```bash
-pip install "prismor-agno[agno]"
+pip install "prismor[agno]"      # Prismor runtime + adapter + agno
 ```
 
 ## Use
@@ -28,7 +28,7 @@ pip install "prismor-agno[agno]"
 ```python
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from prismor_agno import prismor_tool_hook
+from prismor.agno import prismor_tool_hook
 
 agent = Agent(
     model=OpenAIChat(id="gpt-4o-mini"),

--- a/adapters/agno/prismor_agno/__init__.py
+++ b/adapters/agno/prismor_agno/__init__.py
@@ -19,7 +19,7 @@ it does not swallow exceptions).
 Easy path::
 
     from agno.agent import Agent
-    from prismor_agno import prismor_tool_hook
+    from prismor.agno import prismor_tool_hook
 
     agent = Agent(model=..., tools=[run_shell], tool_hooks=[prismor_tool_hook])
 """

--- a/adapters/autogen-core/README.md
+++ b/adapters/autogen-core/README.md
@@ -26,7 +26,7 @@ primitives (`SingleThreadedAgentRuntime`, `ToolAgent`,
 ## Install
 
 ```bash
-pip install "prismor-autogen-core[autogen]"
+pip install "prismor[autogen-core]"      # Prismor runtime + adapter + autogen-core
 ```
 
 ## Use
@@ -34,7 +34,7 @@ pip install "prismor-autogen-core[autogen]"
 ```python
 from autogen_core import SingleThreadedAgentRuntime, AgentId
 from autogen_core.tool_agent import ToolAgent
-from prismor_autogen_core import PrismorInterventionHandler
+from prismor.autogen_core import PrismorInterventionHandler
 
 runtime = SingleThreadedAgentRuntime(
     intervention_handlers=[

--- a/adapters/autogen-core/prismor_autogen_core/__init__.py
+++ b/adapters/autogen-core/prismor_autogen_core/__init__.py
@@ -17,7 +17,7 @@ so this adapter does not cover ``AssistantAgent`` usage.
 Easy path::
 
     from autogen_core import SingleThreadedAgentRuntime
-    from prismor_autogen_core import PrismorInterventionHandler
+    from prismor.autogen_core import PrismorInterventionHandler
 
     runtime = SingleThreadedAgentRuntime(
         intervention_handlers=[PrismorInterventionHandler(subject="user:alice", mode="enforce")],

--- a/adapters/beeai/README.md
+++ b/adapters/beeai/README.md
@@ -21,14 +21,14 @@ turned out not to actually block (see the Mastra adapter's notes).
 ## Install
 
 ```bash
-pip install "prismor-beeai[beeai]"
+pip install "prismor[beeai]"      # Prismor runtime + adapter + beeai-framework
 ```
 
 ## Use
 
 ```python
 from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
-from prismor_beeai import guard_tool
+from prismor.beeai import guard_tool
 
 tool = guard_tool(DuckDuckGoSearchTool(), subject="user:alice", mode="enforce")
 ```

--- a/adapters/beeai/prismor_beeai/__init__.py
+++ b/adapters/beeai/prismor_beeai/__init__.py
@@ -18,7 +18,7 @@ practice — see the Mastra adapter's notes.)
 
 Easy path::
 
-    from prismor_beeai import guard_tool
+    from prismor.beeai import guard_tool
 
     tool = guard_tool(RunShellTool(), subject="user:alice", mode="enforce")
 """

--- a/adapters/claude-agent-sdk/README.md
+++ b/adapters/claude-agent-sdk/README.md
@@ -41,14 +41,14 @@ defaults to `None` (every tool call) for exactly this reason.
 ## Install
 
 ```bash
-pip install "prismor-claude-agent-sdk[sdk]"
+pip install "prismor[claude-agent-sdk]"      # Prismor runtime + adapter + claude-agent-sdk
 ```
 
 ## Use
 
 ```python
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
-from prismor_claude_agent_sdk import prismor_hook_matcher
+from prismor.claude_agent_sdk import prismor_hook_matcher
 
 options = ClaudeAgentOptions(
     hooks={"PreToolUse": [prismor_hook_matcher(mode="enforce", subject="user:alice")]},

--- a/adapters/claude-agent-sdk/prismor_claude_agent_sdk/__init__.py
+++ b/adapters/claude-agent-sdk/prismor_claude_agent_sdk/__init__.py
@@ -36,7 +36,7 @@ anything but Claude's own built-in tools — ``matcher`` now defaults to
 Use::
 
     from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
-    from prismor_claude_agent_sdk import prismor_hook_matcher
+    from prismor.claude_agent_sdk import prismor_hook_matcher
 
     options = ClaudeAgentOptions(
         hooks={"PreToolUse": [prismor_hook_matcher(mode="enforce", subject="user:alice")]},

--- a/adapters/google-adk/README.md
+++ b/adapters/google-adk/README.md
@@ -19,14 +19,14 @@ execute.
 ## Install
 
 ```bash
-pip install "prismor-google-adk[adk]"
+pip install "prismor[google-adk]"      # Prismor runtime + adapter + google-adk
 ```
 
 ## Use
 
 ```python
 from google.adk.agents import LlmAgent
-from prismor_google_adk import make_before_tool_callback
+from prismor.google_adk import make_before_tool_callback
 
 agent = LlmAgent(
     model="gemini-2.0-flash",  # or a LiteLlm-wrapped model, e.g. openai/gpt-4o-mini

--- a/adapters/google-adk/prismor_google_adk/__init__.py
+++ b/adapters/google-adk/prismor_google_adk/__init__.py
@@ -13,7 +13,7 @@ result instead — the model never sees the tool actually execute.
 Easy path::
 
     from google.adk.agents import LlmAgent
-    from prismor_google_adk import make_before_tool_callback
+    from prismor.google_adk import make_before_tool_callback
 
     agent = LlmAgent(
         model="gemini-2.0-flash", name="ops", tools=[run_shell],

--- a/adapters/pydantic-ai/README.md
+++ b/adapters/pydantic-ai/README.md
@@ -17,7 +17,7 @@ observe-only callback.
 ## Install
 
 ```bash
-pip install "prismor-pydantic-ai[pydantic-ai]"
+pip install "prismor[pydantic-ai]"      # Prismor runtime + adapter + pydantic-ai-slim
 ```
 
 ## Use
@@ -25,7 +25,7 @@ pip install "prismor-pydantic-ai[pydantic-ai]"
 ```python
 from pydantic_ai import Agent
 from pydantic_ai.toolsets import FunctionToolset
-from prismor_pydantic_ai import guard_toolsets
+from prismor.pydantic_ai import guard_toolsets
 
 toolset = FunctionToolset([run_shell, read_file])
 agent = Agent(

--- a/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
+++ b/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
@@ -14,7 +14,7 @@ of the above. This is a hard pre-execution gate — not calling
 Easy path::
 
     from pydantic_ai import Agent
-    from prismor_pydantic_ai import guard_toolsets
+    from prismor.pydantic_ai import guard_toolsets
 
     agent = Agent('openai:gpt-4o-mini', toolsets=guard_toolsets(
         [my_toolset], subject="user:alice", mode="enforce",

--- a/adapters/semantic-kernel/README.md
+++ b/adapters/semantic-kernel/README.md
@@ -19,7 +19,7 @@ integrates with.
 ## Install
 
 ```bash
-pip install "prismor-semantic-kernel[semantic-kernel]"
+pip install "prismor[semantic-kernel]"      # Prismor runtime + adapter + semantic-kernel
 ```
 
 ## Use
@@ -27,7 +27,7 @@ pip install "prismor-semantic-kernel[semantic-kernel]"
 ```python
 from semantic_kernel import Kernel
 from semantic_kernel.filters import FilterTypes
-from prismor_semantic_kernel import make_filter
+from prismor.semantic_kernel import make_filter
 
 kernel = Kernel()
 kernel.add_service(...)

--- a/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
+++ b/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
@@ -18,7 +18,7 @@ Easy path::
 
     from semantic_kernel import Kernel
     from semantic_kernel.filters import FilterTypes
-    from prismor_semantic_kernel import make_filter
+    from prismor.semantic_kernel import make_filter
 
     kernel = Kernel()
     kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, make_filter(subject="user:alice", mode="enforce"))

--- a/docs/frameworks-browser-use.md
+++ b/docs/frameworks-browser-use.md
@@ -1,8 +1,8 @@
 # browser-use integration
 
 Prismor adapter for [browser-use](https://github.com/browser-use/browser-use).
-Ships from [`adapters/browser-use/`](../adapters/browser-use/) as
-`prismor-browser-use`. Registry entry: `id: browser-use` in
+Source lives at [`adapters/browser-use/`](../adapters/browser-use/), bundled
+into the main `prismor` package (no separate PyPI package). Registry entry: `id: browser-use` in
 [`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
 
 Browser agents carry unique risk: they can navigate to attacker-controlled URLs,

--- a/docs/frameworks-crewai.md
+++ b/docs/frameworks-crewai.md
@@ -1,7 +1,8 @@
 # CrewAI integration
 
-Prismor adapter for CrewAI. Ships from
-[`adapters/crewai/`](../adapters/crewai/) as `prismor-crewai`.
+Prismor adapter for CrewAI. Source lives at
+[`adapters/crewai/`](../adapters/crewai/), bundled into the main `prismor`
+package (no separate PyPI package).
 Registry entry: `id: crewai` in
 [`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
 

--- a/docs/frameworks-langchain.md
+++ b/docs/frameworks-langchain.md
@@ -1,7 +1,8 @@
 # LangChain / LangGraph integration
 
-Prismor adapter for LangChain and LangGraph. Ships from
-[`adapters/langchain/`](../adapters/langchain/) as `prismor-langchain`.
+Prismor adapter for LangChain and LangGraph. Source lives at
+[`adapters/langchain/`](../adapters/langchain/), bundled into the main
+`prismor` package (no separate PyPI package).
 Registry entry: `id: langchain` in
 [`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
 

--- a/docs/frameworks-openai-agents.md
+++ b/docs/frameworks-openai-agents.md
@@ -6,9 +6,9 @@ hook-config files, so the control point is an **in-process SDK adapter**: a thin
 wrapper around tool execution that routes every call through the same
 `prismor.runtime.runtime.evaluate_tool_call` pipeline a local coding-agent hook uses.
 
-The OpenAI Agents SDK adapter ships from
-[`adapters/openai-agents/`](../adapters/openai-agents/) as the
-`prismor-openai` distribution. Registry entry:
+The OpenAI Agents SDK adapter's source lives at
+[`adapters/openai-agents/`](../adapters/openai-agents/), bundled into the
+main `prismor` package (no separate PyPI package). Registry entry:
 [`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml)
 (`id: openai-agents`).
 

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.34.0"
+__version__ = "1.34.1"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/integrations/registry.yaml
+++ b/prismor/runtime/integrations/registry.yaml
@@ -378,7 +378,7 @@ agents:
     events: [tool_call]
     blocking: throw
     normalizer: "prismor_openai"
-    notes: "In-process tool wrapper / guardrail. pip install prismor-openai."
+    notes: "In-process tool wrapper / guardrail. pip install \"prismor[openai-agents]\"."
     sources: ["https://openai.github.io/openai-agents-python/"]
 
   - id: crewai
@@ -390,7 +390,7 @@ agents:
     events: [tool_call]
     blocking: throw
     normalizer: "prismor_crewai"
-    notes: "In-process tool wrapper (func/_run/run). pip install prismor-crewai."
+    notes: "In-process tool wrapper (func/_run/run). pip install \"prismor[crewai]\"."
     sources: ["https://docs.crewai.com/"]
 
   - id: langchain
@@ -402,7 +402,7 @@ agents:
     events: [on_tool_start, on_tool_end]
     blocking: throw
     normalizer: "prismor_langchain"
-    notes: "Tool wrapper + PrismorCallbackHandler. pip install prismor-langchain."
+    notes: "Tool wrapper + PrismorCallbackHandler. pip install \"prismor[langchain]\"."
     sources: ["https://python.langchain.com/docs/concepts/callbacks/"]
 
   - id: browser-use
@@ -414,7 +414,7 @@ agents:
     events: [go_to_url, click_element, input_text, search_google, open_tab, upload_file, save_pdf, extract_content]
     blocking: throw
     normalizer: "prismor_browser_use"
-    notes: "Patches Registry.execute_action — single dispatch point for all browser actions. go_to_url/search_google → network event; upload_file/save_pdf → file_write; everything else → shell. pip install prismor-browser-use."
+    notes: "Patches Registry.execute_action — single dispatch point for all browser actions. go_to_url/search_google → network event; upload_file/save_pdf → file_write; everything else → shell. pip install \"prismor[browser-use]\"."
     sources: ["https://github.com/browser-use/browser-use"]
 
   - id: pydantic-ai
@@ -426,7 +426,7 @@ agents:
     events: [call_tool]
     blocking: throw
     normalizer: "prismor_pydantic_ai"
-    notes: "PrismorToolset(WrapperToolset) overrides call_tool(name, tool_args, ctx, tool) — the single choke point every tool call passes through. Deny raises ToolFailed (definitive failure, no retry-budget consumption) by default, or PrismorBlocked with raise_on_block=True. Verified live (2026-07) against a real `openai:gpt-4o-mini` Agent with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install prismor-pydantic-ai."
+    notes: "PrismorToolset(WrapperToolset) overrides call_tool(name, tool_args, ctx, tool) — the single choke point every tool call passes through. Deny raises ToolFailed (definitive failure, no retry-budget consumption) by default, or PrismorBlocked with raise_on_block=True. Verified live (2026-07) against a real `openai:gpt-4o-mini` Agent with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install \"prismor[pydantic-ai]\"."
     sources: ["https://ai.pydantic.dev/toolsets/", "https://ai.pydantic.dev/api/toolsets/"]
 
   - id: autogen-core
@@ -438,7 +438,7 @@ agents:
     events: [on_send]
     blocking: throw
     normalizer: "prismor_autogen_core"
-    notes: "PrismorInterventionHandler(DefaultInterventionHandler) overrides on_send(message, *, message_context, recipient), the real per-message gate every autogen-core AgentRuntime send passes through; tool calls arrive as FunctionCall messages en route to a ToolAgent. Deny raises ToolException by default (tool_agent_caller_loop specifically catches this and converts it to a failed FunctionExecutionResult fed back to the model — conversation continues); drop_instead_of_raise=True returns DropMessage instead. Verified live (2026-07) against a real SingleThreadedAgentRuntime + ToolAgent + tool_agent_caller_loop calling openai:gpt-4o-mini with a genuine OpenAI key: a destructive shell command was denied before the tool ever ran; a benign command executed normally. SCOPE CAVEAT (unchanged from roadmap): only covers the low-level autogen-core runtime — the high-level AgentChat AssistantAgent does not route tool execution through this same path. pip install prismor-autogen-core."
+    notes: "PrismorInterventionHandler(DefaultInterventionHandler) overrides on_send(message, *, message_context, recipient), the real per-message gate every autogen-core AgentRuntime send passes through; tool calls arrive as FunctionCall messages en route to a ToolAgent. Deny raises ToolException by default (tool_agent_caller_loop specifically catches this and converts it to a failed FunctionExecutionResult fed back to the model — conversation continues); drop_instead_of_raise=True returns DropMessage instead. Verified live (2026-07) against a real SingleThreadedAgentRuntime + ToolAgent + tool_agent_caller_loop calling openai:gpt-4o-mini with a genuine OpenAI key: a destructive shell command was denied before the tool ever ran; a benign command executed normally. SCOPE CAVEAT (unchanged from roadmap): only covers the low-level autogen-core runtime — the high-level AgentChat AssistantAgent does not route tool execution through this same path. pip install \"prismor[autogen-core]\"."
     sources: ["https://microsoft.github.io/autogen/stable/user-guide/core-user-guide/cookbook/tool-use-with-intervention.html"]
 
   - id: agno
@@ -450,7 +450,7 @@ agents:
     events: [tool_hook]
     blocking: throw
     normalizer: "prismor_agno"
-    notes: "tool_hooks list on Agent/Team (distinct from the singular pre_hook/post_hook). Hook signature (function_name, function_call, arguments) — Agno introspects and injects by param name; function_call is the callable that continues the chain, not a data object. Deny by raising (confirmed against source: the try/finally wrapper around hook calls only isolates message-list state, does not swallow exceptions) instead of calling function_call(**arguments). Verified live (2026-07) against a real Agent(model=OpenAIChat(id='gpt-4o-mini')) with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran (Agno surfaced the RuntimeError as a tool error, model reported the block); a benign command executed normally. pip install prismor-agno."
+    notes: "tool_hooks list on Agent/Team (distinct from the singular pre_hook/post_hook). Hook signature (function_name, function_call, arguments) — Agno introspects and injects by param name; function_call is the callable that continues the chain, not a data object. Deny by raising (confirmed against source: the try/finally wrapper around hook calls only isolates message-list state, does not swallow exceptions) instead of calling function_call(**arguments). Verified live (2026-07) against a real Agent(model=OpenAIChat(id='gpt-4o-mini')) with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran (Agno surfaced the RuntimeError as a tool error, model reported the block); a benign command executed normally. pip install \"prismor[agno]\"."
     sources: ["https://docs.agno.com/tools/hooks"]
 
   - id: semantic-kernel
@@ -462,7 +462,7 @@ agents:
     events: [auto_function_invocation]
     blocking: throw
     normalizer: "prismor_semantic_kernel"
-    notes: "kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, filter_fn) where filter_fn(context, next) wraps the actual invocation; every filter composes into one middleware stack whose innermost link calls context.function.invoke(...). Deny by not calling await next(context) — cleanest gate-then-continue semantics of any framework in this table (Python confirmed; the .NET IAutoFunctionInvocationFilter equivalent was not independently re-verified in this pass). Sets a synthetic context.function_result so the model sees a coherent denied response. Verified live (2026-07) against a real Kernel + OpenAIChatCompletion(ai_model_id='gpt-4o-mini') with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install prismor-semantic-kernel."
+    notes: "kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, filter_fn) where filter_fn(context, next) wraps the actual invocation; every filter composes into one middleware stack whose innermost link calls context.function.invoke(...). Deny by not calling await next(context) — cleanest gate-then-continue semantics of any framework in this table (Python confirmed; the .NET IAutoFunctionInvocationFilter equivalent was not independently re-verified in this pass). Sets a synthetic context.function_result so the model sees a coherent denied response. Verified live (2026-07) against a real Kernel + OpenAIChatCompletion(ai_model_id='gpt-4o-mini') with a genuine OpenAI key: a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install \"prismor[semantic-kernel]\"."
     sources: ["https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/filters"]
 
   - id: google-adk
@@ -474,7 +474,7 @@ agents:
     events: [before_tool_callback]
     blocking: throw
     normalizer: "prismor_google_adk"
-    notes: "before_tool_callback(tool, args, tool_context) set on LlmAgent(before_tool_callback=fn) (or as a BasePlugin method, which take precedence over agent-level callbacks). Deny-by-substitution by default, not exception: returning None proceeds with the real tool call; returning a dict SKIPS tool execution and that dict becomes the result instead — the model never sees the tool actually run. raise_on_block=True raises PrismorBlocked instead. Verified live (2026-07) against a real LlmAgent using ADK's LiteLlm wrapper for openai/gpt-4o-mini with a genuine OpenAI key (pip install \"google-adk[extensions]\"): a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install prismor-google-adk."
+    notes: "before_tool_callback(tool, args, tool_context) set on LlmAgent(before_tool_callback=fn) (or as a BasePlugin method, which take precedence over agent-level callbacks). Deny-by-substitution by default, not exception: returning None proceeds with the real tool call; returning a dict SKIPS tool execution and that dict becomes the result instead — the model never sees the tool actually run. raise_on_block=True raises PrismorBlocked instead. Verified live (2026-07) against a real LlmAgent using ADK's LiteLlm wrapper for openai/gpt-4o-mini with a genuine OpenAI key (pip install \"google-adk[extensions]\"): a destructive shell command was denied before the tool's Python implementation ever ran; a benign command executed normally. pip install \"prismor[google-adk]\"."
     sources: ["https://adk.dev/callbacks/types-of-callbacks/", "https://adk.dev/plugins/"]
 
   - id: mastra
@@ -498,7 +498,7 @@ agents:
     events: ["start"]
     blocking: throw
     normalizer: "prismor_beeai"
-    notes: "guard_tool()/guard_tools() subscribe a blocking listener to a Tool's Emitter \"start\" event (emitter.on(\"start\", handler, EmitterOptions(is_blocking=True))), fired by Tool.run() before self._run(...). Verified against source (not just docs, after the Mastra lesson): Emitter._invoke runs listeners as tasks inside asyncio.TaskGroup, which always awaits every task and re-raises on failure before the surrounding block exits — a listener that raises genuinely prevents the tool body from running. Deny raises a plain RuntimeError by default, or PrismorBlocked with raise_on_block=True. Verified live (2026-07) against a real ReActAgent (Python 3.13; beeai-framework's pydantic TypedDict config hits an unrelated pydantic/3.14 rebuild issue, unrelated to this adapter) running openai:gpt-4o-mini via ChatModel.from_name with a genuine OpenAI key: a destructive shell command was denied before the tool's _run ever executed; a benign command executed normally. pip install \"prismor-beeai[beeai]\"."
+    notes: "guard_tool()/guard_tools() subscribe a blocking listener to a Tool's Emitter \"start\" event (emitter.on(\"start\", handler, EmitterOptions(is_blocking=True))), fired by Tool.run() before self._run(...). Verified against source (not just docs, after the Mastra lesson): Emitter._invoke runs listeners as tasks inside asyncio.TaskGroup, which always awaits every task and re-raises on failure before the surrounding block exits — a listener that raises genuinely prevents the tool body from running. Deny raises a plain RuntimeError by default, or PrismorBlocked with raise_on_block=True. Verified live (2026-07) against a real ReActAgent (Python 3.13; beeai-framework's pydantic TypedDict config hits an unrelated pydantic/3.14 rebuild issue, unrelated to this adapter) running openai:gpt-4o-mini via ChatModel.from_name with a genuine OpenAI key: a destructive shell command was denied before the tool's _run ever executed; a benign command executed normally. pip install \"prismor[beeai]\"."
     sources: ["https://framework.beeai.dev/modules/emitter", "https://framework.beeai.dev/modules/middleware", "https://framework.beeai.dev/modules/agents/requirement-agent"]
 
   - id: claude-agent-sdk
@@ -510,7 +510,7 @@ agents:
     events: [PreToolUse]
     blocking: json-permission
     normalizer: "prismor_claude_agent_sdk"
-    notes: "prismor_hook_matcher()/prismor_pre_tool_use_hook() register via HookMatcher(matcher=None, hooks=[cb]) on ClaudeAgentOptions.hooks — the same PreToolUse hooks system as the Claude Code CLI itself, exposed programmatically. Deny via hookSpecificOutput.permissionDecision: \"deny\", overriding even bypassPermissions mode. matcher defaults to None (match every tool call, not a fixed built-in-tool-name list) specifically because custom tools registered via create_sdk_mcp_server arrive as \"mcp__<server>__<tool>\" — a narrower default would silently exempt every custom/MCP tool from policy. VERIFICATION METHODOLOGY NOTE: unlike the OpenAI-key-backed adapters, this one requires genuine Anthropic auth to run at all, so it was live-tested (2026-07) on a separate host with an authenticated Claude Code CLI session (claude-agent-sdk shells out to the installed `claude` binary) rather than the shared OpenAI key. Naive destructive commands (rm -rf /, IMDS SSRF) turned out NOT to isolate the adapter — Claude's own alignment refuses those regardless of any hook, confirmed by a baseline run with zero Prismor hooks installed that also refused. Switched to a discriminating case instead: a benign-framed write to .claude/settings.json (Prismor's own agent-config-tampering CRITICAL rule) that Claude readily executes with no hook installed, and that the Prismor hook denies once installed — isolating the adapter's actual effect from the model's own judgment. An earlier version of this adapter's default matcher (\"Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch\") silently never fired for the custom MCP tool used in testing; caught by this same discriminating test, not the naive rm -rf / case, which is why the naive case is an unreliable verification signal for this particular framework. First-run failure caveat: end-to-end verification depends on the target ClaudeAgentOptions.hooks wiring being correct in the caller's own app; this adapter's own hook logic is what was verified. pip install \"prismor-claude-agent-sdk[sdk]\"."
+    notes: "prismor_hook_matcher()/prismor_pre_tool_use_hook() register via HookMatcher(matcher=None, hooks=[cb]) on ClaudeAgentOptions.hooks — the same PreToolUse hooks system as the Claude Code CLI itself, exposed programmatically. Deny via hookSpecificOutput.permissionDecision: \"deny\", overriding even bypassPermissions mode. matcher defaults to None (match every tool call, not a fixed built-in-tool-name list) specifically because custom tools registered via create_sdk_mcp_server arrive as \"mcp__<server>__<tool>\" — a narrower default would silently exempt every custom/MCP tool from policy. VERIFICATION METHODOLOGY NOTE: unlike the OpenAI-key-backed adapters, this one requires genuine Anthropic auth to run at all, so it was live-tested (2026-07) on a separate host with an authenticated Claude Code CLI session (claude-agent-sdk shells out to the installed `claude` binary) rather than the shared OpenAI key. Naive destructive commands (rm -rf /, IMDS SSRF) turned out NOT to isolate the adapter — Claude's own alignment refuses those regardless of any hook, confirmed by a baseline run with zero Prismor hooks installed that also refused. Switched to a discriminating case instead: a benign-framed write to .claude/settings.json (Prismor's own agent-config-tampering CRITICAL rule) that Claude readily executes with no hook installed, and that the Prismor hook denies once installed — isolating the adapter's actual effect from the model's own judgment. An earlier version of this adapter's default matcher (\"Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch\") silently never fired for the custom MCP tool used in testing; caught by this same discriminating test, not the naive rm -rf / case, which is why the naive case is an unreliable verification signal for this particular framework. First-run failure caveat: end-to-end verification depends on the target ClaudeAgentOptions.hooks wiring being correct in the caller's own app; this adapter's own hook logic is what was verified. pip install \"prismor[claude-agent-sdk]\"."
     sources: ["https://code.claude.com/docs/en/agent-sdk/hooks", "https://code.claude.com/docs/en/agent-sdk/permissions"]
 
   # ── Vercel AI SDK (TypeScript, via HTTP eval-server) ─────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,30 @@ langchain = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.30"]
 openai-agents = ["openai-agents>=0.0.1"]
 browser-use = ["browser-use>=0.1.0"]
+pydantic-ai = ["pydantic-ai-slim>=0.1"]
+autogen-core = ["autogen-core>=0.4"]
+agno = ["agno>=1.0"]
+semantic-kernel = ["semantic-kernel>=1.0"]
+google-adk = ["google-adk>=1.0"]
+beeai = ["beeai-framework>=0.1"]
+# Live-verified separately from the rest of this list, against an
+# authenticated Claude Code CLI session rather than the shared OpenAI key
+# (the SDK needs real Anthropic auth to run at all) — see
+# prismor.claude_agent_sdk's module docstring and
+# adapters/claude-agent-sdk/README.md for the verification methodology.
+claude-agent-sdk = ["claude-agent-sdk>=0.1"]
 frameworks = [
     "langchain-core>=0.2",
     "crewai>=0.30",
     "openai-agents>=0.0.1",
     "browser-use>=0.1.0",
+    "pydantic-ai-slim>=0.1",
+    "autogen-core>=0.4",
+    "agno>=1.0",
+    "semantic-kernel>=1.0",
+    "google-adk>=1.0",
+    "beeai-framework>=0.1",
+    "claude-agent-sdk>=0.1",
 ]
 
 [project.urls]
@@ -79,6 +98,13 @@ packages = [
     "adapters/crewai/prismor_crewai",
     "adapters/openai-agents/prismor_openai",
     "adapters/browser-use/prismor_browser_use",
+    "adapters/pydantic-ai/prismor_pydantic_ai",
+    "adapters/autogen-core/prismor_autogen_core",
+    "adapters/agno/prismor_agno",
+    "adapters/semantic-kernel/prismor_semantic_kernel",
+    "adapters/google-adk/prismor_google_adk",
+    "adapters/beeai/prismor_beeai",
+    "adapters/claude-agent-sdk/prismor_claude_agent_sdk",
 ]
 
 # Bundle runtime data into the wheel under prismor/runtime/data/
@@ -89,6 +115,13 @@ packages = [
 "adapters/crewai/prismor/crewai/__init__.py" = "prismor/crewai/__init__.py"
 "adapters/openai-agents/prismor/openai/__init__.py" = "prismor/openai/__init__.py"
 "adapters/browser-use/prismor/browser_use/__init__.py" = "prismor/browser_use/__init__.py"
+"adapters/pydantic-ai/prismor/pydantic_ai/__init__.py" = "prismor/pydantic_ai/__init__.py"
+"adapters/autogen-core/prismor/autogen_core/__init__.py" = "prismor/autogen_core/__init__.py"
+"adapters/agno/prismor/agno/__init__.py" = "prismor/agno/__init__.py"
+"adapters/semantic-kernel/prismor/semantic_kernel/__init__.py" = "prismor/semantic_kernel/__init__.py"
+"adapters/google-adk/prismor/google_adk/__init__.py" = "prismor/google_adk/__init__.py"
+"adapters/beeai/prismor/beeai/__init__.py" = "prismor/beeai/__init__.py"
+"adapters/claude-agent-sdk/prismor/claude_agent_sdk/__init__.py" = "prismor/claude_agent_sdk/__init__.py"
 "immunity-agent.pth" = "immunity-agent.pth"
 "advisories/immunity-feed.json" = "prismor/runtime/data/advisories/immunity-feed.json"
 "advisories/immunity-feed.json.sig" = "prismor/runtime/data/advisories/immunity-feed.json.sig"


### PR DESCRIPTION
## Summary

Follow-up to #214. The `adapters-v1.34.0` release run failed on every single PyPI leg — including the pre-existing `prismor-langchain`/`crewai`/`openai`/`browser-use` packages, not just the 7 new ones. Root cause: **none of those standalone packages were ever real PyPI projects.** Every adapter's own README already documented `pip install "prismor[<name>]"` — the main `prismor` wheel already bundles the original 4 adapters directly via `pyproject.toml`'s `packages`/`force-include`; the separate `adapters/<name>/pyproject.toml` files were never the actual shipping path, just leftover scaffolding.

This does the same bundling for the 7 new adapters (`pydantic-ai`, `autogen-core`, `agno`, `semantic-kernel`, `google-adk`, `beeai`, `claude-agent-sdk`):

- Extended `pyproject.toml`'s `packages` / `force-include` / `optional-dependencies` so `pip install "prismor[beeai]"` etc. actually installs the adapter code (`from prismor.beeai import guard_tool`).
- Updated each new adapter's README + module docstring to the `prismor.<name>` import path and `prismor[<name>]` install line (matching the existing 4's convention).
- Fixed the same stale "ships as `prismor-<name>`" phrasing in `registry.yaml` notes and the 4 existing `docs/frameworks-*.md` pages for the original 4 adapters.
- `.github/workflows/release-adapters.yml` no longer tries to publish standalone Python packages — only the genuinely-separate npm packages (`prismor-vercel`, `prismor-mastra`), which can't be bundled into a Python wheel.

## Verification

- Built the wheel locally (`python -m build`) and confirmed all 7 new `prismor.<name>` namespace shims + `prismor_<name>` implementations are present in the archive.
- Installed the built wheel into a clean venv; confirmed `from prismor.beeai import guard_tool` (and the other 6) import correctly once the framework's own package is installed (e.g. `pip install beeai-framework`).

## Test plan

- [x] `python3 -m pytest tests/test_hooks.py tests/test_hooks_extended.py tests/test_hook_coverage.py -q` → 114 passed
- [x] `bash scripts/verify_registry.sh` → registry schema valid, coverage matrix in sync
- [x] `python -m build` → wheel builds clean, contains all 7 new adapter modules + shims
- [x] Clean-venv install of the built wheel → all 7 new `prismor.<name>` imports succeed with the framework extra installed