### PR TITLE
feat(cloaking): env-guard — agent-safe .env ingestion, deny reads until imported

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1804,6 +1804,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     enable_userprompt_guard=not args.no_userprompt_guard,
                     enable_secret_guard=not args.no_secret_guard,
                     enable_read_guard=not args.no_read_guard,
+                    enable_env_guard=not args.no_env_guard,
                     enable_sweep_on_stop=args.sweep_on_stop,
                 )
                 print(f"Installed Claude Code cloaking hooks at {result['configPath']}")
@@ -2815,6 +2816,9 @@ def build_parser() -> argparse.ArgumentParser:
                            help="Skip the PreToolUse detect-and-block hook for raw secrets in tool calls")
     t_install.add_argument("--no-read-guard", action="store_true",
                            help="Skip the PreToolUse hook that denies reading files containing a registered secret")
+    t_install.add_argument("--no-env-guard", action="store_true",
+                           help="Skip the PreToolUse hook that denies reading .env-style files whose entries "
+                                "are not yet imported into the vault (prismor cloak add --env-file)")
     t_install.add_argument("--sweep-on-stop", action="store_true",
                            help="Also wire a Stop-hook dry-run sweep for residue detection")
 

--- a/prismor/runtime/cloaking/README.md
+++ b/prismor/runtime/cloaking/README.md
@@ -49,12 +49,13 @@ From inside a project:
 prismor cloak install
 ```
 
-This merges four hook entries into `.claude/settings.json` (preserving any Prismor runtime-monitor hooks already there):
+This merges the hook entries into `.claude/settings.json` (preserving any Prismor runtime-monitor hooks already there):
 
 | Event | Matcher | Script | Purpose |
 |---|---|---|---|
 | `PreToolUse` | `Bash\|Write\|Edit\|MultiEdit\|mcp__.*` | `secret-guard.sh` | Detect raw secrets in tool input, vault + deny |
 | `PreToolUse` | `Read` | `read-guard.sh` | Deny a Read of a file that holds a registered secret |
+| `PreToolUse` | `Read\|Bash` | `env-guard.sh` | Deny content access to a dotenv file until its entries are imported into the vault |
 | `PreToolUse` | `Bash` | `decloak.sh` | Substitute placeholders, wrap output through `scrub-stream.sh` |
 | `PostToolUse` | `mcp__.*` | `recloak-mcp.sh` | Scrub real values from MCP responses |
 | `UserPromptSubmit` | — | `userprompt-guard.sh` | Soft-block + auto-cloak pasted secrets |
@@ -70,8 +71,38 @@ Flags:
 prismor cloak install --scope user           # install globally in ~/.claude
 prismor cloak install --no-userprompt-guard  # skip the paste-detection hook
 prismor cloak install --no-secret-guard      # skip the tool-call detect-and-block hook
+prismor cloak install --no-env-guard         # skip the unimported-.env bootstrap guard
 prismor cloak install --sweep-on-stop        # add the Stop-hook sweep
 ```
+
+### The bootstrap gap (`env-guard.sh`)
+
+`read-guard.sh` and the decloak output scrub only protect values **already
+registered** in the vault. Without `env-guard.sh`, the very first thing an
+agent does in a fresh workspace — `cat .env` or `Read(.env)` — leaks every
+secret before any of them has a placeholder.
+
+`env-guard.sh` denies content access (built-in `Read`, or a Bash command that
+reads content: `cat`, `head`, `sed`, a bare `grep`, `< .env` redirection, …)
+to a dotenv-style file **while it holds values missing from the vault**, and
+the deny reason is itself the fix:
+
+```
+prismor cloak add --env-file .env
+```
+
+That command parses the file in the CLI process and registers every entry as
+its own `@@SECRET:name@@` placeholder — only names and byte counts are ever
+printed, so the values never enter model context. Once every entry is
+imported, the guard stands down and the registration-based hooks take over.
+The unimported-entry check runs through the same parser the importer uses
+(`env_guard.py` → `secrets_store._parse_env_line`), so guard and importer can
+never disagree about what "fully imported" means.
+
+Deliberately allowed even before import: `prismor cloak …` commands (the
+ingestion path), append-only writes (`echo KEY=@@SECRET:KEY@@ >> .env`), and
+presence checks (`grep -q '^KEY=' .env`). Example/sample/template env files
+are exempt — reading those is how an agent learns which keys a project needs.
 
 Uninstall leaves unrelated Claude Code settings untouched:
 
