### PR TITLE
feat(runtime): emit subagent_id/subagent_type attribution for Claude subagents

### DIFF
--- a/prismor/runtime/enterprise/telemetry.py
+++ b/prismor/runtime/enterprise/telemetry.py
@@ -189,6 +189,15 @@ def build_record(
         "category": finding.get("category"),
         "rule_id": finding.get("ruleId"),
         "tool_name": _tool_name(event, extra),
+        # Subagent attribution: which spawned subagent took this action, and its
+        # persona. Non-sensitive identifiers — agent_id is a runtime-assigned
+        # opaque id, subagent_type is a static persona name (e.g.
+        # "general-purpose") — so they survive redaction. Null on main-agent
+        # calls and agents without subagents, letting the dashboard attribute an
+        # inner tool call to its subagent instead of flattening it into the
+        # parent session. See hooks.py (_normalize_claude).
+        "subagent_id": _subagent_id(event),
+        "subagent_type": _subagent_type(event),
         # Repo + policy scope so the org dashboard can show which repo an event
         # came from and whether it ran under an admin-granted exemption (vs full
         # org policy). Only managed/company repos report, so the repo identifier
@@ -236,6 +245,26 @@ def _tool_name(event: Dict[str, Any], extra: Dict[str, Any]) -> Optional[str]:
         return str(meta["tool_name"])
     # Fall back to the normalized event type as a coarse tool name.
     return str(event.get("type")) if event.get("type") else None
+
+
+def _subagent_id(event: Dict[str, Any]) -> Optional[str]:
+    """Opaque id of the subagent that took this action, if any. Set by the
+    normalizer on tool calls made *inside* a spawned subagent."""
+    meta = event.get("metadata")
+    sid = meta.get("subagent_id") if isinstance(meta, dict) else None
+    return str(sid) if sid else None
+
+
+def _subagent_type(event: Dict[str, Any]) -> Optional[str]:
+    """Persona of the subagent. On a spawn event it is the top-level
+    ``subagent_type`` (the persona being launched); on an inner tool call it is
+    ``metadata.subagent_type`` (the persona that took the action)."""
+    top = event.get("subagent_type")
+    if top:
+        return str(top)
+    meta = event.get("metadata")
+    st = meta.get("subagent_type") if isinstance(meta, dict) else None
+    return str(st) if st else None
 
 
 def assert_redacted(record: Dict[str, Any]) -> None:

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -509,13 +509,20 @@ def _merge_claude(config: Dict[str, Any], command: str, workspace: Path) -> Dict
         hooks.get("UserPromptSubmit", []),
         {"matcher": "*", "hooks": [{"type": "command", "command": command}]},
     )
+    # `Task` is Claude's subagent-spawn tool. Matching it means the delegated
+    # charter (subagent prompt) is scanned before the subagent runs, and the
+    # spawn is recorded — otherwise a subagent is an unlogged laundering path
+    # for prompt-injection/exfiltration. A subagent's *inner* tool calls fire
+    # their own Pre/PostToolUse hooks (Bash/Read/...) and are already matched;
+    # they arrive tagged with the payload's agent_id/agent_type (see
+    # _normalize_claude) so they can be attributed to the subagent.
     hooks["PreToolUse"] = _merge_claude_entries(
         hooks.get("PreToolUse", []),
-        {"matcher": "Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*", "hooks": [{"type": "command", "command": command}]},
+        {"matcher": "Task|Agent|Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*", "hooks": [{"type": "command", "command": command}]},
     )
     hooks["PostToolUse"] = _merge_claude_entries(
         hooks.get("PostToolUse", []),
-        {"matcher": "Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*", "hooks": [{"type": "command", "command": command}]},
+        {"matcher": "Task|Agent|Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*", "hooks": [{"type": "command", "command": command}]},
     )
     # SessionStart carries the project-memory files (CLAUDE.md/AGENTS.md) that
     # Claude auto-loads before any tool call. Scanning them here brings their
