### PR TITLE
docs: add per-framework guides for the 8 new adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 🧠 [Semantic Guard](docs/semantic-guard.md): opt-in hybrid layer that adds an LLM-assisted intent check for paraphrased prompt-injection attempts the regex rules cannot catch
 - 🪤 [Canary](docs/canary.md) plants honeytoken credential files that trip a CRITICAL finding the moment an agent reads them, catching recon behavior
 - 🪪 [IAM](docs/iam.md) gives each agent a named identity and least-privilege permission profile when several agents share a workspace
-- 🧩 [Framework Agents](docs/frameworks-overview.md) guards production agents (OpenAI Agents SDK, LangChain/LangGraph in Python and JS, CrewAI, browser-use, Vercel AI SDK) with one call — wrap each request in `use_subject("user:alice")` and a multi-tenant agent gets per-user attribution, per-user IAM profiles, and per-user suspension
+- 🧩 [Framework Agents](docs/frameworks-overview.md) guards production agents (OpenAI Agents SDK, LangChain/LangGraph in Python and JS, CrewAI, browser-use, Pydantic AI, AutoGen Core, Agno, Semantic Kernel, Google ADK, BeeAI, Claude Agent SDK, Vercel AI SDK, Mastra) with one call — wrap each request in `use_subject("user:alice")` and a multi-tenant agent gets per-user attribution, per-user IAM profiles, and per-user suspension
 - 🎯 [Scoped Agent](docs/scoped-agent.md) synthesizes minimal, task-specific rules per session so an injected pivot off-task gets blocked
 - 🧬 [Learning](docs/learning.md) mines session history to propose new rules, flag false positives, and detect evasion
 - ⚖️ [Layered Policy & Exemptions](docs/policy-layers-and-exemptions.md) covers per-rule observe/enforce, the non-overridable floor, and admin-granted, time-boxed exemptions across org / project / repo layers

