### PR TITLE
Per-agent tool-tag overlays, and honour toolTagsSig on the device

### DIFF
--- a/prismor/runtime/enterprise/remote_policy.py
+++ b/prismor/runtime/enterprise/remote_policy.py
@@ -249,10 +249,19 @@ def check_and_refresh(interval: Optional[float] = None) -> bool:
         latest_egress_sig is not None
         and str(latest_egress_sig) != str(_current_egress_sig())
     )
+    # Tool-tag governance (settings.tool_tags) is served without a version bump
+    # as well. The server has always sent toolTagsSig; nothing here compared it,
+    # so a new tag rule only reached the device when some OTHER channel happened
+    # to churn — an admin adding a blocking rule would watch it do nothing.
+    latest_tool_tags_sig = body.get("toolTagsSig")
+    tool_tags_changed = (
+        latest_tool_tags_sig is not None
+        and str(latest_tool_tags_sig) != str(_current_tool_tags_sig())
+    )
     if (version_changed or profile_changed or capture_changed
             or repos_changed or controls_changed or rule_ex_changed
             or egress_changed or tool_denies_changed or subject_controls_changed
-            or device_mode_changed):
+            or device_mode_changed or tool_tags_changed):
         return fetch(force=True)
     return False
 
@@ -405,6 +414,30 @@ def _current_egress_sig() -> str:
             egress = {"egress_allowlist": sorted(str(x) for x in legacy)}
         import hashlib
         blob = json.dumps(egress, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def _current_tool_tags_sig() -> str:
+    """Signature of the cached policy's tool-tag config, matching the server's
+    ``toolTagsSig`` format (canonical JSON of settings.tool_tags → sha256 → 16
+    hex; empty when unset).
+
+    Canonical JSON for the same reason egress uses it: the block is nested (a
+    tag map, a rule list, and per-agent overlays) and — more importantly — the
+    device only ever holds the RESOLVED block, never the rows behind it. The
+    server originally hashed those rows, which is a signature the device cannot
+    reproduce, so this comparison could not exist at all.
+    """
+    try:
+        pol = verify_and_load()
+        settings = (pol or {}).get("settings") or {}
+        tags = settings.get("tool_tags")
+        if not isinstance(tags, dict) or not tags:
+            return ""
+        import hashlib
+        blob = json.dumps(tags, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
     except Exception:
         return ""

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1561,28 +1561,36 @@ class PolicyEngine:
         ):
             try:
                 from prismor.runtime.trifecta import (
-                    classify_tool_tags, egress_tags, TagLedger,
+                    classify_tool_tags, egress_tags, TagLedger, tool_tags_for_agent,
                 )
                 from prismor.runtime.tag_rules import compile_tool_tag_rules
                 _tt_tool = str((event.get("metadata") or {}).get("tool_name") or "")
+                # A policy attached to this agent in the control plane rides in
+                # the bundle as settings.tool_tags.agents[<name>], the same shape
+                # settings.egress.agents uses. Tighten-only — see
+                # trifecta.tool_tags_for_agent for why that is not optional.
+                _tt_cfg = tool_tags_for_agent(
+                    self.tool_tags,
+                    str(event.get("agent_name") or event.get("agent") or ""),
+                )
                 # Destination-derived tags let a tag rule reference where a call
                 # is going, not just which tool it is — the egress verdict for
                 # THIS event is already in `findings` by the time we get here.
                 _extra = (
                     egress_tags(findings)
-                    if self.tool_tags.get("egress_tags_enabled", True) else set()
+                    if _tt_cfg.get("egress_tags_enabled", True) else set()
                 )
                 _tags = classify_tool_tags(
                     event, event_type,
                     {f.get("category") for f in findings},
-                    self.tool_tags,
+                    _tt_cfg,
                     extra_tags=_extra,
                 )
                 if _tags:
-                    _rules = compile_tool_tag_rules(self.tool_tags)
+                    _rules = compile_tool_tag_rules(_tt_cfg)
                     _ledger = TagLedger(self.workspace, session_id)
                     _done = _ledger.completes_rules(_tags, _rules, index)
-                    _tt_mode = self.device_mode or str(self.tool_tags.get("mode", "observe")).lower()
+                    _tt_mode = self.device_mode or str(_tt_cfg.get("mode", "observe")).lower()
                     if _done is not None and _done.get("action") == "warn":
                         # A warn rule observes but never blocks — even under a
                         # device-level enforce override.
@@ -2968,26 +2976,46 @@ def validate_policy(path: Path) -> List[str]:
             except re.error as e:
                 errors.append(f"{prefix}.patterns[{j}]: invalid regex: {e}")
 
-    # settings.tool_tags: lint tag-rule expressions + legacy incompatible sets.
+    # settings.tool_tags: lint tag-rule expressions + legacy incompatible sets,
+    # for the fleet block AND each per-agent overlay under `agents:`. A broken
+    # rule hidden in an overlay is exactly as broken as one in the fleet block,
+    # and considerably harder to notice.
     tt = ((raw.get("settings") or {}).get("tool_tags") or {})
     if isinstance(tt, dict):
         from prismor.runtime.tag_rules import ParseError as _TagParseError, compile_rule as _compile_tag_rule
 
-        for i, entry in enumerate(tt.get("rules") or []):
-            prefix = f"settings.tool_tags.rules[{i}]"
-            expr = entry if isinstance(entry, str) else (
-                entry.get("expr") if isinstance(entry, dict) else None)
-            if not isinstance(expr, str):
-                errors.append(f"{prefix}: must be a string or an {{expr, action}} map")
-                continue
-            try:
-                _compile_tag_rule(expr)
-            except _TagParseError as e:
-                errors.append(f"{prefix}: {e.args[0]} in \"{expr}\"")
-            if isinstance(entry, dict) and entry.get("action") not in (None, "block", "warn"):
-                errors.append(f"{prefix}: invalid action '{entry.get('action')}' (block or warn)")
-        for i, s in enumerate(tt.get("incompatible") or []):
-            if not isinstance(s, (list, tuple)) or len({str(t) for t in s}) < 2:
-                errors.append(f"settings.tool_tags.incompatible[{i}]: needs at least 2 distinct tags")
+        def _lint_tag_block(block: Dict[str, Any], where: str) -> None:
+            for i, entry in enumerate(block.get("rules") or []):
+                prefix = f"{where}.rules[{i}]"
+                expr = entry if isinstance(entry, str) else (
+                    entry.get("expr") if isinstance(entry, dict) else None)
+                if not isinstance(expr, str):
+                    errors.append(f"{prefix}: must be a string or an {{expr, action}} map")
+                    continue
+                try:
+                    _compile_tag_rule(expr)
+                except _TagParseError as e:
+                    errors.append(f"{prefix}: {e.args[0]} in \"{expr}\"")
+                if isinstance(entry, dict) and entry.get("action") not in (None, "block", "warn"):
+                    errors.append(f"{prefix}: invalid action '{entry.get('action')}' (block or warn)")
+            for i, combo in enumerate(block.get("incompatible") or []):
+                if not isinstance(combo, (list, tuple)) or len({str(t) for t in combo}) < 2:
+                    errors.append(f"{where}.incompatible[{i}]: needs at least 2 distinct tags")
+
+        _lint_tag_block(tt, "settings.tool_tags")
+
+        agents = tt.get("agents")
+        if agents is not None and not isinstance(agents, dict):
+            errors.append("settings.tool_tags.agents: must be a map of agent name -> overlay")
+        elif isinstance(agents, dict):
+            for name, sub in agents.items():
+                where = f"settings.tool_tags.agents.{name}"
+                if not isinstance(sub, dict):
+                    errors.append(f"{where}: must be a map")
+                    continue
+                mode = sub.get("mode")
+                if mode is not None and str(mode).lower() not in ("observe", "enforce"):
+                    errors.append(f"{where}.mode: must be observe or enforce")
+                _lint_tag_block(sub, where)
 
     return errors

--- a/prismor/runtime/trifecta.py
+++ b/prismor/runtime/trifecta.py
@@ -138,6 +138,59 @@ def egress_tags(findings: Optional[list] = None) -> Set[str]:
     return out
 
 
+def tool_tags_for_agent(
+    tt_settings: Optional[Dict[str, Any]],
+    agent_name: str,
+) -> Dict[str, Any]:
+    """Resolve ``settings.tool_tags`` for one agent.
+
+    A policy attached to an agent in the control plane ships as an overlay under
+    ``settings.tool_tags.agents[<agent name>]``, mirroring the shape
+    ``settings.egress.agents`` already uses so the two channels behave the same
+    way.
+
+    TIGHTEN-ONLY, deliberately. The overlay may add tag mappings and rules and
+    raise the mode to enforce; it can never remove a tag, drop a rule, or lower
+    the mode. An agent's name is asserted by its own process — it arrives in the
+    event, not from any credential — so a permissive overlay would be a way for
+    a compromised agent to name itself out of the fleet's policy. Adding
+    restrictions is safe under the same assumption; removing them is not.
+    """
+    tt = tt_settings or {}
+    if not agent_name:
+        return tt
+    agents = tt.get("agents")
+    if not isinstance(agents, dict):
+        return tt
+    sub = agents.get(agent_name)
+    if not isinstance(sub, dict) or not sub:
+        return tt
+
+    merged = dict(tt)
+
+    # Tag mappings union per tool, so an overlay adds tags rather than
+    # replacing whatever the fleet already assigned to that tool.
+    base_map = tt.get("tags") if isinstance(tt.get("tags"), dict) else {}
+    over_map = sub.get("tags") if isinstance(sub.get("tags"), dict) else {}
+    if over_map:
+        combined = {k: list(_as_list(v)) for k, v in base_map.items()}
+        for tool, val in over_map.items():
+            combined[tool] = sorted(set(combined.get(tool, [])) | set(_as_list(val)))
+        merged["tags"] = combined
+
+    # Rules and legacy incompatible sets append; neither list can be shortened.
+    for key in ("rules", "incompatible"):
+        extra = sub.get(key)
+        if isinstance(extra, (list, tuple)) and extra:
+            merged[key] = list(tt.get(key) or []) + list(extra)
+
+    # Mode escalates only. observe -> enforce is a tighten; the reverse is not.
+    if str(sub.get("mode", "")).lower() == "enforce":
+        merged["mode"] = "enforce"
+
+    return merged
+
+
 def classify_tool_tags(
     event: Dict[str, Any],
     event_type: str,

--- a/tests/test_remote_policy.py
+++ b/tests/test_remote_policy.py
@@ -190,3 +190,75 @@ def test_agent_controls_sig_matches_server_format(tmp_path, monkeypatch):
     # No controls → empty signature.
     _write_remote(tmp_path / ".prismor", "settings: {}\nrules: []\n")
     assert remote_policy._current_agent_controls_sig() == ""
+
+
+TOOL_TAGS_POLICY = """
+version: "1.0"
+rules: []
+settings:
+  tool_tags:
+    enabled: true
+    mode: enforce
+    tags:
+      WebFetch: [untrusted_content]
+    rules:
+      - expr: untrusted_content then critical_action
+        action: block
+    agents:
+      scraper:
+        mode: enforce
+        tags:
+          Bash: [critical_action]
+"""
+
+
+def test_tool_tags_sig_matches_server_format(tmp_path, monkeypatch):
+    """_current_tool_tags_sig reproduces the server's toolTagsSig (canonical
+    JSON of settings.tool_tags -> sha256 -> 16 hex).
+
+    This comparison did not exist: the server sent toolTagsSig from the start,
+    nothing on the device read it, and the server hashed the DB ROWS - which the
+    device never sees and so could never reproduce. Both sides now hash the
+    resolved block, the way egressSig already did.
+    """
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    from prismor.runtime.enterprise import remote_policy
+
+    _write_remote(tmp_path / ".prismor", TOOL_TAGS_POLICY)
+    _enroll()
+    sig = remote_policy._current_tool_tags_sig()
+    assert sig and len(sig) == 16
+
+    import hashlib
+    import json as _json
+    block = {
+        "enabled": True,
+        "mode": "enforce",
+        "tags": {"WebFetch": ["untrusted_content"]},
+        "rules": [{"expr": "untrusted_content then critical_action", "action": "block"}],
+        "agents": {"scraper": {"mode": "enforce", "tags": {"Bash": ["critical_action"]}}},
+    }
+    blob = _json.dumps(block, sort_keys=True, separators=(",", ":"))
+    assert sig == hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+    # No tool-tag config -> empty signature, so an org that never enabled the
+    # feature does not re-pull on every heartbeat.
+    _write_remote(tmp_path / ".prismor", "version: \"1.0\"\nsettings: {}\nrules: []\n")
+    assert remote_policy._current_tool_tags_sig() == ""
+
+
+def test_tool_tags_sig_changes_when_an_agent_overlay_changes(tmp_path, monkeypatch):
+    """Attaching a policy to an agent alters the bundle without bumping the
+    profile version, so the signature has to move or the device never re-pulls."""
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / ".prismor"))
+    from prismor.runtime.enterprise import remote_policy
+
+    _write_remote(tmp_path / ".prismor", TOOL_TAGS_POLICY)
+    _enroll()
+    before = remote_policy._current_tool_tags_sig()
+
+    _write_remote(tmp_path / ".prismor", TOOL_TAGS_POLICY.replace(
+        "          Bash: [critical_action]",
+        "          Bash: [critical_action, private_data]",
+    ))
+    assert remote_policy._current_tool_tags_sig() != before

