### PR TITLE
release: v1.35.0 — per-agent tool-tag overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.35.0] — 2026-07-29
+
+### Added
+
+- **Per-agent tool-tag overlays.** `settings.tool_tags.agents[<agent>]` mirrors the shape `settings.egress.agents` already uses, so the two channels behave identically: a policy attached to one agent in the control plane arrives here and applies to that agent alone. The overlay is **tighten-only** by design — it may add tag mappings and rules and raise the mode to enforce, but can never remove a tag, drop a rule, or lower the mode. An agent's name arrives in the event asserted by its own process rather than by any credential, so a permissive overlay would be a way for a compromised agent to name itself out of the fleet's policy; adding restrictions is safe under that assumption, removing them is not. `validate_policy` now walks the per-agent overlays too, since a broken rule expression hidden in an overlay is exactly as broken as one in the fleet block and considerably harder to notice. (#225)
+
+### Fixed
+
+- **`toolTagsSig` is now compared on the device, so a new tag rule actually reaches it.** The control plane has always sent the signature and nothing here read it, so a tag change only propagated when some *other* channel happened to churn — an admin adding a blocking tag rule would watch it do nothing. The signature hashes the resolved `settings.tool_tags` block as canonical JSON, the way `_current_egress_sig` already does. That detail is what made the comparison possible at all: the device only ever holds the resolved block, never the rows behind it, so a row-derived signature is one it cannot reproduce. Expect one re-pull per org as the signature format settles. (#225)
+
 ## [1.34.1] — 2026-07-24
 
 ### Fixed

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.34.2"
+__version__ = "1.35.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk


### PR DESCRIPTION
Cuts a release for the two commits sitting unshipped on main (#225). Diff is the version source and the CHANGELOG — no code changes.

PyPI and the last tag are both at 1.34.2; main is 2 commits ahead. Minor bump because #225 adds a capability (per-agent `settings.tool_tags.agents[...]` overlays) and fixes a propagation bug (`toolTagsSig` was sent by the control plane and never read by the device, so tag rules only reached a device when another channel happened to churn).

### Verified before tagging

`release.yml` triggers on a `v*` tag and gates on nothing — not the test suite, not oss-guard — and a PyPI version can never be reused. So:

- security regression suite (the one CI runs) green
- wheel built **from the sdist**, as CI does; installs clean into an empty venv
- `prismor --version` → 1.35.0; both new code paths verified present in the wheel, not just the tree
- all 11 adapter shims **and** their impl packages ship — 1.14.1 shipped shims without impls
- `prismor.openai` imports alongside the real `openai` SDK without shadowing it — the 1.18.3 regression
- `sys.path` unchanged after importing the runtime
- the immunity-agent shim's CI version-sync + build succeeds at 1.35.0

### Known, pre-existing — not from this release

A full `pytest` run has 25 failures from **test pollution**: each passes in isolation and fails in the full run, and the same 25 fail identically at `v1.34.2`. CI never sees them because `scripts/run_security_tests.sh` runs only a subset (`test_policies.py`, `test_cloak_secret_guard.py`, plus the shell tests). Worth fixing separately; it is not a regression and does not affect the shipped code.