### PR TITLE
feat(runtime): honor org-pushed pause/resume from the console

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -485,6 +485,16 @@ def main(argv: Optional[List[str]] = None) -> None:
     if args.command == "resume":
         from prismor.runtime import pause as _pause
         existed = _pause.clear_paused()
+        # An org pause is not ours to lift — clearing the local marker above is
+        # still right (it stops a stale local pause outliving the org one), but
+        # enforcement stays off, so say so rather than printing "resumed" over a
+        # machine that is still paused.
+        _org = _pause.org_state()
+        if _org is not None and _org.get("paused"):
+            why = f' Reason: "{_org.get("reason")}".' if _org.get("reason") else ""
+            print(f"  {_color('⏸  Still paused by your organization', _YELLOW)} — this was pushed from the Prismor console.{why}")
+            print(f"  {_color('Ask an admin to resume it there; `prismor resume` cannot lift an org pause.', _DIM)}")
+            return
         if existed:
             # Push the resume immediately so the console clears its "paused"
             # badge now, instead of waiting on the next real tool call.
@@ -1123,6 +1133,23 @@ def main(argv: Optional[List[str]] = None) -> None:
                         sys.stderr.write(
                             f"[prismor] re-asserted guard for unhooked agent(s): {', '.join(_repaired)}\n"
                         )
+                # An org pause/resume arrives INSIDE that freshly pulled policy,
+                # and _pstate above was read from the previous one. Re-read it so
+                # a console pause (or resume) takes effect on THIS call rather
+                # than the next — the admin flips it, the agent's very next tool
+                # call already honors it.
+                from prismor.runtime import pause as _pause_mod
+                _was = _pstate
+                _pstate = _pause_mod.active_state()
+                if (_pstate is None) != (_was is None):
+                    if _pstate is not None and _pstate.get("source") == "org":
+                        _why = f" ({_pstate.get('reason')})" if _pstate.get("reason") else ""
+                        sys.stderr.write(
+                            f"[prismor] enforcement paused by your organization{_why} — "
+                            "screening and telemetry continue; blocking is off.\n"
+                        )
+                    elif _pstate is None and _was is not None:
+                        sys.stderr.write("[prismor] enforcement resumed by your organization.\n")
         except Exception:
             pass
 
@@ -3689,9 +3716,15 @@ def _print_status_overview(workspace: Path) -> None:
     except Exception:
         _pstate = None
     if _pstate is not None:
+        _by_org = _pstate.get("source") == "org"
         if _pstate.get("until"):
             _until = datetime.fromtimestamp(float(_pstate["until"])).strftime("%H:%M")
             _pmsg = f"yes — auto-resumes {_until}"
+            if _by_org:
+                _pmsg = f"by your organization — auto-resumes {_until}"
+        elif _by_org:
+            # `prismor resume` can't lift this one; don't suggest it.
+            _pmsg = "by your organization — ask an admin to resume it in the console"
         else:
             _pmsg = "yes — run `prismor resume` to re-enable"
         if _pstate.get("reason"):

--- a/prismor/runtime/enterprise/remote_policy.py
+++ b/prismor/runtime/enterprise/remote_policy.py
@@ -258,10 +258,20 @@ def check_and_refresh(interval: Optional[float] = None) -> bool:
         latest_tool_tags_sig is not None
         and str(latest_tool_tags_sig) != str(_current_tool_tags_sig())
     )
+    # The org's pause/resume for THIS machine (settings.device_pause) is served
+    # in the resolved policy without a version bump. Only its signature appears
+    # here — never the pause itself — because this endpoint is unsigned, and a
+    # pause the runtime obeys is a remote off-switch for enforcement. Seeing the
+    # signature change is enough to trigger a signed re-pull.
+    latest_pause_sig = body.get("pauseSig")
+    pause_changed = (
+        latest_pause_sig is not None
+        and str(latest_pause_sig) != str(_current_pause_sig())
+    )
     if (version_changed or profile_changed or capture_changed
             or repos_changed or controls_changed or rule_ex_changed
             or egress_changed or tool_denies_changed or subject_controls_changed
-            or device_mode_changed or tool_tags_changed):
+            or device_mode_changed or tool_tags_changed or pause_changed):
         return fetch(force=True)
     return False
 