--- a/tests/test_trifecta.py
+++ b/tests/test_trifecta.py
@@ -9,7 +9,7 @@ import pytest
 
 from prismor.runtime.trifecta import (
     UNTRUSTED, CRITICAL, classify_tool_tags, TagLedger, normalize_incompatible,
-    TOOL_TAG_DEFAULTS,
+    TOOL_TAG_DEFAULTS, tool_tags_for_agent,
 )
 from prismor.runtime.runtime import evaluate_tool_call
 from prismor.runtime.policy_engine import (
@@ -196,3 +196,124 @@ def test_completed_set_stays_restricted(tmp_path):
     assert UNTRUSTED in ledger.seen and CRITICAL in ledger.seen
     d = _call(ws, sid, "mcp__Gmail__send_email", "network")
     assert any(f.get("category") == "lethal_trifecta" for f in d.findings)
+
+
+# ── per-agent overlays (a policy attached to one agent) ───────────────────────
+#
+# A policy attached to an agent in the control plane ships as
+# settings.tool_tags.agents[<name>], mirroring settings.egress.agents. The
+# invariant worth pinning is that it can only ever TIGHTEN: an agent's name
+# arrives in the event, asserted by its own process, so a permissive overlay
+# would let a compromised agent name itself out of the fleet's policy.
+
+def _base_tt():
+    return {
+        "enabled": True,
+        "mode": "observe",
+        "tags": {"WebFetch": ["untrusted_content"]},
+        "rules": [{"expr": "untrusted_content then critical_action", "action": "block"}],
+        "agents": {
+            "scraper": {
+                "mode": "enforce",
+                "tags": {"Bash": ["critical_action"]},
+                "rules": [{"expr": "private_data with external_comms", "action": "block"}],
+            }
+        },
+    }
+
+
+def test_overlay_untouched_for_other_agents():
+    tt = _base_tt()
+    for name in ("", "some-other-agent"):
+        got = tool_tags_for_agent(tt, name)
+        assert got["mode"] == "observe"
+        assert sorted(got["tags"]) == ["WebFetch"]
+        assert len(got["rules"]) == 1
+
+
+def test_overlay_adds_tags_rules_and_escalates_mode():
+    got = tool_tags_for_agent(_base_tt(), "scraper")
+    assert got["mode"] == "enforce"
+    assert sorted(got["tags"]) == ["Bash", "WebFetch"]
+    assert len(got["rules"]) == 2
+
+
+def test_overlay_cannot_lower_the_mode():
+    tt = _base_tt()
+    tt["mode"] = "enforce"
+    tt["agents"] = {"scraper": {"mode": "observe"}}
+    assert tool_tags_for_agent(tt, "scraper")["mode"] == "enforce"
+
+
+def test_overlay_cannot_remove_a_tag():
+    tt = _base_tt()
+    tt["agents"] = {"scraper": {"tags": {"WebFetch": []}}}
+    assert tool_tags_for_agent(tt, "scraper")["tags"]["WebFetch"] == ["untrusted_content"]
+
+
+def test_overlay_cannot_drop_a_rule():
+    tt = _base_tt()
+    tt["agents"] = {"scraper": {"rules": []}}
+    assert len(tool_tags_for_agent(tt, "scraper")["rules"]) == 1
+
+
+def test_overlay_unions_tags_for_the_same_tool():
+    tt = _base_tt()
+    tt["agents"] = {"scraper": {"tags": {"WebFetch": ["private_data"]}}}
+    assert tool_tags_for_agent(tt, "scraper")["tags"]["WebFetch"] == [
+        "private_data", "untrusted_content",
+    ]
+
+
+def test_malformed_overlay_is_ignored_not_fatal():
+    for agents in (None, [], "nope", {"scraper": "nope"}, {"scraper": {}}):
+        tt = _base_tt()
+        tt["agents"] = agents
+        got = tool_tags_for_agent(tt, "scraper")
+        assert got["mode"] == "observe"
+        assert sorted(got["tags"]) == ["WebFetch"]
+
+
+def _validate(tmp_path, tool_tags):
+    """Lint a minimally-valid policy carrying this settings.tool_tags block."""
+    import yaml
+    from prismor.runtime.policy_engine import validate_policy
+    f = tmp_path / "policy.yaml"
+    f.write_text(yaml.safe_dump({"version": "1.0", "rules": [], "settings": {"tool_tags": tool_tags}}))
+    return validate_policy(f)
+
+
+def test_lint_walks_agent_overlays(tmp_path):
+    # A broken rule hidden inside an overlay is exactly as broken as one in the
+    # fleet block, and much easier to miss.
+    errs = _validate(tmp_path, {
+        "agents": {
+            "scraper": {
+                "mode": "sometimes",
+                "rules": ["untrusted_content then then"],
+                "incompatible": [["only_one"]],
+            }
+        }
+    })
+    joined = "\n".join(errs)
+    assert "settings.tool_tags.agents.scraper.mode" in joined
+    assert "settings.tool_tags.agents.scraper.rules[0]" in joined
+    assert "settings.tool_tags.agents.scraper.incompatible[0]" in joined
+
+
+def test_lint_rejects_a_non_map_agents_block(tmp_path):
+    errs = _validate(tmp_path, {"agents": ["nope"]})
+    assert any("settings.tool_tags.agents" in e for e in errs)
+
+
+def test_lint_accepts_a_valid_overlay(tmp_path):
+    errs = _validate(tmp_path, {
+        "agents": {
+            "scraper": {
+                "mode": "enforce",
+                "rules": ["untrusted_content then critical_action"],
+                "incompatible": [["private_data", "external_comms"]],
+            }
+        }
+    })
+    assert [e for e in errs if "tool_tags" in e] == []


### PR DESCRIPTION
Two halves of the same gap, both on the tool-tag channel.

## Per-agent overlays

`settings.tool_tags.agents[<agent>]` — mirroring the shape `settings.egress.agents` already uses, so the two channels behave the same way. A policy scoped to one agent applies to that agent alone rather than to the fleet.

**Tighten-only, deliberately.** An overlay may add tag mappings and rules and raise the mode to enforce; it can never remove a tag, drop a rule, or lower the mode.

An agent's name arrives in the event, asserted by its own process rather than by any credential. A permissive overlay would therefore be a way for a compromised agent to name itself out of the fleet's policy. Adding restrictions is safe under that assumption; removing them is not — so the merge only ever goes one way, and there are tests for each direction.

## toolTagsSig is now compared

The control plane has always sent `toolTagsSig`; nothing on the device read it. A new tag rule only reached a device when some *other* channel happened to churn — an admin adding a blocking rule would watch it do nothing until an unrelated change forced a re-pull.

It hashes the resolved `settings.tool_tags` block as canonical JSON, the way `_current_egress_sig` already does. That detail is the reason the comparison could not exist before: the device only ever holds the resolved block, never the rows behind it, so a row-derived signature is one it has no way to reproduce.

## Lint

`validate_policy` walks the per-agent overlays too. A broken rule expression hidden in an overlay is exactly as broken as one in the fleet block, and considerably harder to notice.

## Compatibility

Additive. A policy with no `agents:` key behaves exactly as before, and an older runtime given a bundle that has one ignores it — verified against the released 1.34.2 from PyPI, which parses such a bundle, still resolves fleet tags, and does not pick up the overlay.

## Testing

- 10 new tests: overlay merge in both directions, malformed overlays, the signature format against an independently computed hash, and a signature that moves when an overlay changes.
- Full suite: 1363 passed, against 1353 on a clean `main` — the same 24 pre-existing failures on both, unrelated to this change (they are the shared-`~/.prismor`-state cluster and pass in isolation).
- Exercised end to end on a Linux box against a real server-signed bundle: the overlay applied to its own agent and not to another on the same device, and both signatures matched what the control plane computed.