--- a/docs/frameworks-agno.md
+++ b/docs/frameworks-agno.md
@@ -1,0 +1,63 @@
+# Agno integration
+
+Prismor adapter for Agno. Source lives at
+[`adapters/agno/`](../adapters/agno/), bundled into the main `prismor`
+package (no separate PyPI package).
+Registry entry: `id: agno` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[agno]"
+```
+
+## Why this hook point
+
+Agno's real hook point is the `tool_hooks` list on `Agent`/`Team` — distinct
+from the singular `pre_hook`/`post_hook`. Each hook is threaded into a
+nested execution chain around the tool's entrypoint; Agno introspects the
+hook's own signature and injects whichever of `function_name` /
+`function_call` / `args` (or `arguments`) it declares. `function_call` is
+the callable that continues the chain — not calling it means the real tool
+never runs, and any exception raised propagates normally (confirmed against
+source: the `try/finally` wrapper around hook calls only isolates
+message-list state, it does not swallow exceptions).
+
+## Use
+
+```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from prismor.agno import prismor_tool_hook
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[run_shell],
+    tool_hooks=[prismor_tool_hook],
+)
+```
+
+Use `make_tool_hook(subject="user:alice", mode="enforce", ...)` instead of
+the bare `prismor_tool_hook` to customize subject/workspace/mode. A denied
+call raises `RuntimeError` by default (Agno surfaces this to the model as a
+tool error); pass `raise_on_block=True` (via `make_tool_hook`) to raise
+`PrismorBlocked` instead for a hard stop. `mode="observe"` is log-only.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## Verified
+
+Live-tested against a real `Agent(model=OpenAIChat(id="gpt-4o-mini"))` with
+a genuine OpenAI API key: a shell tool call matching a destructive-command
+policy rule was denied before the tool's Python implementation ever ran; a
+benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-autogen-core.md
+++ b/docs/frameworks-autogen-core.md
@@ -1,0 +1,73 @@
+# AutoGen (Microsoft) — Core runtime integration
+
+Prismor adapter for the **AutoGen Core** runtime. Source lives at
+[`adapters/autogen-core/`](../adapters/autogen-core/), bundled into the main
+`prismor` package (no separate PyPI package).
+Registry entry: `id: autogen-core` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[autogen-core]"
+```
+
+## Why this hook point (and its scope)
+
+`autogen_core.tool_agent.tool_agent_caller_loop` / `ToolAgent` send each
+model-requested tool call to the runtime as an individual
+`runtime.send_message(FunctionCall, recipient=tool_agent_id)` call. Every
+message sent through an `autogen-core` `AgentRuntime` passes through its
+registered `InterventionHandler.on_send()` first — that's the real,
+genuine pre-execution gate this adapter hooks.
+
+**Scope caveat:** this only covers the low-level `autogen-core` runtime.
+The high-level `AgentChat` `AssistantAgent` (what most AutoGen users
+actually build with) does not route tool execution through this same
+`send_message`/`ToolAgent` path, so this adapter does not cover
+`AssistantAgent` usage — only code built directly on `autogen-core`
+primitives (`SingleThreadedAgentRuntime`, `ToolAgent`,
+`tool_agent_caller_loop`).
+
+## Use
+
+```python
+from autogen_core import SingleThreadedAgentRuntime, AgentId
+from autogen_core.tool_agent import ToolAgent
+from prismor.autogen_core import PrismorInterventionHandler
+
+runtime = SingleThreadedAgentRuntime(
+    intervention_handlers=[
+        PrismorInterventionHandler(subject="user:alice", mode="enforce"),
+    ],
+)
+await ToolAgent.register(runtime, "tool_agent", lambda: ToolAgent("tools", [run_shell_tool]))
+runtime.start()
+```
+
+A denied call raises `autogen_core.tool_agent.ToolException` by default —
+`tool_agent_caller_loop` specifically catches this exception type and
+converts it into a failed `FunctionExecutionResult` fed back to the model,
+so the conversation continues with the denial visible to the model. Pass
+`drop_instead_of_raise=True` to return `DropMessage` instead (silently
+cancels delivery with no result fed back). `mode="observe"` is log-only.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## Verified
+
+Live-tested against a real `SingleThreadedAgentRuntime` + `ToolAgent` +
+`tool_agent_caller_loop`, calling `openai:gpt-4o-mini` with a genuine
+OpenAI API key: a shell tool call matching a destructive-command policy
+rule was denied before the tool's Python implementation ever ran (the
+model received a `ToolException`-derived failure result and reported the
+denial), while a benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-beeai.md
+++ b/docs/frameworks-beeai.md
@@ -1,0 +1,59 @@
+# BeeAI Framework integration
+
+Prismor adapter for the **BeeAI Framework** (IBM Research / Linux
+Foundation). Source lives at [`adapters/beeai/`](../adapters/beeai/),
+bundled into the main `prismor` package (no separate PyPI package).
+Registry entry: `id: beeai` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[beeai]"
+```
+
+## Why this hook point
+
+BeeAI tools are built around an `Emitter`. `Tool.run()` awaits
+`context.emitter.emit("start", ToolStartEvent(input=..., options=...))`
+*before* calling `self._run(...)`. Verified against source
+(`beeai_framework.emitter.Emitter._invoke`): listener callbacks run as
+tasks inside an `asyncio.TaskGroup`, which always awaits every task before
+the surrounding `async with` block exits, and re-raises if any task
+failed. A listener that raises therefore genuinely prevents the tool body
+from ever running — this was checked directly against source rather than
+assumed, after a different framework's documented "before execution" hook
+turned out not to actually block (see the Mastra adapter's notes).
+
+## Use
+
+```python
+from beeai_framework.tools.search.duckduckgo import DuckDuckGoSearchTool
+from prismor.beeai import guard_tool
+
+tool = guard_tool(DuckDuckGoSearchTool(), subject="user:alice", mode="enforce")
+```
+
+A denied call raises inside the `"start"` listener (a plain `RuntimeError`
+by default, or `PrismorBlocked` if `raise_on_block=True`); BeeAI's tool
+executor surfaces this as a tool error visible to the agent, and
+`self._run(...)` is never reached. `guard_tools([...])` wraps a list of
+tools in one call.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## Verified
+
+Live-tested against a real BeeAI `ReActAgent` running `gpt-4o-mini` via
+`beeai_framework.backend.chat.ChatModel` with a genuine OpenAI API key: a
+destructive shell command was denied before the wrapped tool's `_run`
+ever executed; a benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-claude-agent-sdk.md
+++ b/docs/frameworks-claude-agent-sdk.md
@@ -1,0 +1,79 @@
+# Claude Code Agent SDK integration
+
+Prismor adapter for the **Claude Agent SDK** (Python). Source lives at
+[`adapters/claude-agent-sdk/`](../adapters/claude-agent-sdk/), bundled
+into the main `prismor` package (no separate PyPI package).
+Registry entry: `id: claude-agent-sdk` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[claude-agent-sdk]"
+```
+
+## Why this hook point
+
+This is the exact same hooks system the Claude Code CLI itself uses (and
+that this repo's own `prismor/runtime/hooks.py` `_merge_claude()` /
+`_normalize_claude()` already install into `.claude/settings.json`),
+exposed programmatically instead of via config file: `hooks` on
+`ClaudeAgentOptions`, matched with `HookMatcher(matcher=..., hooks=[cb])`
+against a `PreToolUseHookInput` (`tool_name`, `tool_input`). Returning
+`hookSpecificOutput.permissionDecision: "deny"` blocks the tool call
+before it runs — this overrides even `bypassPermissions` permission mode.
+
+## Use
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+from prismor.claude_agent_sdk import prismor_hook_matcher
+
+options = ClaudeAgentOptions(
+    hooks={"PreToolUse": [prismor_hook_matcher(mode="enforce", subject="user:alice")]},
+)
+
+async with ClaudeSDKClient(options=options) as client:
+    ...
+```
+
+`prismor_hook_matcher`'s `matcher` defaults to `None` (every tool call),
+not a fixed built-in-tool-name list — custom tools registered via
+`create_sdk_mcp_server` arrive as `mcp__<server>__<tool>`, and a narrower
+default would silently exempt every custom/MCP tool from policy. A denied
+call returns `hookSpecificOutput.permissionDecision: "deny"` with a
+human-readable reason (or raises `PrismorBlocked` if
+`raise_on_block=True`), which Claude surfaces as a permission denial
+instead of running the tool.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## ⚠️ Verification methodology note
+
+Unlike the other adapters on this page, this one can't be live-tested with
+an OpenAI key — the Claude Agent SDK requires genuine Anthropic/Claude Code
+authentication to run at all. It was instead live-tested on a separate
+host with an authenticated Claude Code CLI session (`claude-agent-sdk`
+shells out to the installed `claude` binary).
+
+Naive destructive test commands (`rm -rf /`, cloud-metadata SSRF) turned
+out to be an **unreliable** way to verify this particular adapter: Claude
+refuses those on its own, hook or no hook — confirmed with a baseline run
+that had *zero* Prismor hooks installed and still refused. The test that
+actually isolates the adapter's effect is a benign-framed write to
+`.claude/settings.json` (Prismor's own `agent-config-tampering` rule):
+Claude executes it readily with no hook installed, and the adapter denies
+it once installed. This discriminating test is also what caught a real
+bug during development — an earlier default `matcher` regex
+(`"Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch"`) never matched
+custom MCP tool names (`mcp__<server>__<tool>`), so the hook silently
+never fired for anything but Claude's built-in tools.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-google-adk.md
+++ b/docs/frameworks-google-adk.md
@@ -1,0 +1,61 @@
+# Google Agent Development Kit (ADK) integration
+
+Prismor adapter for Google's Agent Development Kit. Source lives at
+[`adapters/google-adk/`](../adapters/google-adk/), bundled into the main
+`prismor` package (no separate PyPI package).
+Registry entry: `id: google-adk` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[google-adk]"
+```
+
+## Why this hook point
+
+`before_tool_callback(tool, args, tool_context)`, set on
+`LlmAgent(before_tool_callback=fn)` (or as a `BasePlugin` method — plugin-level
+callbacks run first and take precedence over agent-level ones). Deny is by
+**substitution**, not exception: returning `None` lets the real tool run;
+returning a `dict` **skips** the real tool call entirely and that dict
+becomes the tool's result instead — the model never sees the tool actually
+execute.
+
+## Use
+
+```python
+from google.adk.agents import LlmAgent
+from prismor.google_adk import make_before_tool_callback
+
+agent = LlmAgent(
+    model="gemini-2.0-flash",  # or a LiteLlm-wrapped model, e.g. openai/gpt-4o-mini
+    name="ops",
+    tools=[run_shell],
+    before_tool_callback=make_before_tool_callback(subject="user:alice", mode="enforce"),
+)
+```
+
+A denied call returns `{"error": "⛔ Prismor blocked this tool call: ..."}`
+as the substituted tool result by default; pass `raise_on_block=True` to
+raise `PrismorBlocked` instead for a hard stop. `mode="observe"` is
+log-only.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## Verified
+
+Live-tested against a real `LlmAgent` running `openai/gpt-4o-mini` via ADK's
+`LiteLlm` model wrapper (`pip install "google-adk[extensions]"`) with a
+genuine OpenAI API key: a shell tool call matching a destructive-command
+policy rule was denied before the tool's Python implementation ever ran; a
+benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-mastra.md
+++ b/docs/frameworks-mastra.md
@@ -1,0 +1,84 @@
+# Mastra (TypeScript) integration
+
+Prismor adapter for **Mastra**. This is a genuinely separate npm package —
+`prismor-mastra` — since a Python wheel can't bundle TypeScript. Source
+lives at [`adapters/mastra/`](../adapters/mastra/).
+Registry entry: `id: mastra` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+Every tool call is routed through the Prismor **eval-server** (a local HTTP
+sidecar wrapping the same policy engine the Python adapters call
+in-process) before the tool body runs.
+
+## Why this hook point (and a correction from the original plan)
+
+The original plan pointed at `processOutputStep` — Mastra's own type docs
+describe it as running "after each LLM response, before tool execution,"
+with an injected `abort()` to deny. **This turned out not to be reliable
+when tested against a real agent run** (`@mastra/core` v0.x, 2026-07):
+calling `abort()` from `processOutputStep` throws a workflow-level error,
+but the tool's `execute` function runs anyway — confirmed with timestamped
+logging showing `execute` firing *after* `abort()` was called.
+
+Instead, `prismorTool`/`prismorTools` wrap a tool's `execute` function
+directly — the same pattern the CrewAI/LangChain adapters use — which
+**is** reliable: the wrapped function is what Mastra actually calls, so a
+thrown error genuinely prevents the tool body from running.
+
+## Install
+
+```bash
+npm install prismor-mastra
+```
+
+Start the eval-server once, alongside your app:
+
+```bash
+prismor eval-server --port 7071
+```
+
+## Use
+
+```ts
+import { Agent } from "@mastra/core/agent";
+import { openai } from "@ai-sdk/openai";
+import { prismorTool } from "prismor-mastra";
+
+const guardedRunShell = prismorTool("run_shell", runShell, {
+  mode: "enforce",
+  subject: "user:alice",
+});
+
+const agent = new Agent({
+  name: "ops",
+  model: openai("gpt-4o-mini"),
+  tools: { run_shell: guardedRunShell },
+});
+```
+
+A denied call throws `PrismorBlocked`; Mastra's tool-execution step
+catches the thrown error and feeds it back to the model as the tool's
+result, so the conversation continues with the denial visible. `mode:
+"observe"` is log-only. `failMode` controls what happens if the
+eval-server is unreachable (`"closed"` in enforce mode by default — a
+policy suspension must hold even when the sidecar is down).
+
+## Per-user control
+
+`subject` follows the same convention as the Vercel AI SDK adapter's
+`useSubject()` / the Python adapters' `use_subject()` — pass it per-call
+or set it on `prismorTool`/`prismorTools` — and is forwarded to the
+eval-server, resolved to per-user IAM profiles, and recorded in telemetry.
+
+## Verified
+
+Live-tested against a real Mastra `Agent` running `gpt-4o-mini` (via
+`@ai-sdk/openai`) with a genuine OpenAI API key and a local `prismor
+eval-server`: a destructive shell command was denied before the tool's
+JavaScript implementation ever ran; a benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [Vercel AI SDK integration](frameworks-vercel-ai.md) — the reference HTTP adapter pattern this one follows
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-overview.md
+++ b/docs/frameworks-overview.md
@@ -12,13 +12,25 @@ on your existing agent or controller object, with no changes to your tool logic.
 | LangChain / LangGraph | Python | `pip install "prismor[langchain]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | CrewAI | Python | `pip install "prismor[crewai]"` | `guard_tools([...])` | `use_subject("user:alice")` |
 | browser-use | Python | `pip install "prismor[browser-use]"` | `guard_controller(controller)` | `use_subject("user:alice")` |
+| Pydantic AI | Python | `pip install "prismor[pydantic-ai]"` | `guard_toolsets([...])` | `subject="user:alice"` |
+| AutoGen Core (Microsoft) | Python | `pip install "prismor[autogen-core]"` | `PrismorInterventionHandler(...)` | `subject="user:alice"` |
+| Agno | Python | `pip install "prismor[agno]"` | `tool_hooks=[prismor_tool_hook]` | `subject="user:alice"` |
+| Semantic Kernel (Microsoft) | Python | `pip install "prismor[semantic-kernel]"` | `add_filter(..., make_filter(...))` | `subject="user:alice"` |
+| Google ADK | Python | `pip install "prismor[google-adk]"` | `before_tool_callback=make_before_tool_callback(...)` | `subject="user:alice"` |
+| BeeAI Framework | Python | `pip install "prismor[beeai]"` | `guard_tool(tool)` / `guard_tools([...])` | `subject="user:alice"` |
+| Claude Code Agent SDK | Python | `pip install "prismor[claude-agent-sdk]"` | `hooks={"PreToolUse": [prismor_hook_matcher(...)]}` | `subject="user:alice"` |
 | Vercel AI SDK | TypeScript | `npm install prismor-warden` | `prismorTools(tools)` | `useSubject("user:alice", fn)` |
 | LangChain JS / LangGraph JS | TypeScript | `npm install prismor-warden` | `prismorLangChainTools([...])` | `useSubject("user:alice", fn)` |
+| Mastra | TypeScript | `npm install prismor-mastra` | `prismorTool(name, tool)` | `subject: "user:alice"` |
 | Any language | Any | — (HTTP client only) | `POST /v1/evaluate` | `X-Prismor-Subject` header |
 
-> The Python adapters ship inside the `prismor` package (needs `>= 1.14.2`) —
-> the extra just pulls the framework itself. `prismor[frameworks]` installs all
-> four. On npm the package is `prismor-warden`.
+> The Python adapters ship inside the `prismor` package (no separate PyPI
+> packages) — each extra just pulls the framework itself.
+> `prismor[frameworks]` installs all of them. Vercel AI SDK / LangChain JS
+> ship as the `prismor-warden` npm package; Mastra ships separately as
+> `prismor-mastra` since it wraps tools directly rather than going through
+> an eval-server client — both are genuinely separate packages since a
+> Python wheel can't bundle TypeScript.
 
 The multi-tenant pattern is the same in every language: guard once at startup
 with no bound subject, then wrap each request with `use_subject` (Python) or
@@ -49,8 +61,16 @@ Regardless of framework, every adapter does the same three things:
 | LangChain / LangGraph | `tool.func` + `tool.coroutine` | before `tool.invoke()` / `tool.ainvoke()` executes |
 | CrewAI | `tool.func` → `tool._run` → `tool.run` (first found) | before the tool implementation runs |
 | browser-use | `Registry.execute_action` | before Playwright executes any browser action |
+| Pydantic AI | `WrapperToolset.call_tool(name, tool_args, ctx, tool)` | before `super().call_tool(...)` — the single choke point for every tool |
+| AutoGen Core (Microsoft) | `InterventionHandler.on_send(message, ...)` | before any `FunctionCall` message reaches a `ToolAgent` |
+| Agno | `tool_hooks` list on `Agent`/`Team` | before `function_call(**arguments)` continues the chain |
+| Semantic Kernel (Microsoft) | filter `filter_fn(context, next)` in the invocation middleware stack | before `await next(context)` — which calls `context.function.invoke(...)` |
+| Google ADK | `before_tool_callback(tool, args, tool_context)` | before the tool call — returning a dict skips it entirely |
+| BeeAI Framework | `Tool`'s `Emitter` `"start"` event | before `self._run(...)` inside `Tool.run()` |
+| Claude Code Agent SDK | `PreToolUse` hook (`HookMatcher`) | before Claude runs the tool — same hook system as the CLI |
 | Vercel AI SDK | `tool.execute` | before the tool body runs, after the LLM emits the tool call |
 | LangChain JS / LangGraph JS | `tool.invoke` (StructuredTool) | before the tool runs — covers LangGraph's `ToolNode` / `createReactAgent` |
+| Mastra | `tool.execute` | before the tool body runs, after the LLM emits the tool call |
 | HTTP (any language) | caller-side `POST /v1/evaluate` | before calling the tool implementation |
 
 ## Eval-server (non-Python languages)
@@ -214,4 +234,12 @@ choosing which client a request belongs to is your app's authentication job.
 - [LangChain / LangGraph](frameworks-langchain.md) — `guard_tools`, `PrismorCallbackHandler`
 - [CrewAI](frameworks-crewai.md) — `guard_tools`, BaseTool and structured tool support
 - [browser-use](frameworks-browser-use.md) — `guard_controller`, network/file/shell event mapping
+- [Pydantic AI](frameworks-pydantic-ai.md) — `guard_toolsets`, `WrapperToolset.call_tool`
+- [AutoGen Core (Microsoft)](frameworks-autogen-core.md) — `PrismorInterventionHandler`, `on_send`
+- [Agno](frameworks-agno.md) — `tool_hooks`, `make_tool_hook`
+- [Semantic Kernel (Microsoft)](frameworks-semantic-kernel.md) — `make_filter`, `AUTO_FUNCTION_INVOCATION`
+- [Google ADK](frameworks-google-adk.md) — `make_before_tool_callback`, `before_tool_callback`
+- [BeeAI Framework](frameworks-beeai.md) — `guard_tool`, `Emitter` `"start"` event
+- [Claude Code Agent SDK](frameworks-claude-agent-sdk.md) — `prismor_hook_matcher`, `PreToolUse` hooks
 - [Vercel AI SDK](frameworks-vercel-ai.md) — `prismorTools`, TypeScript, eval-server HTTP protocol
+- [Mastra](frameworks-mastra.md) — `prismorTool`, TypeScript, direct `execute` wrapping

--- a/docs/frameworks-pydantic-ai.md
+++ b/docs/frameworks-pydantic-ai.md
@@ -1,0 +1,63 @@
+# Pydantic AI integration
+
+Prismor adapter for Pydantic AI. Source lives at
+[`adapters/pydantic-ai/`](../adapters/pydantic-ai/), bundled into the main
+`prismor` package (no separate PyPI package).
+Registry entry: `id: pydantic-ai` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[pydantic-ai]"
+```
+
+## Why this hook point
+
+Pydantic AI's real interception point is a `WrapperToolset` subclass:
+`call_tool(name, tool_args, ctx, tool)` is the single choke point every tool
+call passes through — plain Python functions, MCP-server tools, or any
+composed toolset. Not calling `super().call_tool(...)` means the wrapped tool
+never runs — a genuine pre-execution deny gate, not an observe-only callback.
+
+## Use
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+from prismor.pydantic_ai import guard_toolsets
+
+toolset = FunctionToolset([run_shell, read_file])
+agent = Agent(
+    "openai:gpt-4o-mini",
+    toolsets=guard_toolsets([toolset], subject="user:alice", mode="enforce"),
+)
+```
+
+A denied call raises `pydantic_ai.exceptions.ToolFailed` by default — the
+model sees a definitive failure and adapts, without consuming the tool's
+retry budget the way `ModelRetry` would (this is a policy denial, not a
+transient/correctable error). Pass `raise_on_block=True` to raise
+`PrismorBlocked` instead for a hard Python-level stop. `mode="observe"` is
+log-only.
+
+## Per-user control
+
+`subject` accepts a `Subject`, a `"user:alice"`-style string, or `None`
+(resolved from `PRISMOR_SUBJECT` / the enrolled device at call time). It is
+threaded into policy evaluation, IAM profile selection (`user:<id>` /
+`team:<id>`), and telemetry — the same generic `Subject`/`resolve_subject`
+plumbing every adapter uses, so per-user IAM profiles (`.prismor/iam.yaml`)
+apply identically to LangChain, CrewAI, or any other adapter.
+
+## Verified
+
+Live-tested against a real `pydantic-ai` `Agent` running `openai:gpt-4o-mini`
+with a genuine OpenAI API key: a shell tool call matching a `block_categories`
+rule (e.g. `rm -rf /`) was denied before execution — the tool's Python
+implementation never ran — while a harmless command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles

--- a/docs/frameworks-semantic-kernel.md
+++ b/docs/frameworks-semantic-kernel.md
@@ -1,0 +1,63 @@
+# Semantic Kernel (Microsoft) integration
+
+Prismor adapter for Semantic Kernel. Source lives at
+[`adapters/semantic-kernel/`](../adapters/semantic-kernel/), bundled into
+the main `prismor` package (no separate PyPI package).
+Registry entry: `id: semantic-kernel` in
+[`prismor/runtime/integrations/registry.yaml`](../prismor/runtime/integrations/registry.yaml).
+
+## Install
+
+```bash
+pip install "prismor[semantic-kernel]"
+```
+
+## Why this hook point
+
+`kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, filter_fn)`
+registers a filter of the form `filter_fn(context, next)`. Every registered
+filter composes into a single middleware stack; the innermost link calls
+`context.function.invoke(...)`. Simply not calling `await next(context)`
+means that inner call — and therefore the real tool — never runs. This is
+the cleanest gate-then-continue semantics of any framework Prismor
+integrates with. (Python confirmed; the .NET `IAutoFunctionInvocationFilter`
+equivalent was not independently re-verified.)
+
+## Use
+
+```python
+from semantic_kernel import Kernel
+from semantic_kernel.filters import FilterTypes
+from prismor.semantic_kernel import make_filter
+
+kernel = Kernel()
+kernel.add_service(...)
+kernel.add_plugin(MyPlugin(), plugin_name="tools")
+kernel.add_filter(
+    FilterTypes.AUTO_FUNCTION_INVOCATION,
+    make_filter(subject="user:alice", mode="enforce"),
+)
+```
+
+A denied call skips `next(context)` and sets a synthetic
+`context.function_result` so the model still sees a coherent (denied) tool
+response. Pass `raise_on_block=True` to raise `PrismorBlocked` instead for
+a hard stop. `mode="observe"` is log-only.
+
+## Per-user control
+
+`subject` (a `Subject`, `"user:alice"`-style string, or `None`) scopes
+policy, IAM profile selection, and telemetry to the end-user — the same
+generic mechanism every adapter uses.
+
+## Verified
+
+Live-tested against a real `Kernel` with an `OpenAIChatCompletion` service
+(`gpt-4o-mini`) and a genuine OpenAI API key: a plugin function call matching
+a destructive-command policy rule was denied before the tool's Python
+implementation ever ran; a benign command executed normally.
+
+## See also
+
+- [Framework adapters overview](frameworks-overview.md)
+- [IAM](iam.md) — per-user permission profiles


### PR DESCRIPTION
## Summary

- Adds `docs/frameworks-<name>.md` for each of the 8 framework adapters shipped in #212/#213/#215 that had a README under `adapters/` but no docs page: `pydantic-ai`, `autogen-core`, `agno`, `semantic-kernel`, `google-adk`, `mastra`, `beeai`, `claude-agent-sdk`.
- Updates `docs/frameworks-overview.md`'s "UX at a glance" table, "Hook points by framework" table, and "Per-framework guides" list — previously stopped at the original 5 pages (langchain, crewai, openai-agents, browser-use, vercel-ai).
- Updates `README.md`'s one-line framework list to match.

## Test plan

- [x] `python3 -m pytest tests/test_hooks.py tests/test_hooks_extended.py tests/test_hook_coverage.py -q` → 114 passed
- [x] `bash scripts/verify_registry.sh` → registry schema valid, coverage matrix in sync