@@ -390,6 +400,44 @@ def _current_device_mode() -> str:
         return mode if mode in ("observe", "enforce") else ""
     except Exception:
         return ""
+
+
+def _current_pause_sig() -> str:
+    """Signature of the cached policy's org pause/resume (settings.device_pause),
+    matching the server's ``pauseSig`` format (canonical JSON → sha256 → 16 hex;
+    empty when the org has no pause opinion) so the device re-pulls the moment
+    an admin pauses or resumes it from the console."""
+    try:
+        pol = verify_and_load()
+        pause = ((pol or {}).get("settings") or {}).get("device_pause")
+        if not isinstance(pause, dict) or not pause:
+            return ""
+        import hashlib
+        blob = json.dumps(pause, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def remote_pause() -> Optional[Dict[str, Any]]:
+    """The org's pause/resume record for this machine from the cached SIGNED
+    policy, or None when the org has no opinion.
+
+    Read through ``verify_and_load`` so an unverified or tampered policy file
+    yields nothing rather than a forged pause — this is the one setting whose
+    whole job is to stop Prismor blocking, so it must never be honored unsigned.
+    """
+    try:
+        pol = verify_and_load()
+        pause = ((pol or {}).get("settings") or {}).get("device_pause")
+        if not isinstance(pause, dict):
+            return None
+        state = str(pause.get("state") or "")
+        if state not in ("paused", "resumed") or not pause.get("at"):
+            return None
+        return pause
+    except Exception:
+        return None
 
 
 def _current_egress_sig() -> str:

--- a/prismor/runtime/pause.py
+++ b/prismor/runtime/pause.py
@@ -152,12 +152,73 @@ def _read_raw() -> Optional[Dict[str, Any]]:
         return None
 
 
-def active_state() -> Optional[Dict[str, Any]]:
-    """The pause record if this machine is currently paused, else None.
+def _parse_iso(text: Any) -> Optional[float]:
+    """Epoch seconds from an ISO-8601 timestamp, or None. Accepts the trailing
+    ``Z`` the control plane emits, which fromisoformat rejects before 3.11."""
+    if not isinstance(text, str) or not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
 
-    If a ``--for`` window has elapsed the marker is cleared (auto-resume) and
-    None is returned, so the caller falls through to normal screening. Never
-    raises."""
+
+def org_state() -> Optional[Dict[str, Any]]:
+    """The org's pause/resume for this machine from the cached SIGNED policy,
+    normalized to the same shape as a local marker, or None.
+
+    Only ever read from a verified policy (see remote_policy.remote_pause), so
+    an unsigned or tampered file can't talk this machine out of enforcing. An
+    org pause past its ``until`` resolves to None — protection heals itself even
+    if nobody clears it in the console."""
+    try:
+        from prismor.runtime.enterprise import remote_policy as _remote
+        rec = _remote.remote_pause()
+    except Exception:
+        return None
+    if not rec:
+        return None
+    at = _parse_iso(rec.get("at"))
+    if at is None:
+        return None
+    state = rec.get("state")
+    until = _parse_iso(rec.get("until"))
+    if state == "paused" and until is not None and _now() >= until:
+        return None
+    return {
+        "schema": _SCHEMA,
+        "paused": state == "paused",
+        "state": state,
+        "source": "org",
+        "hard": until is None,
+        "at": at,
+        "until": until,
+        "reason": rec.get("reason") or "",
+        "by": rec.get("by") or "",
+    }
+
+
+def active_state() -> Optional[Dict[str, Any]]:
+    """The pause record if enforcement is currently paused on this machine,
+    else None. Never raises.
+
+    Two sources, resolved by timestamp:
+
+    * An ORG pause (pushed from the console) wins outright. ``prismor resume``
+      cannot lift it — same precedence as the org agent kill switch, where a
+      local re-enable can't override a fleet-wide disable.
+    * An ORG resume clears a local pause marker OLDER than it, so an admin can
+      bring back a machine they have no shell access to. A later local
+      ``prismor pause`` still wins, so developers keep the ability to pause
+      their own box.
+
+    A local ``--for`` window that has elapsed clears the marker (auto-resume)
+    and returns None, so the caller falls through to normal screening.
+    """
+    org = org_state()
+    if org is not None and org.get("paused"):
+        return org
+
     rec = _read_raw()
     if rec is None:
         return None
@@ -169,6 +230,21 @@ def active_state() -> Optional[Dict[str, Any]]:
                 return None
         except (TypeError, ValueError):
             pass
+
+    # An org resume issued after this marker was written overrides it. Clear the
+    # marker rather than just ignoring it, so the machine converges on one
+    # answer and `prismor status` doesn't keep claiming a pause that isn't
+    # in effect.
+    if org is not None and org.get("state") == "resumed":
+        try:
+            local_at = float(rec.get("at") or 0)
+        except (TypeError, ValueError):
+            local_at = 0.0
+        if float(org.get("at") or 0) >= local_at:
+            clear_paused()
+            return None
+
+    rec.setdefault("source", "local")
     return rec
 
 
@@ -183,6 +259,12 @@ def beat(agent: Optional[str] = None, state: Optional[Dict[str, Any]] = None) ->
     uploaded a record."""
     rec = state or active_state()
     if rec is None:
+        return False
+    # An ORG pause came FROM the control plane, so reporting it back tells it
+    # nothing it doesn't already know — and there's no local marker to stamp
+    # last_beat onto, so every call would re-upload. Normal screening telemetry
+    # keeps lastSeenAt fresh in that case.
+    if rec.get("source") == "org":
         return False
     now = _now()
     try:

--- a/tests/test_pause_org.py
+++ b/tests/test_pause_org.py
@@ -1,0 +1,144 @@
+"""Org (console-pushed) pause/resume and how it resolves against a local one.
+
+The precedence here is the whole feature, and every case is a way for a machine
+to end up enforcing when it shouldn't (or not enforcing when it should), so each
+one is pinned separately.
+"""
+
+import os
+import sys
+import time
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime import pause
+
+
+def iso(ts: float) -> str:
+    """Control-plane wire format: UTC ISO-8601 with a trailing Z."""
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def org(state, at, until=None, reason=""):
+    rec = {"state": state, "at": iso(at)}
+    if until is not None:
+        rec["until"] = iso(until)
+    if reason:
+        rec["reason"] = reason
+    return rec
+
+
+class OrgPauseBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._env = patch.dict(os.environ, {"PRISMOR_HOME": self._tmp})
+        self._env.start()
+        # Stand in for the signed-policy read; the real one goes through
+        # remote_policy.verify_and_load, which is covered by its own tests.
+        self._remote = patch("prismor.runtime.enterprise.remote_policy.remote_pause")
+        self.remote_pause = self._remote.start()
+        self.remote_pause.return_value = None
+
+    def tearDown(self):
+        self._remote.stop()
+        self._env.stop()
+
+
+class TestOrgPause(OrgPauseBase):
+    def test_org_pause_alone_suspends_enforcement(self):
+        self.remote_pause.return_value = org("paused", time.time() - 60)
+        state = pause.active_state()
+        self.assertIsNotNone(state)
+        self.assertEqual(state["source"], "org")
+        self.assertTrue(state["paused"])
+
+    def test_local_resume_cannot_lift_an_org_pause(self):
+        # The developer pauses, then runs `prismor resume` — which clears the
+        # local marker. The org pause must survive that.
+        pause.set_paused(reason="local")
+        self.remote_pause.return_value = org("paused", time.time() - 60, reason="incident 412")
+        pause.clear_paused()
+        state = pause.active_state()
+        self.assertIsNotNone(state)
+        self.assertEqual(state["source"], "org")
+        self.assertEqual(state["reason"], "incident 412")
+
+    def test_org_pause_outranks_a_live_local_pause(self):
+        pause.set_paused(reason="local")
+        self.remote_pause.return_value = org("paused", time.time() - 10, reason="org")
+        self.assertEqual(pause.active_state()["source"], "org")
+
+    def test_expired_org_pause_heals_itself(self):
+        now = time.time()
+        self.remote_pause.return_value = org("paused", now - 7200, until=now - 60)
+        self.assertIsNone(pause.active_state())
+
+    def test_org_pause_inside_its_window_still_applies(self):
+        now = time.time()
+        self.remote_pause.return_value = org("paused", now - 60, until=now + 3600)
+        self.assertIsNotNone(pause.active_state())
+
+    def test_malformed_org_record_is_ignored(self):
+        # Fail toward enforcing: anything we can't read means "no pause".
+        for bad in ({}, {"state": "paused"}, {"state": "nonsense", "at": iso(time.time())},
+                    {"state": "paused", "at": "not-a-date"}):
+            self.remote_pause.return_value = bad
+            self.assertIsNone(pause.active_state(), bad)
+
+    def test_unreadable_policy_does_not_pause(self):
+        self.remote_pause.side_effect = RuntimeError("bad signature")
+        self.assertIsNone(pause.active_state())
+
+
+class TestOrgResume(OrgPauseBase):
+    def test_org_resume_clears_an_older_local_pause(self):
+        # The admin's "spin it up again from here" case: no shell access to the
+        # machine, but the local marker still has to go.
+        pause.set_paused(reason="local")
+        self.remote_pause.return_value = org("resumed", time.time() + 5)
+        self.assertIsNone(pause.active_state())
+        # And converges — the marker is gone, not merely ignored.
+        self.assertFalse(pause.pause_path().exists())
+
+    def test_a_newer_local_pause_wins_over_an_older_org_resume(self):
+        # Developers keep the ability to pause their own box after an admin has
+        # resumed it; otherwise one console click locks them out for good.
+        self.remote_pause.return_value = org("resumed", time.time() - 3600)
+        pause.set_paused(reason="local, after the resume")
+        state = pause.active_state()
+        self.assertIsNotNone(state)
+        self.assertEqual(state["source"], "local")
+
+    def test_org_resume_with_no_local_pause_is_a_no_op(self):
+        self.remote_pause.return_value = org("resumed", time.time())
+        self.assertIsNone(pause.active_state())
+
+    def test_org_resume_never_expires(self):
+        # A resume is a point-in-time event; an `until` on it must not make it
+        # lapse back into a pause.
+        now = time.time()
+        pause.set_paused()
+        # The resume is unambiguously newer than the local marker, so only its
+        # long-past `until` could bring the pause back — and must not.
+        self.remote_pause.return_value = org("resumed", now + 5, until=now - 60)
+        self.assertIsNone(pause.active_state())
+
+
+class TestOrgHeartbeat(OrgPauseBase):
+    def test_no_heartbeat_for_an_org_pause(self):
+        # The control plane set it, so reporting it back tells it nothing — and
+        # there's no local marker to stamp last_beat onto, so an unguarded beat
+        # would re-upload on every single tool call.
+        self.remote_pause.return_value = org("paused", time.time() - 60)
+        state = pause.active_state()
+        with patch("prismor.runtime.sinks.upload_telemetry") as up:
+            self.assertFalse(pause.beat(agent="claude", state=state))
+            up.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pause_refresh_trigger.py
+++ b/tests/test_pause_refresh_trigger.py
@@ -1,0 +1,122 @@
+"""A changed pauseSig must actually trigger the signed re-pull.
+
+The sig-compare block in check_and_refresh is a long chain of near-identical
+clauses, and a new one that is computed but left out of the final `if` is both
+easy to write and invisible — it just means the feature silently never
+propagates (exactly the bug the toolTagsSig comment in that function records).
+This pins the wiring, not the hashing.
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import urllib.request
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.enterprise import identity, remote_policy
+
+# What the server sends when nothing at all has changed for this device.
+STEADY_STATE = {
+    "version": 3,
+    "profileId": "prof_1",
+    "fullCapture": False,
+    "deviceMode": "",
+    "managedReposSig": "",
+    "agentControlsSig": "",
+    "ruleExemptionsSig": "",
+    "toolDeniesSig": "",
+    "subjectControlsSig": "",
+    "toolTagsSig": "",
+    "egressSig": "",
+    "pauseSig": "",
+}
+
+
+class PauseRefreshTrigger(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._env = patch.dict(os.environ, {"PRISMOR_HOME": self._tmp})
+        self._env.start()
+        identity.save_identity({
+            "device_id": "d1", "org_id": "o1", "user_id": "u1",
+            "device_key": "prism_dev_x", "api_base": "http://127.0.0.1:1",
+        })
+        # Pin EVERY channel the refresh check compares, not just the pause one,
+        # so STEADY_STATE is a genuine no-op and any re-pull below is
+        # attributable to pauseSig alone. Leaving the other nine to fall through
+        # to real reads makes this test depend on the cached-policy state, which
+        # other suites in this repo are known to leak into.
+        self._patches = [
+            patch.object(remote_policy, "current_version", return_value=3),
+            patch.object(remote_policy, "current_profile_id", return_value="prof_1"),
+            patch.object(remote_policy, "current_full_capture", return_value=False),
+            patch.object(remote_policy, "_current_managed_repos_sig", return_value=""),
+            patch.object(remote_policy, "_current_agent_controls_sig", return_value=""),
+            patch.object(remote_policy, "_current_rule_exemptions_sig", return_value=""),
+            patch.object(remote_policy, "_current_tool_denies_sig", return_value=""),
+            patch.object(remote_policy, "_current_subject_controls_sig", return_value=""),
+            patch.object(remote_policy, "_current_tool_tags_sig", return_value=""),
+            patch.object(remote_policy, "_current_egress_sig", return_value=""),
+            patch.object(remote_policy, "_current_device_mode", return_value=""),
+        ]
+        self._pause_sig = patch.object(remote_policy, "_current_pause_sig", return_value="")
+        self._patches.append(self._pause_sig)
+        for p in self._patches:
+            p.start()
+        # Other suites here monkeypatch identity module-wide without always
+        # undoing it; assert our own enrolled, non-revoked state explicitly.
+        self._ident = patch.object(remote_policy._identity, "revoked_backoff_active", return_value=False)
+        self._ident.start()
+        self._fetch = patch.object(remote_policy, "fetch", return_value=True)
+        self.fetch = self._fetch.start()
+
+    def tearDown(self):
+        self._fetch.stop()
+        self._ident.stop()
+        for p in self._patches:
+            p.stop()
+        self._env.stop()
+
+    def _respond(self, body):
+        class _Resp(io.BytesIO):
+            def __enter__(self_inner): return self_inner
+            def __exit__(self_inner, *a): return False
+        return patch.object(urllib.request, "urlopen",
+                            return_value=_Resp(json.dumps(body).encode("utf-8")))
+
+    def test_no_repull_when_nothing_changed(self):
+        with self._respond(STEADY_STATE):
+            self.assertFalse(remote_policy.check_and_refresh(interval=0))
+        self.fetch.assert_not_called()
+
+    def test_a_new_pause_triggers_a_signed_repull(self):
+        with self._respond({**STEADY_STATE, "pauseSig": "57c0ab6b692feadf"}):
+            self.assertTrue(remote_policy.check_and_refresh(interval=0))
+        self.fetch.assert_called_once_with(force=True)
+
+    def test_a_lifted_pause_triggers_a_repull_too(self):
+        # Resuming has to reach the device as reliably as pausing it, or a
+        # machine stays unprotected until something unrelated churns.
+        # Nested patch: overrides the setUp one and restores back to it, so a
+        # failure here can't leave the class-wide patch torn down.
+        with patch.object(remote_policy, "_current_pause_sig", return_value="57c0ab6b692feadf"):
+            with self._respond({**STEADY_STATE, "pauseSig": ""}):
+                self.assertTrue(remote_policy.check_and_refresh(interval=0))
+        self.fetch.assert_called_once_with(force=True)
+
+    def test_an_older_server_omitting_pausesig_is_not_a_change(self):
+        # Absent field != changed field. A control plane that predates this
+        # feature must not put every device into a permanent re-pull loop.
+        body = {k: v for k, v in STEADY_STATE.items() if k != "pauseSig"}
+        with self._respond(body):
+            self.assertFalse(remote_policy.check_and_refresh(interval=0))
+        self.fetch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pause_sig_contract.py
+++ b/tests/test_pause_sig_contract.py
@@ -1,0 +1,117 @@
+"""The device half of the pause propagation contract.
+
+``/api/policy/version`` sends ``pauseSig``; this machine recomputes it from the
+``settings.device_pause`` block in its cached signed policy and re-pulls when
+they differ. If the two hashers ever disagree, the device re-pulls on EVERY
+heartbeat forever — a silent, uncapped request loop that neither side's own
+tests would catch.
+
+The fixture and expected digest below are the SAME ones pinned server-side in
+prismor-web/__tests__/api/policy-pause-propagation.test.ts. Change one, change
+both — that is the point of pinning rather than recomputing.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.enterprise import remote_policy
+
+# Exactly what composeBundle serves for a paused device, and the 16 hex chars
+# blockSig() produces for it.
+SERVED_PAUSE = {
+    "state": "paused",
+    "at": "2026-07-30T12:00:00.000Z",
+    "until": "2099-01-01T00:00:00.000Z",
+    "reason": "incident 412",
+    "by": "user_1",
+}
+EXPECTED_SIG = "57c0ab6b692feadf"
+
+
+def policy(pause_block):
+    settings = {} if pause_block is None else {"device_pause": pause_block}
+    return {"version": "1.0", "rules": [], "settings": settings}
+
+
+class TestPauseSigContract(unittest.TestCase):
+    def sig_for(self, pause_block):
+        with patch.object(remote_policy, "verify_and_load", return_value=policy(pause_block)):
+            return remote_policy._current_pause_sig()
+
+    def test_matches_the_server_digest_byte_for_byte(self):
+        self.assertEqual(self.sig_for(SERVED_PAUSE), EXPECTED_SIG)
+
+    def test_key_order_on_the_wire_does_not_change_the_digest(self):
+        # JSON object order is not meaningful, and the server's key order is an
+        # implementation detail of how the record is built. Canonicalisation has
+        # to absorb that or the digests drift for no reason at all.
+        reordered = {k: SERVED_PAUSE[k] for k in reversed(list(SERVED_PAUSE))}
+        self.assertEqual(self.sig_for(reordered), EXPECTED_SIG)
+
+    def test_no_pause_signs_empty(self):
+        # Must be "" and not the hash of {}, to match the server's empty-string
+        # sentinel — otherwise every unpaused device re-pulls forever.
+        self.assertEqual(self.sig_for(None), "")
+        self.assertEqual(self.sig_for({}), "")
+
+    def test_every_distinct_pause_gets_a_distinct_digest(self):
+        variants = [
+            SERVED_PAUSE,
+            {**SERVED_PAUSE, "state": "resumed"},
+            {**SERVED_PAUSE, "at": "2026-07-30T12:00:01.000Z"},
+            {**SERVED_PAUSE, "reason": "something else"},
+            {k: v for k, v in SERVED_PAUSE.items() if k != "until"},
+        ]
+        sigs = [self.sig_for(v) for v in variants]
+        self.assertEqual(len(set(sigs)), len(variants))
+
+    def test_unreadable_policy_signs_empty_rather_than_raising(self):
+        # This runs on the hot path of every tool call; it must never throw.
+        with patch.object(remote_policy, "verify_and_load", side_effect=RuntimeError("bad signature")):
+            self.assertEqual(remote_policy._current_pause_sig(), "")
+
+    def test_a_non_dict_block_is_ignored(self):
+        for junk in ("paused", 1, [], None):
+            self.assertEqual(self.sig_for(junk), "")
+
+
+class TestRemotePauseRead(unittest.TestCase):
+    """remote_pause() is what actually turns enforcement off, so it rejects
+    anything it can't fully understand rather than guessing."""
+
+    def read(self, pause_block):
+        with patch.object(remote_policy, "verify_and_load", return_value=policy(pause_block)):
+            return remote_policy.remote_pause()
+
+    def test_reads_a_well_formed_pause(self):
+        self.assertEqual(self.read(SERVED_PAUSE), SERVED_PAUSE)
+
+    def test_reads_a_resume(self):
+        rec = {"state": "resumed", "at": "2026-07-30T12:00:00.000Z"}
+        self.assertEqual(self.read(rec), rec)
+
+    def test_rejects_a_record_with_no_timestamp(self):
+        # Precedence against a local pause is decided by time; without one there
+        # is no safe answer, so refuse to act on it.
+        self.assertIsNone(self.read({"state": "paused"}))
+
+    def test_rejects_an_unknown_state(self):
+        self.assertIsNone(self.read({"state": "halted", "at": "2026-07-30T12:00:00.000Z"}))
+
+    def test_unverified_policy_yields_no_pause(self):
+        # verify_and_load raising is how a tampered or unsigned policy presents.
+        # Failing toward "keep enforcing" is the only safe direction here.
+        with patch.object(remote_policy, "verify_and_load", side_effect=RuntimeError("bad signature")):
+            self.assertIsNone(remote_policy.remote_pause())
+
+    def test_no_policy_at_all_yields_no_pause(self):
+        with patch.object(remote_policy, "verify_and_load", return_value=None):
+            self.assertIsNone(remote_policy.remote_pause())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Pause was local-only: `prismor pause` wrote `~/.prismor/pause.json` and a heartbeat told the control plane about it. The console could display that but not act on it — an admin looking at a paused machine had no way to resume it without shell access to that box.

This reads the org's pause/resume out of the **signed** policy (`settings.device_pause`) and resolves it against the local marker by timestamp.

## Precedence

| | |
|---|---|
| **org pause** | Wins outright. `prismor resume` cannot lift it — the same precedence the org agent kill switch already has, where a local re-enable can't override a fleet-wide disable. |
| **org resume** | Clears a local marker **older** than it, so an admin can bring a machine back remotely. A later local `prismor pause` still wins, so developers keep the ability to pause their own box. |

## Fail direction

Read through `verify_and_load`, so an unsigned or tampered policy yields nothing rather than a forged pause. This is the one setting whose entire job is to stop Prismor blocking, so every failure path leans toward *keep enforcing*: an unreadable policy, a malformed record, a missing timestamp, an unknown state, and a lapsed window all resolve to not-paused.

## Propagation

`pauseSig` joins the other nine signatures on the `/api/policy/version` hot path, so a console pause reaches the device within one debounce (~30s).

It also re-reads pause state **right after** a policy refresh in `hook-dispatch`, so the flip takes effect on *that* tool call rather than the next one — the admin pauses, and the agent's very next tool call already honors it.

## UX

`prismor resume` and `prismor status` now say when a pause came from the org, instead of suggesting a command that can't lift it:

```
⏸  Still paused by your organization — this was pushed from the Prismor console. Reason: "incident 412".
   Ask an admin to resume it there; `prismor resume` cannot lift an org pause.
```

No heartbeat for an org pause: the control plane set it, so reporting it back tells it nothing — and there's no local marker to stamp `last_beat` onto, so an unguarded beat would re-upload on every single tool call.

## Testing

28 new tests across precedence, the sig contract, and the refresh wiring. Full suite: 1406 passed, with the same 24 pre-existing (environment-related) failures as `main` — no regressions.

Verified end-to-end by driving the real CLI against a simulated org pause, patching only `verify_and_load` (the signature boundary) so every layer below it is the real code path: local pause/resume, org pause surviving `prismor resume`, org resume clearing a local marker, and the `status` wording.

The sig contract is **pinned against the identical fixture** the web test pins, in both repos. A drift there is an uncapped re-pull loop on every heartbeat that neither side's own tests would catch.

## Notes

- Requires the matching prismor-web change to serve `settings.device_pause`. An older control plane simply omits `pauseSig`, which is correctly read as "no opinion" rather than as a change — pinned by a test, since otherwise every device would sit in a permanent re-pull loop.