@@ -228,6 +259,7 @@ prismor/runtime/cloaking/
 ├── __init__.py             # public API re-exports
 ├── installer.py            # install/uninstall settings.json merger
 ├── secrets_store.py        # add/list/remove operations on $PRISMOR_SECRETS_DIR
+├── env_guard.py            # unimported-entry check shared with env-guard.sh
 ├── patterns.py             # built-in + custom detection-pattern management
 ├── builtin_patterns.txt    # single source of truth for detection regexes
 ├── hooks/
@@ -235,6 +267,7 @@ prismor/runtime/cloaking/
 │   ├── decloak.sh          # PreToolUse:Bash — placeholder substitution + output scrub
 │   ├── scrub-stream.sh     # stdin filter — masks registered secrets in command output
 │   ├── read-guard.sh       # PreToolUse:Read — deny reads of secret-bearing files
+│   ├── env-guard.sh        # PreToolUse:Read|Bash — deny access to unimported .env files
 │   ├── secret-guard.sh     # PreToolUse — detect raw secrets, vault + deny
 │   ├── recloak-mcp.sh      # PostToolUse:mcp__.*
 │   ├── userprompt-guard.sh # UserPromptSubmit soft-block
@@ -242,4 +275,8 @@ prismor/runtime/cloaking/
 └── README.md               # this file
 ```
 
-Hook scripts are pure bash and depend only on `jq`. No Python startup cost on the hot path.
+Hook scripts are pure bash and depend only on `jq`. No Python startup cost on
+the hot path — the one exception is `env-guard.sh`, which shells out to
+`env_guard.py` only after it has already found an existing dotenv-style file
+in the tool input (so the common case stays bash-only), because the
+unimported-entry check must share the importer's parser.

--- a/prismor/runtime/cloaking/env_guard.py
+++ b/prismor/runtime/cloaking/env_guard.py
@@ -1,0 +1,95 @@
+"""Unprotected-entry check for env-guard.sh.
+
+``env-guard.sh`` denies a Read or a content-reading Bash command that targets
+a dotenv-style file *only while that file holds values not yet registered in
+the cloak vault* — once every entry is imported (``prismor cloak add
+--env-file``), the guard stands down and the existing hooks take over
+(read-guard denies Reads of registered values; decloak's output scrub masks
+them in Bash output).
+
+The "is this file fully imported?" question must be answered with exactly the
+same parsing the import path uses, or a file could look unprotected forever
+after a successful import. That is why this lives in Python next to
+``secrets_store`` instead of being re-implemented in the hook's bash: both
+sides share ``_parse_env_line``.
+
+Invoked by the hook as:
+
+    python3 -c 'from prismor.runtime.cloaking.env_guard import main; main()' FILE...
+
+and prints a JSON object: ``{"files": {path: [entry names...]}, "total": N}``
+listing, per file, the KEY names (never values) whose values are absent from
+the vault. Parse errors are treated leniently — a malformed line is skipped
+rather than failing the whole file, so one odd line cannot mask real secrets
+on the lines around it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Set
+
+from prismor.runtime.cloaking.secrets_store import _parse_env_line, secrets_dir
+
+# Values shorter than this are ignored, mirroring read-guard.sh's minimum —
+# tiny values ("1", "true", "dev") are config, not secrets, and matching them
+# against the vault would be noise either way.
+MIN_VALUE_LEN = 4
+
+
+def vault_values() -> Set[str]:
+    """Every registered secret value, read fresh from the vault."""
+    values: Set[str] = set()
+    sdir = secrets_dir()
+    if not sdir.is_dir():
+        return values
+    for child in sdir.iterdir():
+        if not child.is_file():
+            continue
+        try:
+            values.add(child.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+    return values
+
+
+def unprotected_entries(path: Path, vault: Set[str] | None = None) -> List[str]:
+    """KEY names in ``path`` whose values are not registered in the vault."""
+    if vault is None:
+        vault = vault_values()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    names: List[str] = []
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        try:
+            item = _parse_env_line(raw_line, line_no)
+        except ValueError:
+            continue
+        if item is None:
+            continue
+        key, value = item
+        if len(value) < MIN_VALUE_LEN:
+            continue
+        if value not in vault:
+            names.append(key)
+    return names
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = sys.argv[1:] if argv is None else argv
+    vault = vault_values()
+    files: Dict[str, List[str]] = {}
+    total = 0
+    for arg in args:
+        names = unprotected_entries(Path(arg), vault)
+        if names:
+            files[arg] = names
+            total += len(names)
+    print(json.dumps({"files": files, "total": total}))
+
+
+if __name__ == "__main__":
+    main()

--- a/prismor/runtime/cloaking/hooks/env-guard.sh
+++ b/prismor/runtime/cloaking/hooks/env-guard.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Prismor — cloaking PreToolUse hook (Claude Code, Read|Bash matcher).
+#
+# Closes the BOOTSTRAP gap. read-guard.sh and the decloak output scrub only
+# protect values already registered in the vault — so the very first thing an
+# agent does in a fresh workspace, `cat .env` or Read(.env), leaks every secret
+# before any of them has a placeholder. This hook denies content access to a
+# dotenv-style file WHILE it holds values missing from the vault, and the deny
+# reason itself is the fix: run `prismor cloak add --env-file <path>`, which
+# imports every entry as its own `@@SECRET:name@@` placeholder without the
+# values ever entering model context (the CLI prints names and byte counts
+# only). Once every entry is imported the guard stands down: Reads are then
+# covered by read-guard.sh and Bash output by the decloak scrub.
+#
+# Deliberately allowed even before import:
+#   * `prismor cloak ...` commands — the sanctioned ingestion path.
+#   * Append-only writes (`echo K=V >> .env`) — nothing is read.
+#   * Presence checks (`grep -q/-c/-l KEY .env`) — no content in the output.
+#
+# The "is every entry imported?" check runs in Python (env_guard.py) so it
+# parses env lines exactly like `prismor cloak add --env-file` does; a bash
+# re-implementation that disagreed with the importer could deny forever.
+#
+# Stdin:  Claude Code PreToolUse JSON payload (Read or Bash).
+# Stdout: JSON permissionDecision=deny (unimported env file), else empty.
+set -uo pipefail
+
+_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# hooks/ → cloaking/ → runtime/ → prismor/ → the dir importable as `prismor`.
+_PKG_ROOT="$(cd "$_HOOK_DIR/../../../.." && pwd)"
+
+command -v jq >/dev/null 2>&1 || exit 0   # no jq → silent no-op; decloak fails loud
+
+input="$(cat)"
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[[ "$tool_name" == "Read" || "$tool_name" == "Bash" ]] || exit 0
+
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty')"
+[[ -n "$cwd" ]] || cwd="$PWD"
+
+# ── env-style filename test (basename) ──────────────────────────────────────
+# Matches .env, .env.production, secrets.env, prod.env.bak, ...
+# Skips example/sample/template/dist files — those hold placeholders, and
+# reading them is how an agent learns which keys a project needs.
+_is_env_basename() {
+  local base lower
+  base="$(basename -- "$1")"
+  lower="$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    *example*|*sample*|*template*|*dist*) return 1 ;;
+  esac
+  case "$lower" in
+    .env|.env.*|*.env|*.env.*) return 0 ;;
+  esac
+  return 1
+}
+
+# ── check files with the shared Python parser; deny if any entry unimported ─
+# $1 = human label for what was attempted; remaining args = existing env files.
+_deny_if_unprotected() {
+  local how="$1"; shift
+  [[ $# -gt 0 ]] || return 0
+  local report
+  report="$(PYTHONPATH="$_PKG_ROOT${PYTHONPATH:+:$PYTHONPATH}" python3 -c \
+    'from prismor.runtime.cloaking.env_guard import main; main()' "$@" 2>/dev/null)" || return 0
+  [[ -n "$report" ]] || return 0
+  local total
+  total="$(printf '%s' "$report" | jq -r '.total // 0')"
+  [[ "$total" -gt 0 ]] 2>/dev/null || return 0
+  local file names
+  file="$(printf '%s' "$report" | jq -r '.files | keys[0]')"
+  names="$(printf '%s' "$report" | jq -r --arg f "$file" '.files[$f] | join(", ")')"
+  reason="Prismor cloaking: $how '$file', which holds $total value(s) not yet in the cloak vault ($names) — its contents would enter the model context unprotected. First run: prismor cloak add --env-file '$file' — this imports every entry as an @@SECRET:name@@ placeholder without exposing any value (only names and byte counts are printed). Then reference values by placeholder; if you only need to know whether a key exists, use a presence check like: grep -q '^KEY=' '$file'"
+  jq -n --arg r "$reason" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+}
+
+# ── Read: deny reads of env files with unimported entries ───────────────────
+if [[ "$tool_name" == "Read" ]]; then
+  file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+  [[ -n "$file_path" && -f "$file_path" ]] || exit 0
+  _is_env_basename "$file_path" || exit 0
+  _deny_if_unprotected "reading" "$file_path"
+  exit 0
+fi
+
+# ── Bash: deny content-reading commands that target such files ──────────────
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+[[ -n "$cmd" ]] || exit 0
+[[ "$cmd" == *env* ]] || exit 0   # cheap fast path
+
+# The sanctioned ingestion path (`prismor cloak add --env-file`, list, ...)
+# names the file but never prints values — always allowed.
+if [[ "$cmd" =~ (^|[[:space:]])prismor[[:space:]]+cloak([[:space:]]|$) ]]; then
+  exit 0
+fi
+
+# Collect existing env-style files referenced by the command.
+env_files=()
+while IFS= read -r tok; do
+  [[ -n "$tok" ]] || continue
+  _is_env_basename "$tok" || continue
+  path="$tok"
+  [[ "$path" == /* || "$path" == "~"* ]] || path="$cwd/$path"
+  path="${path/#\~\//$HOME/}"
+  [[ -f "$path" ]] || continue
+  env_files+=("$path")
+done < <(printf '%s' "$cmd" | grep -oE '[A-Za-z0-9_.~/-]+' | sort -u)
+[[ ${#env_files[@]} -gt 0 ]] || exit 0
+
+# Is this command actually READING content? Appends and presence checks pass.
+is_reader=0
+_READERS='(^|[;&|(`[:space:]])(sudo[[:space:]]+)?(cat|bat|head|tail|less|more|most|nl|tac|strings|od|xxd|hexdump|column|paste|sort|uniq|rev|cut|tr|sed|awk|gawk|diff|cmp|source|python[0-9.]*|node|ruby|perl)([[:space:]]|$)'
+_GREPPERS='(^|[;&|(`[:space:]])(sudo[[:space:]]+)?(grep|egrep|fgrep|rg|ag|ack)([[:space:]]|$)'
+_PRESENCE_FLAGS='[[:space:]]-(q|c|l|L)([[:space:]]|$)|--(quiet|silent|count|files-with-matches)'
+if [[ "$cmd" =~ $_READERS ]]; then
+  is_reader=1
+elif [[ "$cmd" =~ $_GREPPERS ]]; then
+  # grep-family reads content unless invoked purely as a presence check.
+  if [[ "$cmd" =~ $_PRESENCE_FLAGS ]]; then
+    is_reader=0
+  else
+    is_reader=1
+  fi
+else
+  # Input redirection (`... < .env`) reads without naming a reader utility.
+  for f in "${env_files[@]}"; do
+    base="$(basename -- "$f")"
+    if [[ "$cmd" == *"<$base"* || "$cmd" == *"< $base"* \
+       || "$cmd" == *"<$f"* || "$cmd" == *"< $f"* ]]; then
+      is_reader=1
+      break
+    fi
+  done
+fi
+[[ "$is_reader" -eq 1 ]] || exit 0
+
+_deny_if_unprotected "this command reads" "${env_files[@]}"
+exit 0