@@ -1592,10 +1599,25 @@ def _normalize_goose(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]
 
 def _merge_claude_entries(entries: List[Dict[str, Any]], new_entry: Dict[str, Any]) -> List[Dict[str, Any]]:
     next_entries = list(entries)
+    new_commands = {hook.get("command") for hook in new_entry.get("hooks", [])}
     existing = next((entry for entry in next_entries if entry.get("matcher") == new_entry["matcher"]), None)
     if existing is None:
-        next_entries.append(new_entry)
-        return next_entries
+        # No entry has today's exact matcher, but an older install may already
+        # carry our command(s) under a now-stale (narrower) matcher — e.g. a
+        # matcher widened to add "Task|Agent" for subagent coverage. Widen that
+        # entry's matcher in place rather than appending a duplicate: two
+        # entries with the same command would fire the dispatcher twice per
+        # tool call. An entry is only ever a migration target if it already
+        # runs one of *our* commands — an entry for someone else's tool/command
+        # is left untouched.
+        existing = next(
+            (entry for entry in next_entries if any(h.get("command") in new_commands for h in entry.get("hooks", []))),
+            None,
+        )
+        if existing is None:
+            next_entries.append(new_entry)
+            return next_entries
+        existing["matcher"] = new_entry["matcher"]
 
     existing_commands = {hook.get("command") for hook in existing.get("hooks", [])}
     for hook in new_entry["hooks"]:
@@ -1840,7 +1862,17 @@ def _normalize_claude(payload: Dict[str, Any], session_id: str, workspace: Path)
         "session_id": session_id,
         "agent": "claude",
         "agent_event": hook_event,
-        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+        "metadata": {
+            "cwd": payload.get("cwd"),
+            "tool_name": tool_name,
+            # Claude tags tool calls made *inside* a spawned subagent with the
+            # subagent's id/persona. These are absent on main-agent calls, so
+            # promoting them here lets telemetry attribute an action to the
+            # subagent that took it instead of flattening it into the parent.
+            "subagent_id": payload.get("agent_id"),
+            "subagent_type": payload.get("agent_type"),
+            "raw": payload,
+        },
     }
     if hook_event == "SessionStart":
         # payload["cwd"] is the live directory of *this* session, sent by
@@ -1859,6 +1891,20 @@ def _normalize_claude(payload: Dict[str, Any], session_id: str, workspace: Path)
         return {**base, "type": "memory", "content": memory["content"]}
     if hook_event == "UserPromptSubmit":
         return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    if tool_name in {"Task", "Agent"}:
+        # Subagent-spawn (named "Task" in the hook matcher, surfaced as "Agent"
+        # in newer Claude payloads). The delegated charter (prompt + description) is
+        # untrusted instruction text that will drive an autonomous agent, so it
+        # is scanned by the same content rules as a user prompt / tool output
+        # (see _UNTRUSTED_CONTENT_ALIASES in policy_engine.py). subagent_type
+        # names the persona being launched.
+        return {
+            **base,
+            "type": "subagent_spawn",
+            "subagent_type": tool_input.get("subagent_type", ""),
+            "description": tool_input.get("description", ""),
+            "prompt": tool_input.get("prompt", ""),
+        }
     if tool_name == "Bash":
         return {**base, "type": "shell", "command": tool_input.get("command", ""), "stdout": payload.get("stdout", ""), "stderr": payload.get("stderr", "")}
     if tool_name == "Read":

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -591,12 +591,27 @@ class TestNormalizePayloadClaude(unittest.TestCase):
         payload = {
             "hook_event_name": "PostToolUse",
             "session_id": "sess-1",
-            "tool_name": "Agent",
+            "tool_name": "NotARealTool",
             "tool_input": {},
         }
         result = normalize_payload(agent="claude", payload=payload, workspace=Path("/tmp"))
         event = result["event"]
         self.assertEqual(event["type"], "tool_result")
