### PR TITLE
Only load the taint store when there is something to mark

### DIFF
--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1104,12 +1104,19 @@ class PolicyEngine:
         # If this event produced any prompt_injection findings, persist that
         # fact so subsequent network events can be escalated regardless of
         # their destination.
-        taint = self._get_taint(session_id)
-        if taint is not None and any(
+        # Test the cheap condition first: _get_taint() reads the session's
+        # taint file from disk, so loading it unconditionally paid a file read
+        # on every event, while only events carrying a prompt-injection finding
+        # ever mark. Left None otherwise — the network block below lazily loads
+        # it on its own when it needs it.
+        taint = None
+        if any(
             f.get("category") in ("prompt_injection", "prompt_injection_semantic")
             for f in findings
         ):
-            taint.mark_injection(index)
+            taint = self._get_taint(session_id)
+            if taint is not None:
+                taint.mark_injection(index)
 
         # ── Network event: cloaking-secret check + taint escalation ───────
         if event_type == "network":


### PR DESCRIPTION
Found this while profiling #27, but it's unrelated so I split it out.

`_get_taint()` reads the session's taint file from disk, and it was getting called on every `evaluate()` even though only events with a prompt-injection finding ever mark. So every other event paid a file read for nothing.

Checking the cheap in-memory condition first avoids that. The network block already loads the store lazily when it needs it, so `taint` just stays `None` otherwise.

On an 800-statement workload that's 1044 ms down to 378 ms, all of it from the removed reads. A benign event now does 0 taint reads instead of 1, and an injection event still does 1 and marks the same as before.

Nothing else changes: the same events mark, and taint escalation on network events is untouched. `test_trifecta.py`, `test_suspicious_network` and `test_sarif_output` all pass, and the CI security-regression suite is green.

Kept separate from #27 so it can be reviewed or reverted on its own. #27 doesn't depend on it. If #221 lands first this will need a trivial rebase on the same hunk, or vice versa.