--- a/prismor/runtime/cloaking/installer.py
+++ b/prismor/runtime/cloaking/installer.py
@@ -25,6 +25,7 @@ _HOOKS_SUBDIR = Path(__file__).resolve().parent / "hooks"
 _DECLOAK = _HOOKS_SUBDIR / "decloak.sh"
 _SECRET_GUARD = _HOOKS_SUBDIR / "secret-guard.sh"
 _READ_GUARD = _HOOKS_SUBDIR / "read-guard.sh"
+_ENV_GUARD = _HOOKS_SUBDIR / "env-guard.sh"
 _RECLOAK_MCP = _HOOKS_SUBDIR / "recloak-mcp.sh"
 _USERPROMPT_GUARD = _HOOKS_SUBDIR / "userprompt-guard.sh"
 _SWEEP_ON_STOP = _HOOKS_SUBDIR / "sweep-on-stop.sh"
@@ -32,6 +33,7 @@ _KNOWN_HOOK_FILENAMES = {
     _DECLOAK.name,
     _SECRET_GUARD.name,
     _READ_GUARD.name,
+    _ENV_GUARD.name,
     _RECLOAK_MCP.name,
     _USERPROMPT_GUARD.name,
     _SWEEP_ON_STOP.name,
@@ -46,6 +48,9 @@ _LEGACY_MARKERS = (
 # raw secrets in shell commands are caught; the guard is order-independent vs
 # decloak because it skips any value already present in the vault.
 _SECRET_GUARD_MATCHER = "Bash|Write|Edit|MultiEdit|mcp__.*"
+
+# The env-guard covers both the built-in Read tool and Bash reader commands.
+_ENV_GUARD_MATCHER = "Read|Bash"
 
 # All cloaking hook commands share this marker so uninstall can find them.
 _MARKER = "prismor/runtime/cloaking/hooks/"
@@ -152,6 +157,7 @@ def install(
     enable_userprompt_guard: bool = True,
     enable_secret_guard: bool = True,
     enable_read_guard: bool = True,
+    enable_env_guard: bool = True,
     enable_sweep_on_stop: bool = False,
 ) -> Dict[str, Any]:
     """Install the cloaking hooks into ``settings.json``.
@@ -169,6 +175,11 @@ def install(
             file containing a registered secret. The built-in Read tool has no
             output-rewrite channel, so the read is blocked rather than scrubbed;
             the model is told to use the ``@@SECRET:name@@`` placeholder instead.
+        enable_env_guard: Wire the PreToolUse hook that denies Read/Bash content
+            access to a dotenv-style file while it holds values not yet in the
+            vault, directing the model to ``prismor cloak add --env-file``
+            first. Closes the bootstrap gap where an unimported ``.env`` is
+            unprotected by the registration-based guards.
         enable_sweep_on_stop: Wire the Stop-hook dry-run sweep. Off by
             default because it runs ``prismor sweep`` against ``~/.claude``
             on every session end, which is noisy for quick sessions.
@@ -210,6 +221,17 @@ def install(
             {"matcher": "Read", "hooks": [_hook_entry(_READ_GUARD)]},
         )
         installed.append("PreToolUse:Read (read-guard)")
+
+    # PreToolUse: deny content access to env files with unimported entries.
+    # The deny reason routes the model to `prismor cloak add --env-file`, which
+    # ingests every entry without the values entering context; once imported,
+    # read-guard and the decloak output scrub take over and this hook no-ops.
+    if enable_env_guard:
+        hooks["PreToolUse"] = _merge_claude_entries(
+            hooks.get("PreToolUse", []),
+            {"matcher": _ENV_GUARD_MATCHER, "hooks": [_hook_entry(_ENV_GUARD)]},
+        )
+        installed.append(f"PreToolUse:{_ENV_GUARD_MATCHER} (env-guard)")
 
     # PreToolUse: decloak on Bash matcher. Substitutes @@SECRET@@ placeholders
     # and wraps every Bash command so its output is scrubbed of registered

--- a/tests/test_cloak_env_guard.py
+++ b/tests/test_cloak_env_guard.py
@@ -1,0 +1,214 @@
+"""Tests for env-guard.sh — the unimported-.env bootstrap guard.
+
+read-guard.sh and the decloak output scrub only protect values already in the
+vault, so the first `cat .env` / Read(.env) in a fresh workspace leaks every
+secret before any placeholder exists. env-guard.sh denies content access to a
+dotenv-style file while it holds unimported values, points the model at
+`prismor cloak add --env-file`, and stands down once every entry is imported.
+These tests exercise both the Read and Bash decision paths in isolation.
+
+Run:  python3 tests/test_cloak_env_guard.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+_HOME = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+_SECRETS = _HOME / "secrets"
+_SECRETS.mkdir(parents=True)
+os.environ["PRISMOR_HOME"] = str(_HOME)
+os.environ["PRISMOR_SECRETS_DIR"] = str(_SECRETS)
+
+_GUARD = _REPO / "prismor" / "runtime" / "cloaking" / "hooks" / "env-guard.sh"
+
+_API_KEY = "sk-live-CANARY-0123456789abcdef0123456789abcdef"
+_DB_PASS = "hunter2-not-really-a-password"
+
+_WS = _HOME / "ws"
+_WS.mkdir()
+(_WS / ".env").write_text(
+    f"API_KEY={_API_KEY}\n"
+    f'DB_PASSWORD="{_DB_PASS}"\n'
+    "DEBUG=1\n"                       # < MIN_VALUE_LEN — never counted
+)
+(_WS / ".env.example").write_text("API_KEY=your-key-here\nDB_PASSWORD=changeme\n")
+(_WS / "prod.env").write_text(f"TOKEN={_API_KEY}\n")
+(_WS / "notes.txt").write_text("harmless notes\n")
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if ok:
+        _passed += 1
+        print(f"  PASS  {name}")
+    else:
+        _failed += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def run(payload: dict) -> dict | None:
+    proc = subprocess.run(["bash", str(_GUARD)], input=json.dumps(payload),
+                          capture_output=True, text=True, env=os.environ)
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+def read_call(file_path: str) -> dict | None:
+    return run({"tool_name": "Read", "tool_input": {"file_path": file_path},
+                "cwd": str(_WS)})
+
+
+def bash_call(command: str) -> dict | None:
+    return run({"tool_name": "Bash", "tool_input": {"command": command},
+                "cwd": str(_WS)})
+
+
+def denied(res) -> bool:
+    return bool(res) and (
+        res.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+    )
+
+
+def reason(res) -> str:
+    return (res or {}).get("hookSpecificOutput", {}).get(
+        "permissionDecisionReason", "")
+
+
+def _clear_vault() -> None:
+    for child in _SECRETS.iterdir():
+        child.unlink()
+
+
+# ── Read path ───────────────────────────────────────────────────────────────
+
+def test_read_unimported_env_denied():
+    res = read_call(str(_WS / ".env"))
+    check("Read of unimported .env is denied",
+          denied(res) and "cloak add --env-file" in reason(res), str(res))
+    check("deny reason names the unimported keys, not values",
+          "API_KEY" in reason(res) and _API_KEY not in reason(res), str(res))
+
+
+def test_read_example_env_allowed():
+    res = read_call(str(_WS / ".env.example"))
+    check("Read of .env.example is allowed", res is None, str(res))
+
+
+def test_read_plain_file_allowed():
+    res = read_call(str(_WS / "notes.txt"))
+    check("Read of a non-env file is allowed", res is None, str(res))
+
+
+def test_read_suffixed_env_denied():
+    res = read_call(str(_WS / "prod.env"))
+    check("Read of unimported prod.env is denied", denied(res), str(res))
+
+
+# ── Bash path ───────────────────────────────────────────────────────────────
+
+def test_bash_cat_env_denied():
+    res = bash_call("cat .env")
+    check("`cat .env` is denied",
+          denied(res) and "cloak add --env-file" in reason(res), str(res))
+
+
+def test_bash_sed_env_denied():
+    res = bash_call("sed -n 1p .env")
+    check("`sed -n 1p .env` is denied", denied(res), str(res))
+
+
+def test_bash_grep_content_denied():
+    res = bash_call("grep API_KEY .env")
+    check("content `grep API_KEY .env` is denied", denied(res), str(res))
+
+
+def test_bash_redirect_read_denied():
+    res = bash_call("while read -r l; do :; done < .env")
+    check("`< .env` input redirection is denied", denied(res), str(res))
+
+
+def test_bash_presence_grep_allowed():
+    res = bash_call("grep -q '^API_KEY=' .env")
+    check("presence check `grep -q` is allowed", res is None, str(res))
+
+
+def test_bash_append_allowed():
+    res = bash_call("echo 'NEW_KEY=@@SECRET:NEW_KEY@@' >> .env")
+    check("append-only write to .env is allowed", res is None, str(res))
+
+
+def test_bash_ingest_command_allowed():
+    res = bash_call("prismor cloak add --env-file .env")
+    check("`prismor cloak add --env-file` is allowed", res is None, str(res))
+
+
+def test_bash_unrelated_command_allowed():
+    res = bash_call("cat notes.txt")
+    check("`cat notes.txt` is allowed", res is None, str(res))
+
+
+def test_bash_absolute_path_denied():
+    res = bash_call(f"cat {_WS}/.env")
+    check("absolute-path `cat` of unimported .env is denied", denied(res), str(res))
+
+
+# ── stand-down after import ─────────────────────────────────────────────────
+
+def test_stands_down_once_imported():
+    from prismor.runtime.cloaking.secrets_store import add_env_secrets
+    # Reset the fixture — the append test above added a placeholder line.
+    (_WS / ".env").write_text(
+        f"API_KEY={_API_KEY}\n"
+        f'DB_PASSWORD="{_DB_PASS}"\n'
+        "DEBUG=1\n"
+    )
+    created = add_env_secrets(_WS / ".env")
+    check("importer registers the two long values",
+          {e["name"] for e in created} >= {"API_KEY", "DB_PASSWORD"}, str(created))
+    res = read_call(str(_WS / ".env"))
+    check("Read of fully imported .env passes env-guard", res is None, str(res))
+    res = bash_call("cat .env")
+    check("`cat .env` of fully imported file passes env-guard", res is None, str(res))
+    # prod.env shares API_KEY's value but TOKEN is the same value → imported too.
+    res = bash_call("cat prod.env")
+    check("file whose values are all vaulted passes env-guard", res is None, str(res))
+    _clear_vault()
+    res = bash_call("cat .env")
+    check("guard re-arms when the vault is cleared", denied(res), str(res))
+
+
+def main() -> int:
+    for fn in [
+        test_read_unimported_env_denied,
+        test_read_example_env_allowed,
+        test_read_plain_file_allowed,
+        test_read_suffixed_env_denied,
+        test_bash_cat_env_denied,
+        test_bash_sed_env_denied,
+        test_bash_grep_content_denied,
+        test_bash_redirect_read_denied,
+        test_bash_presence_grep_allowed,
+        test_bash_append_allowed,
+        test_bash_ingest_command_allowed,
+        test_bash_unrelated_command_allowed,
+        test_bash_absolute_path_denied,
+        test_stands_down_once_imported,
+    ]:
+        fn()
+    print(f"\n{_passed} passed, {_failed} failed")
+    return 1 if _failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`read-guard.sh` and the decloak output scrub only protect values **already registered** in the vault. So the very first thing an agent does in a fresh workspace — `cat .env` or `Read(.env)` — leaks every secret into model context before any of them has a placeholder. The safe ingestion primitive (`prismor cloak add --env-file`) already existed, but nothing funneled agents into it.

## Fix

A new `PreToolUse:Read|Bash` hook, **`env-guard.sh`** (on by default), denies content access to a dotenv-style file *while it holds values missing from the vault*. The deny reason is itself the fix:

```
prismor cloak add --env-file .env
```

That command parses the file in the CLI process and registers every entry as its own placeholder — only names and byte counts are printed, so values never enter agent context. The agent can complete the whole loop autonomously from the deny message. Once every entry is imported, the guard stands down and the registration-based hooks (read-guard, decloak output scrub) take over.

## Deliberately allowed even before import

- `prismor cloak …` commands — the sanctioned ingestion path
- Append-only writes (`echo KEY=… >> .env`) — nothing is read
- Presence checks (`grep -q/-c/-l KEY .env`) — no content in output
- `.env.example` / sample / template / dist files — placeholders, not secrets

## Design notes

- The unimported-entry check runs in Python (`env_guard.py`) so it shares the importer's parser (`secrets_store._parse_env_line`). A bash re-implementation that disagreed with the importer could deny a fully-imported file forever.
- Python is only invoked after the bash fast path has found an existing env-style file in the tool input — the common case stays bash+jq only.
- Wired into `install()` / `uninstall()` / `status()` like the other hooks; opt out with `prismor cloak install --no-env-guard`.

## Tests

- New `tests/test_cloak_env_guard.py`: 19 checks across the Read path, Bash reader detection (cat/sed/grep/redirection), the allowed paths, and the stand-down-after-import / re-arm-on-vault-clear lifecycle. All pass.
- Existing suites: cloak secret-guard (23), output-scrub (13), atfile-guard (6), installer-cleanup, hooks-extended + prismor-home-consistency (88) all pass. The 4 `test_cli.py` failures are pre-existing on `main` (verified on a clean checkout).