+
+    def test_agent_tool_becomes_subagent_spawn(self):
+        # "Agent" is the newer-payload name for Claude's subagent-spawn tool
+        # (matcher-level name is "Task"); both must classify as subagent_spawn
+        # rather than falling through to the generic tool_result bucket.
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "session_id": "sess-1",
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "general-purpose"},
+        }
+        result = normalize_payload(agent="claude", payload=payload, workspace=Path("/tmp"))
+        event = result["event"]
+        self.assertEqual(event["type"], "subagent_spawn")
+        self.assertEqual(event["subagent_type"], "general-purpose")
 
     def test_ephemeral_session_id_when_missing(self):
         payload = {"hook_event_name": "Stop"}

--- a/tests/test_subagent_state.py
+++ b/tests/test_subagent_state.py
@@ -1,0 +1,233 @@
+"""Subagent attribution and hook-matcher migration.
+
+Every hook invocation is a separate process and Claude runs subagents
+concurrently, so a session's tag ledger is written by several processes at
+once. A lost update silently un-taints a session, so the forbidden tool
+combination is never blocked — that failure mode is fail-*open*.
+
+This file also pins down subagent_id/subagent_type attribution: Claude tags
+tool calls made inside a spawned subagent with agent_id/agent_type, and the
+normalizer/telemetry layer must promote those into metadata.subagent_id /
+subagent_type (and the Task/Agent tool itself into a subagent_spawn event) so
+the control plane can attribute an action to the subagent that took it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import unittest
+from multiprocessing import Process
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from prismor.runtime.enterprise.telemetry import build_record  # noqa: E402
+from prismor.runtime.hooks import _merge_claude_entries, _normalize_claude  # noqa: E402
+from prismor.runtime.trifecta import (  # noqa: E402
+    CRITICAL,
+    UNTRUSTED,
+    TagLedger,
+    normalize_incompatible,
+)
+
+SESSION = "sess"
+INCOMPATIBLE = normalize_incompatible(None)  # the default red/blue pair
+
+
+def _record_worker(home: str, tag: str, index: int, tool: str, barrier: str) -> None:
+    """Runs in a child process, mimicking one hook invocation."""
+    os.environ["PRISMOR_HOME"] = home
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from prismor.runtime.trifecta import TagLedger as Ledger
+
+    while not Path(barrier).exists():  # collide the writes as hard as possible
+        pass
+    Ledger(Path(home), SESSION).record({tag}, index, tool)
+
+
+def _run_concurrently(home: Path, specs) -> None:
+    barrier = home / "GO"
+    procs = [
+        Process(target=_record_worker, args=(str(home), tag, idx, tool, str(barrier)))
+        for tag, idx, tool in specs
+    ]
+    for p in procs:
+        p.start()
+    barrier.write_text("go")
+    for p in procs:
+        p.join()
+
+
+class ConcurrentLedgerWrites(unittest.TestCase):
+    """Parallel subagents must not drop each other's ledger records."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self.home = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+        self._prior_home = os.environ.get("PRISMOR_HOME")
+        os.environ["PRISMOR_HOME"] = str(self.home)
+
+    def tearDown(self) -> None:
+        import shutil
+
+        if self._prior_home is None:
+            os.environ.pop("PRISMOR_HOME", None)
+        else:
+            os.environ["PRISMOR_HOME"] = self._prior_home
+        shutil.rmtree(self.home, ignore_errors=True)
+
+    def test_no_lost_updates_under_concurrent_writers(self):
+        n = 12
+        _run_concurrently(self.home, [(f"tag{i}", i, f"tool{i}") for i in range(n)])
+        ledger = TagLedger(self.home, SESSION)
+        missing = {f"tag{i}" for i in range(n)} - set(ledger.seen)
+        self.assertEqual(missing, set(), f"lost {len(missing)} concurrent records")
+
+    def test_ledger_file_never_tears(self):
+        _run_concurrently(self.home, [(f"tag{i}", i, f"tool{i}") for i in range(12)])
+        path = self.home / "trifecta" / f"{SESSION}.json"
+        # A torn file is swallowed by the loader's except-and-continue, which
+        # resets the session to clean state — so it must be impossible, not rare.
+        json.loads(path.read_text(encoding="utf-8"))
+
+    def test_concurrent_writers_do_not_open_the_trifecta_gate(self):
+        """The security consequence of a lost update: one subagent fetches
+        untrusted content while others write concurrently; a later critical
+        action must still be blocked."""
+        specs = [(UNTRUSTED, 0, "WebFetch")]
+        specs += [(f"noise{i}", i + 1, f"tool{i}") for i in range(11)]
+        _run_concurrently(self.home, specs)
+        done = TagLedger(self.home, SESSION).completes(
+            {CRITICAL}, INCOMPATIBLE, current_index=99
+        )
+        self.assertIsNotNone(done, "forbidden combination was not detected")
+
+
+class HookMatcherMigration(unittest.TestCase):
+    """Re-running install-hooks must widen an existing entry's matcher rather
+    than appending a second one."""
+
+    COMMAND = 'PYTHONPATH="/x" "/py" -m prismor.runtime.immunity_cli hook-dispatch --agent claude'
+    NEW_MATCHER = "Task|Agent|Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*"
+
+    def _new_entry(self):
+        return {
+            "matcher": self.NEW_MATCHER,
+            "hooks": [{"type": "command", "command": self.COMMAND}],
+        }
+
+    def _stale(self):
+        return [
+            {
+                "matcher": "Bash|Write|Edit|MultiEdit|mcp__.*",
+                "hooks": [{"type": "command", "command": "some-other-tool"}],
+            },
+            {
+                "matcher": "Bash|Read|Edit|MultiEdit|Write|WebFetch|WebSearch|mcp__.*",
+                "hooks": [{"type": "command", "command": self.COMMAND}],
+            },
+        ]
+
+    def test_stale_matcher_is_widened_in_place(self):
+        merged = _merge_claude_entries(self._stale(), self._new_entry())
+        ours = [e for e in merged if any(h.get("command") == self.COMMAND for h in e["hooks"])]
+        self.assertEqual(len(ours), 1, "dispatcher would fire twice per tool call")
+        self.assertEqual(ours[0]["matcher"], self.NEW_MATCHER)
+
+    def test_subagent_spawn_tools_are_matched_after_migration(self):
+        merged = _merge_claude_entries(self._stale(), self._new_entry())
+        ours = [e for e in merged if any(h.get("command") == self.COMMAND for h in e["hooks"])]
+        for tool in ("Task", "Agent"):
+            self.assertTrue(
+                any(re.fullmatch(e["matcher"], tool) for e in ours),
+                f"{tool} spawn would not be screened",
+            )
+
+    def test_migration_is_idempotent(self):
+        once = _merge_claude_entries(self._stale(), self._new_entry())
+        twice = _merge_claude_entries(once, self._new_entry())
+        self.assertEqual(once, twice)
+
+    def test_another_tools_entry_is_never_hijacked(self):
+        merged = _merge_claude_entries(self._stale(), self._new_entry())
+        foreign = [e for e in merged if e["matcher"] == "Bash|Write|Edit|MultiEdit|mcp__.*"]
+        self.assertEqual(len(foreign), 1)
+        self.assertEqual(foreign[0]["hooks"][0]["command"], "some-other-tool")
+
+    def test_fresh_install_still_appends_new_entry(self):
+        """No prior install at all: nothing to migrate, so a plain append."""
+        merged = _merge_claude_entries([], self._new_entry())
+        self.assertEqual(merged, [self._new_entry()])
+
+
+class SubagentAttribution(unittest.TestCase):
+    """Task/Agent tool calls are classified as subagent_spawn, and inner tool
+    calls made inside a spawned subagent carry subagent_id/subagent_type
+    through the normalizer into the telemetry record."""
+
+    WORKSPACE = Path("/tmp/workspace")
+
+    def test_task_tool_call_is_classified_as_subagent_spawn(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Task",
+            "tool_input": {
+                "subagent_type": "general-purpose",
+                "description": "research something",
+                "prompt": "go find X",
+            },
+        }
+        event = _normalize_claude(payload, SESSION, self.WORKSPACE)
+        self.assertEqual(event["type"], "subagent_spawn")
+        self.assertEqual(event["subagent_type"], "general-purpose")
+        self.assertEqual(event["description"], "research something")
+
+    def test_inner_tool_call_promotes_agent_id_to_subagent_id(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "agent_id": "sub-42",
+            "agent_type": "general-purpose",
+        }
+        event = _normalize_claude(payload, SESSION, self.WORKSPACE)
+        self.assertEqual(event["metadata"]["subagent_id"], "sub-42")
+        self.assertEqual(event["metadata"]["subagent_type"], "general-purpose")
+
+    def test_main_agent_tool_call_has_no_subagent_id(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        }
+        event = _normalize_claude(payload, SESSION, self.WORKSPACE)
+        self.assertIsNone(event["metadata"]["subagent_id"])
+        self.assertIsNone(event["metadata"]["subagent_type"])
+
+    def test_telemetry_record_carries_subagent_id_for_inner_call(self):
+        event = {
+            "type": "shell",
+            "metadata": {"tool_name": "Bash", "subagent_id": "sub-42", "subagent_type": "general-purpose"},
+        }
+        record = build_record(finding={}, event=event, extra={}, full_capture=False)
+        self.assertEqual(record["subagent_id"], "sub-42")
+        self.assertEqual(record["subagent_type"], "general-purpose")
+
+    def test_telemetry_record_carries_subagent_type_for_spawn_event(self):
+        event = {"type": "subagent_spawn", "subagent_type": "general-purpose", "metadata": {}}
+        record = build_record(finding={}, event=event, extra={}, full_capture=False)
+        self.assertIsNone(record["subagent_id"])
+        self.assertEqual(record["subagent_type"], "general-purpose")
+
+    def test_telemetry_record_subagent_id_null_on_main_agent_call(self):
+        event = {"type": "shell", "metadata": {"tool_name": "Bash"}}
+        record = build_record(finding={}, event=event, extra={}, full_capture=False)
+        self.assertIsNone(record["subagent_id"])
+        self.assertIsNone(record["subagent_type"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prismor-web already has `subagentId`/`subagentType` columns, ingest parsing, and a fork/join DAG UI (`SessionFlow.tsx`) waiting for this data — the runtime never sent it, so the feature was fully inert on real sessions.
- `hooks.py`: match `Task|Agent` in the hook matcher, promote `agent_id`/`agent_type` into `metadata.subagent_id`/`subagent_type` on inner tool calls, classify the spawn call itself as `subagent_spawn`.
- `telemetry.py`: `build_record` carries `subagent_id`/`subagent_type` into the redacted record, matching the field names prismor-web's ingest route already expects.
- Fixed a latent bug in `_merge_claude_entries`: widening an existing matcher on a re-run of `install-hooks` used to append a duplicate entry with the same command (double-firing the dispatcher per tool call) instead of migrating the stale entry in place.

## Test plan
- [x] `tests/test_subagent_state.py` — hook-matcher migration + attribution unit tests (14 tests, new)
- [x] `tests/test_hooks_extended.py` — updated `test_unknown_tool_becomes_tool_result` (was asserting the old, incorrect fallthrough for the `Agent` tool) + added `test_agent_tool_becomes_subagent_spawn`
- [x] Full suite (`pytest tests/`) diffed against a clean `origin/main` worktree run — identical 23 pre-existing failures on both (unrelated test-isolation issue), zero regressions from this change