### PR TITLE
feat(gateway): add the LLM lane — governed, brokered, metered model egress

### DIFF
--- a/docs/llm-gateway.md
+++ b/docs/llm-gateway.md
@@ -1,0 +1,121 @@
+# LLM Gateway
+
+`prismor gateway llm` is the **model lane** of the Prismor data plane. Where
+[`prismor gateway mcp`](./mcp-gateway.md) governs the *tools* an agent calls,
+this governs the *model* it calls: a local HTTP proxy you point an SDK at
+instead of `api.anthropic.com` or `api.openai.com`.
+
+Both lanes run the same policy engine as the PreToolUse hooks, emit to the
+same control plane, and share a session id — so an agent's tool calls and its
+model calls land on one trace.
+
+## What routing through it buys
+
+- **Policy.** Every request is evaluated as a `network` event carrying the
+  outbound payload, so your egress allowlist, secret-in-payload rules, and
+  taint escalation apply to model traffic with no new rules to write. A
+  blocked call is refused *before* egress — the provider never sees the body.
+- **Credential brokering.** The real provider key lives on the gateway, not on
+  the laptop. Clients can send a Cloak placeholder (`@@SECRET:name@@`), a
+  dummy value, or nothing at all.
+- **Metering.** Token counts and cost come from the provider's own usage
+  accounting, attributed per session and agent, and flushed as `llm_usage`
+  telemetry through the same uploader (and offline spool) as every other
+  record.
+- **Response scanning.** The completion is re-evaluated as untrusted content
+  before it is returned, so a poisoned or compromised upstream cannot inject
+  directives into context.
+
+## Quick start
+
+```bash
+# The gateway holds the real key; nothing else needs it.
+export ANTHROPIC_API_KEY=sk-ant-...
+prismor gateway llm --port 8787 --mode enforce
+```
+
+Point your SDK at it — only the base URL changes:
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(base_url="http://127.0.0.1:8787", api_key="unused")
+client.messages.create(model="claude-sonnet-5", max_tokens=256,
+                       messages=[{"role": "user", "content": "hello"}])
+```
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8787/openai
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8787/anthropic
+```
+
+## Provider routing
+
+With no `--provider`, the gateway picks per request:
+
+| Request path | Routed to |
+|---|---|
+| `/anthropic/...`, `/openai/...` | that provider (explicit prefix wins) |
+| `/v1/messages`, `/v1/complete` | Anthropic |
+| `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings` | OpenAI |
+
+Pin a single provider with `--provider anthropic` to accept native paths
+without a prefix. `--base-url` overrides the upstream entirely (self-hosted
+or already-proxied providers).
+
+## Streaming
+
+SSE is a first-class path. Bytes are relayed to the client as they arrive —
+no buffering, no added time-to-first-token — while a tap accumulates just
+enough to recover the usage block and the assistant text. Because usage is
+only knowable at the end of a stream, the response scan on a streamed call is
+necessarily post-hoc; the pre-call policy check has already run, and the scan
+result still lands in telemetry.
+
+## Cost
+
+Cost is estimated from a built-in table of USD per 1M tokens, matched by
+longest model-id prefix, with cache reads discounted and cache writes at a
+premium. An unknown model falls back to a conservative non-zero rate — a
+silent `$0` would read as "this model is free". Override per deployment:
+
+```bash
+prismor gateway llm --pricing ./pricing.json
+```
+
+```json
+{ "pricing": { "claude-sonnet": [3.0, 15.0], "our-finetune": [0.5, 1.5] } }
+```
+
+The gateway's job here is attribution and trend, not invoicing — reconcile
+against your provider bill for accounting.
+
+## Operating
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /healthz` | liveness, session id, mode |
+| `GET /metrics` | in-process call count, token totals, cost, pending records |
+
+`--mode observe` (default) logs verdicts without blocking; `--mode enforce`
+blocks, and fails **closed** if the policy engine itself errors. Denials are
+returned in the provider's own error shape (HTTP 403) so the SDK on the other
+side surfaces a readable refusal rather than crashing.
+
+Bind stays on `127.0.0.1` unless you set `--host`. Exposing the gateway on a
+routable address makes it a credential-bearing egress point for anything that
+can reach it — put it behind an authenticating proxy first.
+
+## Flags
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--port` | `8787` | listen port |
+| `--host` | `127.0.0.1` | loopback only by default |
+| `--provider` | auto-detect | `anthropic` \| `openai` |
+| `--base-url` | provider default | override upstream |
+| `--mode` | `observe` | `observe` \| `enforce` |
+| `--session-id` | fresh per process | env fallback `PRISMOR_SESSION_ID`; set it to join a hook session's trace |
+| `--agent-name` | `llm-gateway` | instance label in telemetry |
+| `--pricing` | built-in table | JSON cost override |
+| `--flush-interval` | `30` | seconds between usage flushes |

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1076,9 +1076,25 @@ def main(argv: Optional[List[str]] = None) -> None:
                 print(f"No Prismor hooks found for {item['agent']} at {item['configPath']}")
         return
 
-    # ── mcp-gateway (single MCP connector for all downstream servers) ──
-    if args.command == "mcp-gateway":
+    # ── gateway (two data-plane lanes: tools via MCP, models via HTTP) ──
+    # `mcp-gateway` predates the split and stays as an alias for the tool lane.
+    if args.command in ("gateway", "mcp-gateway"):
+        lane = getattr(args, "lane", None)
+        if args.command == "mcp-gateway":
+            lane = "mcp"
+        if not lane:
+            sys.stderr.write(
+                "[prismor] pick a lane: `prismor gateway mcp` (tools) or "
+                "`prismor gateway llm` (models)\n")
+            sys.exit(2)
         register_workspace(workspace)
+        if lane == "llm":
+            from prismor.runtime.llm_gateway import run_llm_gateway, LlmGatewayError
+            try:
+                sys.exit(run_llm_gateway(args, workspace))
+            except LlmGatewayError as exc:
+                sys.stderr.write(f"[prismor] {exc}\n")
+                sys.exit(2)
         from prismor.runtime.mcp_gateway import run_gateway, GatewayConfigError
         try:
             sys.exit(run_gateway(args, workspace))
@@ -2595,36 +2611,86 @@ def build_parser() -> argparse.ArgumentParser:
     uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro", "crush", "openhands", "qwen", "continue", "goose", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
-    # ── mcp-gateway ────────────────────────────────────────────────────
+    # ── gateway ────────────────────────────────────────────────────────
+    def _add_mcp_lane_args(parser):
+        parser.add_argument("action", nargs="?", choices=["serve", "install", "uninstall"],
+                            default="serve",
+                            help="serve (default) | install: move this workspace's .mcp.json servers "
+                            "behind the gateway | uninstall: restore the .mcp.json backup")
+        parser.add_argument("--config", help="Downstream servers config (.mcp.json-shaped; "
+                            "default: ~/.prismor/mcp-gateway.json)")
+        parser.add_argument("--upstream", help="Single upstream shim mode: a URL, or a quoted command "
+                            "(e.g. --upstream 'npx -y @modelcontextprotocol/server-github')")
+        parser.add_argument("--server", action="append",
+                            help="Inline upstream as name=<url|command> (repeatable)")
+        parser.add_argument("--mode", choices=["observe", "enforce"], default="observe",
+                            help="observe=log only (default), enforce=block policy violations")
+        parser.add_argument("--workspace", help="Workspace path for policy + session store")
+        parser.add_argument("--session-id", dest="session_id", default="",
+                            help="Stable session id (default: fresh per process). Hosted deployments "
+                            "set this so restored session state survives gateway restarts. "
+                            "Env fallback: PRISMOR_SESSION_ID")
+        parser.add_argument("--namespace", choices=["plain", "none"], default="plain",
+                            help="plain=<server>__<tool> (default); none=raw tool names "
+                            "(single-upstream shim only)")
+
+    def _add_llm_lane_args(parser):
+        parser.add_argument("--port", type=int, default=8787,
+                            help="Listen port (default: 8787)")
+        parser.add_argument("--host", default="127.0.0.1",
+                            help="Bind address (default: 127.0.0.1 — loopback only)")
+        parser.add_argument("--provider", choices=["anthropic", "openai"],
+                            help="Pin one provider. Omit to pick per request from the "
+                            "path (/anthropic/..., /openai/..., or the native API path)")
+        parser.add_argument("--base-url", dest="base_url", default="",
+                            help="Override the upstream base URL (self-hosted or proxied providers)")
+        parser.add_argument("--mode", choices=["observe", "enforce"], default="observe",
+                            help="observe=log only (default), enforce=block policy violations")
+        parser.add_argument("--workspace", help="Workspace path for policy + session store")
+        parser.add_argument("--session-id", dest="session_id", default="",
+                            help="Stable session id (default: fresh per process). "
+                            "Env fallback: PRISMOR_SESSION_ID")
+        parser.add_argument("--agent-name", dest="agent_name", default="llm-gateway",
+                            help="Instance label reported in telemetry (default: llm-gateway)")
+        parser.add_argument("--pricing", help="JSON file of {\"model-prefix\": [usd_per_mtok_in, "
+                            "usd_per_mtok_out]} overriding the built-in cost table")
+        parser.add_argument("--flush-interval", dest="flush_interval", type=float, default=30.0,
+                            help="Seconds between usage telemetry flushes (default: 30)")
+
+    gateway_parser = subparsers.add_parser(
+        "gateway",
+        help="Run a Prismor gateway lane — tools (MCP) or models (LLM)",
+        description="The data plane. Two lanes share one policy engine: `gateway mcp` "
+        "aggregates and guards your MCP servers; `gateway llm` proxies model API "
+        "traffic, brokering credentials and metering tokens. Both emit to the same "
+        "control plane, so a session's tool calls and model calls land on one trace.",
+    )
+    gateway_lanes = gateway_parser.add_subparsers(dest="lane")
+    _add_mcp_lane_args(gateway_lanes.add_parser(
+        "mcp",
+        help="Tool lane: one MCP connector fronting and guarding all your MCP servers",
+        description="Aggregates the MCP servers in --config behind a single stdio MCP server. "
+        "Every tools/call is policy-evaluated before forwarding and every response is "
+        "injection-scanned before the model sees it."))
+    _add_llm_lane_args(gateway_lanes.add_parser(
+        "llm",
+        help="Model lane: a local HTTP proxy that governs, brokers, and meters model API calls",
+        description="Point an SDK's base URL at this proxy. Each request is policy-evaluated "
+        "as a network event (egress allowlist, secret-in-payload), the real provider key "
+        "is resolved server-side so it never has to live on the client, tokens and cost are "
+        "metered per session, and the completion is scanned before it is returned."))
+
+    # ── mcp-gateway (alias for `gateway mcp`, kept for compatibility) ───
     gw_parser = subparsers.add_parser(
         "mcp-gateway",
-        help="Run the Prismor MCP gateway — one MCP connector that fronts and guards all your MCP servers",
+        help="Alias for `prismor gateway mcp`",
         description="Aggregates the MCP servers in --config behind a single stdio MCP server. "
         "Every tools/call is policy-evaluated before forwarding and every response is "
         "injection-scanned before the model sees it. Point your agent's .mcp.json at "
         "`prismor mcp-gateway` and move your existing mcpServers block into the gateway config "
         "(or run `prismor mcp-gateway install` to do that automatically).",
     )
-    gw_parser.add_argument("action", nargs="?", choices=["serve", "install", "uninstall"],
-                           default="serve",
-                           help="serve (default) | install: move this workspace's .mcp.json servers "
-                           "behind the gateway | uninstall: restore the .mcp.json backup")
-    gw_parser.add_argument("--config", help="Downstream servers config (.mcp.json-shaped; "
-                           "default: ~/.prismor/mcp-gateway.json)")
-    gw_parser.add_argument("--upstream", help="Single upstream shim mode: a URL, or a quoted command "
-                           "(e.g. --upstream 'npx -y @modelcontextprotocol/server-github')")
-    gw_parser.add_argument("--server", action="append",
-                           help="Inline upstream as name=<url|command> (repeatable)")
-    gw_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe",
-                           help="observe=log only (default), enforce=block policy violations")
-    gw_parser.add_argument("--workspace", help="Workspace path for policy + session store")
-    gw_parser.add_argument("--session-id", dest="session_id", default="",
-                           help="Stable session id (default: fresh per process). Hosted deployments "
-                           "set this so restored session state survives gateway restarts. "
-                           "Env fallback: PRISMOR_SESSION_ID")
-    gw_parser.add_argument("--namespace", choices=["plain", "none"], default="plain",
-                           help="plain=<server>__<tool> (default); none=raw tool names "
-                           "(single-upstream shim only)")
+    _add_mcp_lane_args(gw_parser)
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")

--- a/prismor/runtime/llm_gateway.py
+++ b/prismor/runtime/llm_gateway.py
@@ -1,0 +1,868 @@
+"""Prismor LLM Gateway — governed egress for model API traffic.
+
+The MCP gateway (``prismor/runtime/mcp_gateway.py``) governs the *tool* lane:
+one connector in front of every MCP server. This module is the *model* lane —
+a local HTTP proxy that agents point at instead of ``api.anthropic.com`` /
+``api.openai.com``. Together they are the two data-plane lanes of
+``prismor gateway``.
+
+What passing through here buys, none of which the agent has to opt into:
+
+  * **Policy.** Every request is evaluated by ``evaluate_tool_call`` — the
+    same engine the PreToolUse hooks run — as a ``network`` event carrying the
+    outbound payload, so the egress allowlist, secret-in-payload rules, and
+    taint escalation all apply with no new policy surface to configure.
+  * **Credential brokering.** The client sends a placeholder (or nothing at
+    all); the real provider key is resolved here, server-side, and never has
+    to exist on the developer's machine. See ``resolve_upstream_auth``.
+  * **Metering.** Token counts and cost are extracted from the provider's own
+    usage accounting and attributed to session/agent/subject, then flushed as
+    ``llm_usage`` telemetry records — the same uploader the finding records
+    and activity heartbeats already use.
+  * **Response scanning.** The completion is re-evaluated as a ``tool_result``
+    event before it reaches the caller, so a poisoned upstream (or a
+    compromised provider account) cannot inject directives into context.
+
+Design constraints inherited from the runtime: stdlib only (the floor is
+Python 3.8 and the sole dependency is pyyaml), fail-closed in enforce mode,
+and never block the hot path on the control plane — usage flushes are
+debounced and spooled exactly like every other telemetry record.
+
+Streaming is a first-class path, not an afterthought: agent traffic is
+overwhelmingly SSE, and a proxy that only handled buffered JSON would be
+useless in practice. Streamed bytes are relayed to the client as they arrive
+(no added latency, no buffering the whole completion) while a tap accumulates
+just enough to recover the usage block and the assistant text for scanning.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+GATEWAY_AGENT = "llm-gateway"
+DEFAULT_PORT = 8787
+UPSTREAM_TIMEOUT = 600.0
+# Bound how much of a request/response body we hand to the policy engine.
+# Prompts are unbounded in principle; scanning the first 256 KiB catches
+# injected directives and secret material without turning a long context
+# window into an O(MB) regex sweep on every call.
+SCAN_CAP = 256 * 1024
+
+
+# ── providers ────────────────────────────────────────────────────────────────
+
+@dataclass
+class ProviderSpec:
+    """How to reach one model provider and how to read its usage accounting."""
+    name: str
+    base_url: str
+    # Header carrying the provider credential, and how the value is formatted.
+    auth_header: str
+    auth_format: str            # "{key}" or "Bearer {key}"
+    env_keys: Tuple[str, ...]   # env vars searched, in order, for the key
+    # Path prefixes this provider claims when the gateway is multiplexing
+    # several providers on one port.
+    path_prefixes: Tuple[str, ...]
+
+
+_PROVIDERS: Dict[str, ProviderSpec] = {
+    "anthropic": ProviderSpec(
+        name="anthropic",
+        base_url="https://api.anthropic.com",
+        auth_header="x-api-key",
+        auth_format="{key}",
+        env_keys=("ANTHROPIC_API_KEY",),
+        path_prefixes=("/v1/messages", "/v1/complete"),
+    ),
+    "openai": ProviderSpec(
+        name="openai",
+        base_url="https://api.openai.com",
+        auth_header="Authorization",
+        auth_format="Bearer {key}",
+        env_keys=("OPENAI_API_KEY",),
+        path_prefixes=("/v1/chat/completions", "/v1/responses", "/v1/embeddings"),
+    ),
+}
+
+
+class LlmGatewayError(RuntimeError):
+    pass
+
+
+def resolve_provider(name: str) -> ProviderSpec:
+    spec = _PROVIDERS.get(name.strip().lower())
+    if spec is None:
+        raise LlmGatewayError(
+            f"unknown provider {name!r} (known: {', '.join(sorted(_PROVIDERS))})")
+    return spec
+
+
+def provider_for_path(path: str) -> Optional[ProviderSpec]:
+    """Pick a provider from the request path when multiplexing.
+
+    Explicit ``/<provider>/...`` prefixes win; otherwise the native API path
+    is matched so an SDK pointed at the gateway with only its base URL changed
+    works untouched.
+    """
+    clean = path.split("?", 1)[0]
+    for name, spec in _PROVIDERS.items():
+        if clean == f"/{name}" or clean.startswith(f"/{name}/"):
+            return spec
+    for spec in _PROVIDERS.values():
+        for prefix in spec.path_prefixes:
+            if clean.startswith(prefix):
+                return spec
+    return None
+
+
+def strip_provider_prefix(path: str, spec: ProviderSpec) -> str:
+    if path == f"/{spec.name}":
+        return "/"
+    if path.startswith(f"/{spec.name}/"):
+        return path[len(spec.name) + 1:]
+    return path
+
+
+# ── credential brokering ─────────────────────────────────────────────────────
+
+# A client may send a Cloak placeholder instead of a real key. Resolving it
+# here is what lets a laptop hold no provider credentials at all.
+_PLACEHOLDER_RE = re.compile(r"^@@SECRET:([A-Za-z0-9_.\-]+)@@$")
+
+
+def resolve_upstream_auth(spec: ProviderSpec,
+                          client_value: Optional[str]) -> Optional[str]:
+    """Resolve the credential actually sent upstream.
+
+    Order: a Cloak placeholder from the client is resolved through the local
+    Cloak store; otherwise the gateway's own environment supplies the key; a
+    real key passed by the client is honoured last so existing setups keep
+    working. Returning ``None`` means "send nothing" — the upstream will
+    reject it, which is the correct, loud failure.
+    """
+    if client_value:
+        match = _PLACEHOLDER_RE.match(client_value.strip())
+        if match:
+            resolved = _lookup_cloak_secret(match.group(1))
+            if resolved:
+                return resolved
+            raise LlmGatewayError(
+                f"secret placeholder '{match.group(1)}' could not be resolved")
+    for env_key in spec.env_keys:
+        value = os.environ.get(env_key)
+        if value:
+            return value
+    return client_value or None
+
+
+def _lookup_cloak_secret(name: str) -> Optional[str]:
+    """Resolve a placeholder through the runtime's Cloak store, if present."""
+    try:
+        from prismor.runtime.cloaking import store as _store  # type: ignore
+    except Exception:
+        return None
+    for attr in ("get_secret", "lookup", "resolve"):
+        fn = getattr(_store, attr, None)
+        if callable(fn):
+            try:
+                value = fn(name)
+            except Exception:
+                continue
+            if value:
+                return str(value)
+    return None
+
+
+# ── usage accounting ─────────────────────────────────────────────────────────
+
+@dataclass
+class Usage:
+    model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return (self.input_tokens + self.output_tokens
+                + self.cache_read_tokens + self.cache_write_tokens)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "model": self.model or None,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+# USD per 1M tokens, matched by longest model-id prefix. Deliberately a small
+# static table with a conservative fallback: the gateway's job is attribution
+# and trend, not invoicing, and a stale price is far better than no cost
+# signal at all. Overridable per deployment via `pricing` in the config file.
+_DEFAULT_PRICING: Dict[str, Tuple[float, float]] = {
+    "claude-opus": (15.0, 75.0),
+    "claude-sonnet": (3.0, 15.0),
+    "claude-haiku": (0.80, 4.0),
+    "gpt-5": (1.25, 10.0),
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4o": (2.50, 10.0),
+    "o3": (2.0, 8.0),
+}
+_FALLBACK_PRICE = (1.0, 5.0)
+
+
+def estimate_cost_usd(usage: Usage,
+                      pricing: Optional[Dict[str, Tuple[float, float]]] = None
+                      ) -> float:
+    table = pricing or _DEFAULT_PRICING
+    model = (usage.model or "").lower()
+    best: Optional[Tuple[float, float]] = None
+    best_len = -1
+    for prefix, price in table.items():
+        if prefix.lower() in model and len(prefix) > best_len:
+            best, best_len = price, len(prefix)
+    price_in, price_out = best or _FALLBACK_PRICE
+    # Cache reads bill at a fraction of input; cache writes at a premium.
+    billed_in = usage.input_tokens + usage.cache_write_tokens * 1.25 \
+        + usage.cache_read_tokens * 0.1
+    return round(
+        (billed_in / 1_000_000.0) * price_in
+        + (usage.output_tokens / 1_000_000.0) * price_out, 6)
+
+
+def extract_usage(provider: str, body: bytes) -> Usage:
+    """Read the provider's own usage block out of a buffered JSON response."""
+    usage = Usage()
+    try:
+        data = json.loads(body.decode("utf-8", "replace"))
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return usage
+    if not isinstance(data, dict):
+        return usage
+    usage.model = str(data.get("model") or "")
+    raw = data.get("usage")
+    if not isinstance(raw, dict):
+        return usage
+    return _fill_usage(usage, provider, raw)
+
+
+def _fill_usage(usage: Usage, provider: str, raw: Dict[str, Any]) -> Usage:
+    def _int(key: str) -> int:
+        value = raw.get(key)
+        return int(value) if isinstance(value, (int, float)) else 0
+
+    if provider == "anthropic":
+        usage.input_tokens = _int("input_tokens") or usage.input_tokens
+        usage.output_tokens = _int("output_tokens") or usage.output_tokens
+        usage.cache_read_tokens = (_int("cache_read_input_tokens")
+                                   or usage.cache_read_tokens)
+        usage.cache_write_tokens = (_int("cache_creation_input_tokens")
+                                    or usage.cache_write_tokens)
+    else:
+        usage.input_tokens = _int("prompt_tokens") or usage.input_tokens
+        usage.output_tokens = _int("completion_tokens") or usage.output_tokens
+        details = raw.get("prompt_tokens_details")
+        if isinstance(details, dict):
+            cached = details.get("cached_tokens")
+            if isinstance(cached, (int, float)):
+                usage.cache_read_tokens = int(cached)
+    return usage
+
+
+class StreamTap:
+    """Accumulate usage + assistant text from an SSE stream as it is relayed.
+
+    The bytes go to the client untouched and unbuffered; this only watches
+    them go past. Text capture is capped so a long completion cannot grow the
+    proxy's memory without bound.
+    """
+
+    def __init__(self, provider: str, cap: int = SCAN_CAP):
+        self.provider = provider
+        self.usage = Usage()
+        self.cap = cap
+        self._text: List[str] = []
+        self._text_len = 0
+        self._buf = b""
+
+    @property
+    def text(self) -> str:
+        return "".join(self._text)
+
+    def feed(self, chunk: bytes) -> None:
+        self._buf += chunk
+        while b"\n" in self._buf:
+            line, self._buf = self._buf.split(b"\n", 1)
+            self._consume_line(line.strip())
+
+    def _consume_line(self, line: bytes) -> None:
+        if not line.startswith(b"data:"):
+            return
+        payload = line[5:].strip()
+        if not payload or payload == b"[DONE]":
+            return
+        try:
+            event = json.loads(payload.decode("utf-8", "replace"))
+        except (json.JSONDecodeError, ValueError):
+            return
+        if isinstance(event, dict):
+            self._consume_event(event)
+
+    def _consume_event(self, event: Dict[str, Any]) -> None:
+        model = event.get("model")
+        if isinstance(model, str) and model and not self.usage.model:
+            self.usage.model = model
+
+        if self.provider == "anthropic":
+            # message_start carries input tokens; message_delta the running
+            # output count. Both are dicts keyed "usage".
+            message = event.get("message")
+            if isinstance(message, dict):
+                if not self.usage.model and isinstance(message.get("model"), str):
+                    self.usage.model = message["model"]
+                if isinstance(message.get("usage"), dict):
+                    _fill_usage(self.usage, "anthropic", message["usage"])
+            if isinstance(event.get("usage"), dict):
+                _fill_usage(self.usage, "anthropic", event["usage"])
+            delta = event.get("delta")
+            if isinstance(delta, dict) and isinstance(delta.get("text"), str):
+                self._append(delta["text"])
+            return
+
+        if isinstance(event.get("usage"), dict):
+            _fill_usage(self.usage, self.provider, event["usage"])
+        for choice in event.get("choices") or []:
+            if not isinstance(choice, dict):
+                continue
+            delta = choice.get("delta")
+            if isinstance(delta, dict) and isinstance(delta.get("content"), str):
+                self._append(delta["content"])
+
+    def _append(self, text: str) -> None:
+        if self._text_len >= self.cap:
+            return
+        room = self.cap - self._text_len
+        piece = text[:room]
+        self._text.append(piece)
+        self._text_len += len(piece)
+
+
+class UsageMeter:
+    """Accumulate per-call usage and flush it as ``llm_usage`` telemetry.
+
+    Mirrors ``enterprise/heartbeat.py``: aggregate in memory, flush on a
+    debounce, and hand the records to the shared uploader so offline periods
+    spool and replay like everything else. Never raises into the request path.
+    """
+
+    def __init__(self, flush_interval: float = 30.0,
+                 pricing: Optional[Dict[str, Tuple[float, float]]] = None):
+        self.flush_interval = flush_interval
+        self.pricing = pricing
+        self._lock = threading.Lock()
+        self._pending: List[Dict[str, Any]] = []
+        self._last_flush = time.time()
+        self.totals = Usage()
+        self.total_cost_usd = 0.0
+        self.calls = 0
+
+    def record(self, *, provider: str, usage: Usage, session_id: str,
+               agent_name: str, subject: Optional[Dict[str, Any]] = None,
+               latency_ms: Optional[int] = None,
+               blocked: bool = False) -> Dict[str, Any]:
+        cost = estimate_cost_usd(usage, self.pricing)
+        record = {
+            "schema": "prismor.telemetry.v1",
+            "event_id": uuid.uuid4().hex,
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": "llm_usage",
+            "verdict": "blocked" if blocked else "observed",
+            "title": "Model call metered",
+            "agent": GATEWAY_AGENT,
+            "agent_name": agent_name or None,
+            "session_id": session_id or None,
+            "subject": subject or None,
+            "provider": provider,
+            "tool_name": f"llm__{provider}__{usage.model or 'unknown'}",
+            "usage": usage.as_dict(),
+            "cost_usd": cost,
+            "latency_ms": latency_ms,
+            "redacted": True,
+        }
+        with self._lock:
+            self._pending.append(record)
+            self.calls += 1
+            self.totals.input_tokens += usage.input_tokens
+            self.totals.output_tokens += usage.output_tokens
+            self.totals.cache_read_tokens += usage.cache_read_tokens
+            self.totals.cache_write_tokens += usage.cache_write_tokens
+            self.total_cost_usd = round(self.total_cost_usd + cost, 6)
+        return record
+
+    def maybe_flush(self, force: bool = False) -> int:
+        now = time.time()
+        with self._lock:
+            if not self._pending:
+                return 0
+            if not force and (now - self._last_flush) < self.flush_interval:
+                return 0
+            batch, self._pending = self._pending, []
+            self._last_flush = now
+        try:
+            from prismor.runtime.sinks import upload_telemetry
+            upload_telemetry(batch)
+        except Exception:
+            # upload_telemetry spools on failure; anything it re-raises is
+            # logged-and-dropped here so metering can never break a call.
+            pass
+        return len(batch)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "calls": self.calls,
+                "usage": self.totals.as_dict(),
+                "cost_usd": self.total_cost_usd,
+                "pending_records": len(self._pending),
+            }
+
+
+# ── the gateway ──────────────────────────────────────────────────────────────
+
+@dataclass
+class GatewayConfig:
+    provider: Optional[str] = None      # pin one provider; else multiplex
+    base_url_override: str = ""
+    mode: str = "observe"
+    workspace: Path = field(default_factory=Path.cwd)
+    session_id: str = ""
+    agent_name: str = "llm-gateway"
+    pricing: Optional[Dict[str, Tuple[float, float]]] = None
+    flush_interval: float = 30.0
+
+
+class LlmGateway:
+    """Policy + metering around one model call. Transport-agnostic core.
+
+    Kept free of ``http.server`` types so the whole request lifecycle is
+    unit-testable without binding a socket.
+    """
+
+    def __init__(self, config: GatewayConfig):
+        self.config = config
+        self.session_id = config.session_id or ("llm-" + uuid.uuid4().hex[:12])
+        self.meter = UsageMeter(flush_interval=config.flush_interval,
+                                pricing=config.pricing)
+        self._eval_lock = threading.Lock()
+
+    # ── policy ───────────────────────────────────────────────────────────
+
+    def _evaluate(self, event: Dict[str, Any]):
+        """One event through the shared engine — the same call the hooks make.
+
+        Serialized for the same reason the MCP gateway serializes: the tag
+        ledger is session-ordered, and interleaved evaluation could let the
+        completing call of a forbidden pair slip past.
+        """
+        try:
+            from prismor.runtime.runtime import evaluate_tool_call
+            with self._eval_lock:
+                return evaluate_tool_call(
+                    event=event,
+                    workspace=self.config.workspace,
+                    agent=GATEWAY_AGENT,
+                    mode=self.config.mode,
+                    session_id=self.session_id,
+                    agent_name=self.config.agent_name,
+                )
+        except Exception as exc:
+            # Fail open on engine errors only in observe mode; in enforce a
+            # broken engine must not wave model traffic through.
+            if self.config.mode == "enforce":
+                raise LlmGatewayError(
+                    f"policy evaluation failed ({exc}); call denied (fail-closed)")
+            return None
+
+    def _event_base(self, agent_event: str, model: str,
+                    provider: str) -> Dict[str, Any]:
+        return {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "session_id": self.session_id,
+            "agent": GATEWAY_AGENT,
+            "agent_event": agent_event,
+            "metadata": {
+                "cwd": str(self.config.workspace),
+                "tool_name": f"llm__{provider}__{model or 'unknown'}",
+            },
+        }
+
+    def build_request_event(self, spec: ProviderSpec, url: str,
+                            body: bytes, model: str) -> Dict[str, Any]:
+        """Outbound model call as a ``network`` event.
+
+        Reusing the network type is the whole trick: the egress allowlist,
+        secret-in-payload detection, and taint escalation already understand
+        this shape, so the model lane inherits them without one new rule.
+        """
+        base = self._event_base("PreToolUse", model, spec.name)
+        return {**base, "type": "network", "url": url,
+                "outbound_payload": body[:SCAN_CAP].decode("utf-8", "replace")}
+
+    def build_response_event(self, spec: ProviderSpec, text: str,
+                             model: str) -> Dict[str, Any]:
+        """Completion as a ``tool_result`` — untrusted content, scanned before
+        it reaches the caller's context."""
+        base = self._event_base("PostToolUse", model, spec.name)
+        return {**base, "type": "tool_result", "response": text[:SCAN_CAP]}
+
+    @staticmethod
+    def model_of(body: bytes) -> str:
+        try:
+            data = json.loads(body.decode("utf-8", "replace"))
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            return ""
+        return str(data.get("model") or "") if isinstance(data, dict) else ""
+
+    @staticmethod
+    def wants_stream(body: bytes) -> bool:
+        try:
+            data = json.loads(body.decode("utf-8", "replace"))
+        except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            return False
+        return bool(isinstance(data, dict) and data.get("stream"))
+
+
+def blocked_payload(provider: str, blocking: Dict[str, Any]) -> Dict[str, Any]:
+    """Render a denial in the provider's own error shape.
+
+    A governed call that fails must look like an ordinary API error to the
+    SDK on the other side — anything else surfaces as a client crash instead
+    of a readable refusal the agent can adapt to.
+    """
+    parts = [f"Blocked by Prismor: [{blocking.get('severity', 'high')}] "
+             f"{blocking.get('title', 'policy violation')}"]
+    if blocking.get("ruleId"):
+        parts[0] += f" (rule: {blocking['ruleId']})"
+    if blocking.get("evidence"):
+        parts.append(str(blocking["evidence"]))
+    if blocking.get("remediation"):
+        parts.append(f"Recommended fix: {blocking['remediation']}")
+    message = "\n".join(parts)
+    if provider == "anthropic":
+        return {"type": "error",
+                "error": {"type": "permission_error", "message": message}}
+    return {"error": {"message": message, "type": "permission_error",
+                      "code": "prismor_policy_block"}}
+
+
+# ── HTTP surface ─────────────────────────────────────────────────────────────
+
+_HOP_BY_HOP = {
+    "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+    "te", "trailers", "transfer-encoding", "upgrade", "host", "content-length",
+    "accept-encoding",  # we relay bytes verbatim; no transparent decompression
+}
+
+
+def _make_handler(gateway: LlmGateway) -> type:
+    import urllib.error
+    import urllib.request
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "prismor-llm-gateway"
+        protocol_version = "HTTP/1.1"
+
+        # Access logging goes through the runtime's own telemetry, not stderr
+        # noise on every request.
+        def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
+            pass
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            if path in ("/healthz", "/health"):
+                self._json(200, {"status": "ok",
+                                 "session_id": gateway.session_id,
+                                 "mode": gateway.config.mode})
+                return
+            if path in ("/metrics", "/usage"):
+                self._json(200, gateway.meter.snapshot())
+                return
+            self._json(404, {"error": {"message": f"no route for {path}"}})
+
+        def do_POST(self) -> None:  # noqa: N802
+            try:
+                self._proxy()
+            except LlmGatewayError as exc:
+                self._json(502, {"error": {"message": str(exc),
+                                           "type": "prismor_gateway_error"}})
+            except Exception as exc:  # never take the server down
+                self._json(500, {"error": {"message": f"prismor-gateway: {exc}",
+                                           "type": "prismor_gateway_error"}})
+
+        # ── core proxy ───────────────────────────────────────────────
+
+        def _proxy(self) -> None:
+            cfg = gateway.config
+            spec = (resolve_provider(cfg.provider) if cfg.provider
+                    else provider_for_path(self.path))
+            if spec is None:
+                self._json(404, {"error": {
+                    "message": f"no provider matches path {self.path!r}; "
+                               "prefix it with /anthropic or /openai, or pin "
+                               "one with --provider"}})
+                return
+
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length) if length else b""
+            upstream_path = strip_provider_prefix(self.path, spec)
+            base = (cfg.base_url_override or spec.base_url).rstrip("/")
+            url = base + upstream_path
+            model = gateway.model_of(body)
+
+            # 1. Pre-call policy on the outbound payload.
+            decision = gateway._evaluate(
+                gateway.build_request_event(spec, url, body, model))
+            self._log_observe(decision, model, spec)
+            if decision is not None and decision.blocking is not None:
+                gateway.meter.record(
+                    provider=spec.name, usage=Usage(model=model),
+                    session_id=gateway.session_id,
+                    agent_name=cfg.agent_name, blocked=True)
+                gateway.meter.maybe_flush()
+                self._json(403, blocked_payload(spec.name, decision.blocking))
+                return
+
+            # 2. Broker the credential — the client never needs the real key.
+            headers = self._upstream_headers(spec)
+
+            started = time.time()
+            request = urllib.request.Request(url, data=body, method="POST",
+                                             headers=headers)
+            try:
+                response = urllib.request.urlopen(request,
+                                                  timeout=UPSTREAM_TIMEOUT)
+            except urllib.error.HTTPError as exc:
+                # Relay provider errors verbatim: the SDK on the other side
+                # knows how to read them, and masking them would make the
+                # gateway look like the fault.
+                payload = exc.read()
+                self._relay_head(exc.code, dict(exc.headers or {}),
+                                 len(payload))
+                self.wfile.write(payload)
+                return
+            except urllib.error.URLError as exc:
+                raise LlmGatewayError(f"upstream unreachable: {exc.reason}")
+
+            streaming = ("text/event-stream"
+                         in (response.headers.get("Content-Type") or "").lower())
+            if streaming:
+                self._relay_stream(spec, response, model, started)
+            else:
+                self._relay_buffered(spec, response, model, started)
+
+        def _upstream_headers(self, spec: ProviderSpec) -> Dict[str, str]:
+            headers: Dict[str, str] = {}
+            for key, value in self.headers.items():
+                if key.lower() in _HOP_BY_HOP:
+                    continue
+                if key.lower() == spec.auth_header.lower():
+                    continue
+                headers[key] = value
+            client_key = self.headers.get(spec.auth_header)
+            resolved = resolve_upstream_auth(spec, client_key)
+            if resolved:
+                headers[spec.auth_header] = spec.auth_format.format(key=resolved)
+            headers.setdefault("Content-Type", "application/json")
+            return headers
+
+        def _relay_buffered(self, spec: ProviderSpec, response: Any,
+                            model: str, started: float) -> None:
+            payload = response.read()
+            usage = extract_usage(spec.name, payload)
+            if not usage.model:
+                usage.model = model
+            latency_ms = int((time.time() - started) * 1000)
+
+            text = _assistant_text(spec.name, payload)
+            decision = gateway._evaluate(
+                gateway.build_response_event(spec, text, usage.model))
+            self._log_observe(decision, usage.model, spec)
+            gateway.meter.record(
+                provider=spec.name, usage=usage,
+                session_id=gateway.session_id,
+                agent_name=gateway.config.agent_name, latency_ms=latency_ms,
+                blocked=bool(decision is not None and decision.blocking))
+            gateway.meter.maybe_flush()
+
+            if decision is not None and decision.blocking is not None:
+                self._json(403, blocked_payload(spec.name, decision.blocking))
+                return
+            self._relay_head(response.status, dict(response.headers or {}),
+                             len(payload))
+            self.wfile.write(payload)
+
+        def _relay_stream(self, spec: ProviderSpec, response: Any,
+                          model: str, started: float) -> None:
+            # Chunked relay: the client sees tokens at upstream speed. Usage
+            # is only knowable at the end of the stream, so scanning the
+            # completion is necessarily post-hoc here — the pre-call check
+            # already ran, and the response scan still lands in telemetry.
+            tap = StreamTap(spec.name)
+            self.send_response(response.status)
+            for key, value in (response.headers or {}).items():
+                if key.lower() in _HOP_BY_HOP or key.lower() == "content-length":
+                    continue
+                self.send_header(key, value)
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            try:
+                while True:
+                    chunk = response.read(8192)
+                    if not chunk:
+                        break
+                    tap.feed(chunk)
+                    self.wfile.write(b"%X\r\n%s\r\n" % (len(chunk), chunk))
+                    self.wfile.flush()
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return  # client hung up mid-stream; still meter what we saw
+            finally:
+                usage = tap.usage
+                if not usage.model:
+                    usage.model = model
+                latency_ms = int((time.time() - started) * 1000)
+                decision = gateway._evaluate(
+                    gateway.build_response_event(spec, tap.text, usage.model))
+                self._log_observe(decision, usage.model, spec)
+                gateway.meter.record(
+                    provider=spec.name, usage=usage,
+                    session_id=gateway.session_id,
+                    agent_name=gateway.config.agent_name,
+                    latency_ms=latency_ms,
+                    blocked=bool(decision is not None and decision.blocking))
+                gateway.meter.maybe_flush()
+
+        # ── helpers ──────────────────────────────────────────────────
+
+        def _log_observe(self, decision: Any, model: str,
+                         spec: ProviderSpec) -> None:
+            if decision is None:
+                return
+            try:
+                from prismor.runtime.runtime import log_observe_findings
+                log_observe_findings(decision, mode=gateway.config.mode,
+                                     tool_name=f"llm__{spec.name}__{model}")
+            except Exception:
+                pass
+
+        def _relay_head(self, status: int, headers: Dict[str, str],
+                        length: int) -> None:
+            self.send_response(status)
+            for key, value in headers.items():
+                if key.lower() in _HOP_BY_HOP or key.lower() == "content-length":
+                    continue
+                self.send_header(key, value)
+            self.send_header("Content-Length", str(length))
+            self.end_headers()
+
+        def _json(self, status: int, payload: Dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return Handler
+
+
+def _assistant_text(provider: str, payload: bytes) -> str:
+    """Pull the assistant's own words out of a buffered completion."""
+    try:
+        data = json.loads(payload.decode("utf-8", "replace"))
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    parts: List[str] = []
+    if provider == "anthropic":
+        for block in data.get("content") or []:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+    else:
+        for choice in data.get("choices") or []:
+            if not isinstance(choice, dict):
+                continue
+            message = choice.get("message")
+            if isinstance(message, dict) and isinstance(message.get("content"), str):
+                parts.append(message["content"])
+    return "\n".join(parts)[:SCAN_CAP]
+
+
+def serve(config: GatewayConfig, host: str = "127.0.0.1",
+          port: int = DEFAULT_PORT) -> int:
+    gateway = LlmGateway(config)
+    httpd = ThreadingHTTPServer((host, port), _make_handler(gateway))
+    httpd.daemon_threads = True
+    import sys
+    target = config.provider or "auto-detect per request"
+    sys.stderr.write(
+        f"[prismor-gateway:llm] listening on http://{host}:{port} "
+        f"provider={target} session={gateway.session_id} "
+        f"mode={config.mode}\n")
+    try:
+        httpd.serve_forever(poll_interval=0.5)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        gateway.meter.maybe_flush(force=True)
+        httpd.server_close()
+    return 0
+
+
+def load_pricing(path: Optional[Path]) -> Optional[Dict[str, Tuple[float, float]]]:
+    """Load a ``{"model-prefix": [in_per_mtok, out_per_mtok]}`` override."""
+    if not path:
+        return None
+    try:
+        raw = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise LlmGatewayError(f"invalid pricing file {path}: {exc}")
+    table: Dict[str, Tuple[float, float]] = {}
+    for key, value in (raw.get("pricing") or raw).items():
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            table[str(key)] = (float(value[0]), float(value[1]))
+    return table or None
+
+
+def run_llm_gateway(args, workspace: Path) -> int:
+    """Entry point for ``prismor gateway llm`` (called from cli.main)."""
+    config = GatewayConfig(
+        provider=getattr(args, "provider", None) or None,
+        base_url_override=getattr(args, "base_url", "") or "",
+        mode=getattr(args, "mode", "observe") or "observe",
+        workspace=workspace,
+        session_id=(getattr(args, "session_id", "") or
+                    os.environ.get("PRISMOR_SESSION_ID", "")),
+        agent_name=getattr(args, "agent_name", "") or "llm-gateway",
+        pricing=load_pricing(getattr(args, "pricing", None)),
+        flush_interval=float(getattr(args, "flush_interval", 30.0) or 30.0),
+    )
+    return serve(config,
+                 host=getattr(args, "host", "127.0.0.1") or "127.0.0.1",
+                 port=int(getattr(args, "port", DEFAULT_PORT) or DEFAULT_PORT))

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1489,23 +1489,32 @@ class PolicyEngine:
                         "action": "block",
                     })
 
-            # MCP / request-body exfiltration: a remote MCP tool call carries
-            # its arguments in the request body, not the URL. Scan the serialized
-            # arguments for any enrolled cloaking secret so secrets shipped as
-            # tool parameters are caught the same way as secrets in a URL.
+            # Request-body exfiltration: a call that carries its arguments in
+            # the body rather than the URL. Two lanes reach here — a remote MCP
+            # tool call (arguments) and a model API call through the LLM gateway
+            # (the prompt) — so the finding names the surface it actually saw.
+            # The ruleId stays `cloaked-secret-in-mcp-args` across both: it is
+            # referenced by the enforcement floor and by existing exemptions,
+            # and renaming it would silently drop those.
             outbound_payload = str(event.get("outbound_payload", ""))
             if outbound_payload:
                 _secret_in_args = _check_cloaked_secrets_in_text(outbound_payload)
                 if _secret_in_args:
                     finding_id = f"cloaked-secret-in-mcp-args-{index}"
                     prefixed_id = f"{session_id}:{finding_id}" if session_id else finding_id
+                    _surface = (
+                        "an outbound model prompt"
+                        if str((event.get("metadata") or {}).get("tool_name", "")
+                               ).startswith("llm__")
+                        else "outbound MCP tool arguments"
+                    )
                     findings.append({
                         "id": prefixed_id,
                         "severity": "CRITICAL",
                         "category": "secret_exfiltration",
                         "title": (
                             f"Enrolled secret '@@SECRET:{_secret_in_args}@@' "
-                            f"detected in outbound MCP tool arguments"
+                            f"detected in {_surface}"
                         ),
                         "evidence": "[secret value redacted from evidence]",
                         "eventIndex": index,

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -630,3 +630,51 @@ class TestTransport:
             assert "no provider matches" in excinfo.value.read().decode()
         finally:
             harness.stop()
+
+
+
+# ── [H] shared secret-exfil rule names the right surface ─────────────────────
+
+class TestSecretExfilSurfaceNaming:
+    """The outbound-payload rule now serves two lanes. It must say which one it
+    saw, without changing the ruleId the enforcement floor keys on."""
+
+    SECRET = "sk-surface-test-" + "a1b2c3d4" * 3
+
+    def _findings(self, tmp_path, tool_name: str):
+        import prismor.runtime.policy_engine as pe
+        original = pe._check_cloaked_secrets_in_text
+        pe._check_cloaked_secrets_in_text = lambda text: (
+            "MY_TOKEN" if self.SECRET in text else None)
+        try:
+            engine = pe.PolicyEngine(workspace=tmp_path)
+            found = engine.evaluate({
+                "type": "network",
+                "url": "https://api.anthropic.com/v1/messages",
+                "outbound_payload": '{"prompt":"' + self.SECRET + '"}',
+                "metadata": {"tool_name": tool_name},
+            }, 0, session_id="s-surface")
+        finally:
+            pe._check_cloaked_secrets_in_text = original
+        return [f for f in found
+                if f.get("ruleId") == "cloaked-secret-in-mcp-args"]
+
+    def test_model_lane_says_model_prompt(self, tmp_path):
+        hits = self._findings(tmp_path, "llm__anthropic__claude-sonnet-5")
+        assert hits, "expected the enrolled-secret rule to fire"
+        assert "model prompt" in hits[0]["title"]
+        # The floor and existing exemptions key on this id — it must not drift.
+        assert hits[0]["ruleId"] == "cloaked-secret-in-mcp-args"
+        assert hits[0]["category"] == "secret_exfiltration"
+
+    def test_tool_lane_still_says_mcp_arguments(self, tmp_path):
+        hits = self._findings(tmp_path, "mcp__github__create_issue")
+        assert hits
+        assert "MCP tool arguments" in hits[0]["title"]
+
+    def test_title_names_the_secret_never_its_value(self, tmp_path):
+        for tool in ("llm__anthropic__x", "mcp__gh__y"):
+            for hit in self._findings(tmp_path, tool):
+                assert self.SECRET not in hit["title"]
+                assert "MY_TOKEN" in hit["title"]
+                assert self.SECRET not in str(hit.get("evidence", ""))

--- a/tests/test_llm_gateway.py
+++ b/tests/test_llm_gateway.py
@@ -1,0 +1,632 @@
+"""LLM gateway — routing, brokering, metering, policy, and transport tests.
+
+The model lane proxies provider API traffic through the same policy engine the
+hooks run. Unit tests drive the pieces in-process; transport tests run the real
+handler against a fake upstream bound on loopback, so the streaming relay and
+header rewriting are exercised end to end rather than mocked away.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
+
+from prismor.runtime import llm_gateway as llm  # noqa: E402
+from prismor.runtime.llm_gateway import (  # noqa: E402
+    GatewayConfig,
+    LlmGateway,
+    LlmGatewayError,
+    StreamTap,
+    Usage,
+    UsageMeter,
+    blocked_payload,
+    estimate_cost_usd,
+    extract_usage,
+    provider_for_path,
+    resolve_provider,
+    resolve_upstream_auth,
+    strip_provider_prefix,
+)
+
+
+class _Decision:
+    """Stand-in for the engine's decision object (only .blocking is read)."""
+
+    def __init__(self, blocking=None):
+        self.blocking = blocking
+        self.findings = []
+
+
+def _cfg(**kw) -> GatewayConfig:
+    kw.setdefault("workspace", Path("/tmp"))
+    kw.setdefault("session_id", "sess-test")
+    return GatewayConfig(**kw)
+
+
+# ── [A] provider resolution ──────────────────────────────────────────────────
+
+class TestProviderResolution:
+    def test_native_paths_map_to_their_provider(self):
+        assert provider_for_path("/v1/messages").name == "anthropic"
+        assert provider_for_path("/v1/chat/completions").name == "openai"
+        assert provider_for_path("/v1/embeddings").name == "openai"
+
+    def test_explicit_prefix_wins_over_native_path(self):
+        # /openai/v1/messages is an OpenAI-fronted call even though the tail
+        # looks Anthropic-shaped; the explicit prefix is authoritative.
+        assert provider_for_path("/openai/v1/messages").name == "openai"
+        assert provider_for_path("/anthropic/v1/messages").name == "anthropic"
+
+    def test_query_string_is_ignored(self):
+        assert provider_for_path("/v1/messages?beta=true").name == "anthropic"
+
+    def test_unknown_path_is_none(self):
+        assert provider_for_path("/nope") is None
+
+    def test_strip_prefix_restores_upstream_path(self):
+        spec = resolve_provider("anthropic")
+        assert strip_provider_prefix("/anthropic/v1/messages", spec) == "/v1/messages"
+        assert strip_provider_prefix("/v1/messages", spec) == "/v1/messages"
+        assert strip_provider_prefix("/anthropic", spec) == "/"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(LlmGatewayError):
+            resolve_provider("bedrock-but-not-yet")
+
+
+# ── [B] credential brokering ─────────────────────────────────────────────────
+
+class TestCredentialBrokering:
+    def test_env_key_used_when_client_sends_nothing(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+        spec = resolve_provider("anthropic")
+        assert resolve_upstream_auth(spec, None) == "sk-from-env"
+
+    def test_env_key_wins_over_client_supplied_key(self, monkeypatch):
+        # The point of brokering: the gateway's own credential is authoritative,
+        # so a client can hold a dummy value (or none) and still reach upstream.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+        spec = resolve_provider("openai")
+        assert resolve_upstream_auth(spec, "sk-client-placeholder") == "sk-real"
+
+    def test_client_key_honoured_when_gateway_has_none(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        spec = resolve_provider("openai")
+        assert resolve_upstream_auth(spec, "sk-byo") == "sk-byo"
+
+    def test_cloak_placeholder_resolves_through_the_store(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(llm, "_lookup_cloak_secret",
+                            lambda name: "sk-unwrapped" if name == "anthropic_key" else None)
+        spec = resolve_provider("anthropic")
+        assert resolve_upstream_auth(spec, "@@SECRET:anthropic_key@@") == "sk-unwrapped"
+
+    def test_unresolvable_placeholder_fails_loudly(self, monkeypatch):
+        monkeypatch.setattr(llm, "_lookup_cloak_secret", lambda name: None)
+        spec = resolve_provider("anthropic")
+        with pytest.raises(LlmGatewayError):
+            resolve_upstream_auth(spec, "@@SECRET:missing@@")
+
+    def test_no_credential_anywhere_returns_none(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        spec = resolve_provider("anthropic")
+        assert resolve_upstream_auth(spec, None) is None
+
+
+# ── [C] usage extraction ─────────────────────────────────────────────────────
+
+class TestUsageExtraction:
+    def test_anthropic_buffered_usage(self):
+        body = json.dumps({
+            "model": "claude-sonnet-5",
+            "usage": {"input_tokens": 120, "output_tokens": 42,
+                      "cache_read_input_tokens": 900,
+                      "cache_creation_input_tokens": 30},
+        }).encode()
+        usage = extract_usage("anthropic", body)
+        assert usage.model == "claude-sonnet-5"
+        assert usage.input_tokens == 120
+        assert usage.output_tokens == 42
+        assert usage.cache_read_tokens == 900
+        assert usage.cache_write_tokens == 30
+        assert usage.total_tokens == 1092
+
+    def test_openai_buffered_usage(self):
+        body = json.dumps({
+            "model": "gpt-5",
+            "usage": {"prompt_tokens": 200, "completion_tokens": 55,
+                      "prompt_tokens_details": {"cached_tokens": 64}},
+        }).encode()
+        usage = extract_usage("openai", body)
+        assert (usage.input_tokens, usage.output_tokens) == (200, 55)
+        assert usage.cache_read_tokens == 64
+
+    def test_malformed_body_yields_empty_usage_not_an_error(self):
+        # A provider that returns HTML on an outage must not take the proxy down.
+        assert extract_usage("openai", b"<html>502</html>").total_tokens == 0
+        assert extract_usage("anthropic", b"").total_tokens == 0
+
+
+class TestStreamTap:
+    def test_anthropic_stream_recovers_usage_and_text(self):
+        tap = StreamTap("anthropic")
+        events = [
+            {"type": "message_start",
+             "message": {"model": "claude-sonnet-5", "usage": {"input_tokens": 77}}},
+            {"type": "content_block_delta", "delta": {"text": "Hello "}},
+            {"type": "content_block_delta", "delta": {"text": "world"}},
+            {"type": "message_delta", "usage": {"output_tokens": 12}},
+        ]
+        for event in events:
+            tap.feed(b"data: " + json.dumps(event).encode() + b"\n\n")
+        assert tap.usage.model == "claude-sonnet-5"
+        assert tap.usage.input_tokens == 77
+        assert tap.usage.output_tokens == 12
+        assert tap.text == "Hello world"
+
+    def test_openai_stream_recovers_usage_and_text(self):
+        tap = StreamTap("openai")
+        chunks = [
+            {"model": "gpt-5", "choices": [{"delta": {"content": "abc"}}]},
+            {"model": "gpt-5", "choices": [{"delta": {"content": "def"}}]},
+            {"model": "gpt-5", "choices": [],
+             "usage": {"prompt_tokens": 9, "completion_tokens": 3}},
+        ]
+        for chunk in chunks:
+            tap.feed(b"data: " + json.dumps(chunk).encode() + b"\n\n")
+        tap.feed(b"data: [DONE]\n\n")
+        assert tap.text == "abcdef"
+        assert (tap.usage.input_tokens, tap.usage.output_tokens) == (9, 3)
+
+    def test_split_across_chunk_boundaries(self):
+        # Real SSE arrives in arbitrary TCP-sized pieces, not whole lines.
+        tap = StreamTap("anthropic")
+        payload = (b'data: {"type":"message_delta","usage":{"output_tokens":5}}\n\n')
+        for i in range(0, len(payload), 7):
+            tap.feed(payload[i:i + 7])
+        assert tap.usage.output_tokens == 5
+
+    def test_text_capture_is_capped(self):
+        tap = StreamTap("anthropic", cap=10)
+        for _ in range(5):
+            tap.feed(b'data: {"delta":{"text":"aaaaa"}}\n\n')
+        assert len(tap.text) == 10
+
+    def test_garbage_lines_are_skipped(self):
+        tap = StreamTap("openai")
+        tap.feed(b": ping\ndata: not-json\ndata: {\"usage\":{\"prompt_tokens\":4}}\n\n")
+        assert tap.usage.input_tokens == 4
+
+
+# ── [D] cost ─────────────────────────────────────────────────────────────────
+
+class TestCost:
+    def test_longest_matching_prefix_wins(self):
+        # "gpt-4o-mini" must not be priced as "gpt-4o".
+        mini = estimate_cost_usd(Usage(model="gpt-4o-mini", input_tokens=1_000_000))
+        full = estimate_cost_usd(Usage(model="gpt-4o", input_tokens=1_000_000))
+        assert mini == pytest.approx(0.15)
+        assert full == pytest.approx(2.50)
+
+    def test_output_priced_separately(self):
+        cost = estimate_cost_usd(Usage(model="claude-sonnet-5",
+                                       input_tokens=1_000_000,
+                                       output_tokens=1_000_000))
+        assert cost == pytest.approx(3.0 + 15.0)
+
+    def test_cache_reads_are_discounted(self):
+        cached = estimate_cost_usd(Usage(model="claude-sonnet-5",
+                                         cache_read_tokens=1_000_000))
+        fresh = estimate_cost_usd(Usage(model="claude-sonnet-5",
+                                        input_tokens=1_000_000))
+        assert cached < fresh
+
+    def test_unknown_model_uses_fallback_not_zero(self):
+        # A cost signal that silently reports $0 for new models is worse than
+        # a conservative estimate — it reads as "this model is free".
+        assert estimate_cost_usd(Usage(model="some-new-model",
+                                       input_tokens=1_000_000)) > 0
+
+    def test_pricing_override(self):
+        cost = estimate_cost_usd(Usage(model="house-model", input_tokens=1_000_000),
+                                 pricing={"house": (10.0, 20.0)})
+        assert cost == pytest.approx(10.0)
+
+
+# ── [E] policy events ────────────────────────────────────────────────────────
+
+class TestPolicyEvents:
+    def test_request_is_a_network_event_carrying_the_payload(self):
+        gateway = LlmGateway(_cfg())
+        spec = resolve_provider("anthropic")
+        event = gateway.build_request_event(
+            spec, "https://api.anthropic.com/v1/messages",
+            b'{"model":"claude-sonnet-5"}', "claude-sonnet-5")
+        # Reusing "network" is what inherits the egress allowlist and the
+        # secret-in-payload rules without any new policy surface.
+        assert event["type"] == "network"
+        assert event["url"] == "https://api.anthropic.com/v1/messages"
+        assert "claude-sonnet-5" in event["outbound_payload"]
+        assert event["agent_event"] == "PreToolUse"
+        assert event["metadata"]["tool_name"] == "llm__anthropic__claude-sonnet-5"
+        assert event["session_id"] == "sess-test"
+
+    def test_response_is_a_tool_result_event(self):
+        gateway = LlmGateway(_cfg())
+        spec = resolve_provider("openai")
+        event = gateway.build_response_event(spec, "the completion", "gpt-5")
+        assert event["type"] == "tool_result"
+        assert event["response"] == "the completion"
+        assert event["agent_event"] == "PostToolUse"
+
+    def test_scan_payload_is_capped(self):
+        gateway = LlmGateway(_cfg())
+        spec = resolve_provider("anthropic")
+        event = gateway.build_request_event(spec, "https://x", b"x" * (llm.SCAN_CAP * 2), "m")
+        assert len(event["outbound_payload"]) <= llm.SCAN_CAP
+
+    def test_model_and_stream_detection(self):
+        assert LlmGateway.model_of(b'{"model":"gpt-5"}') == "gpt-5"
+        assert LlmGateway.model_of(b"not json") == ""
+        assert LlmGateway.wants_stream(b'{"stream":true}') is True
+        assert LlmGateway.wants_stream(b'{"stream":false}') is False
+
+    def test_enforce_mode_fails_closed_on_engine_error(self, monkeypatch):
+        gateway = LlmGateway(_cfg(mode="enforce"))
+        monkeypatch.setattr("prismor.runtime.runtime.evaluate_tool_call",
+                            lambda **kw: (_ for _ in ()).throw(RuntimeError("engine down")))
+        with pytest.raises(LlmGatewayError):
+            gateway._evaluate({"type": "network"})
+
+    def test_observe_mode_fails_open_on_engine_error(self, monkeypatch):
+        gateway = LlmGateway(_cfg(mode="observe"))
+        monkeypatch.setattr("prismor.runtime.runtime.evaluate_tool_call",
+                            lambda **kw: (_ for _ in ()).throw(RuntimeError("engine down")))
+        assert gateway._evaluate({"type": "network"}) is None
+
+
+class TestBlockedPayload:
+    def test_anthropic_error_shape(self):
+        payload = blocked_payload("anthropic", {"title": "secret exfil",
+                                                "severity": "critical",
+                                                "ruleId": "secret-exfiltration"})
+        assert payload["type"] == "error"
+        assert payload["error"]["type"] == "permission_error"
+        assert "secret exfil" in payload["error"]["message"]
+        assert "secret-exfiltration" in payload["error"]["message"]
+
+    def test_openai_error_shape(self):
+        payload = blocked_payload("openai", {"title": "blocked"})
+        assert payload["error"]["code"] == "prismor_policy_block"
+        assert "blocked" in payload["error"]["message"]
+
+
+# ── [F] metering ─────────────────────────────────────────────────────────────
+
+class TestUsageMeter:
+    def test_record_accumulates_totals_and_cost(self):
+        meter = UsageMeter(flush_interval=9999)
+        meter.record(provider="anthropic",
+                     usage=Usage(model="claude-sonnet-5", input_tokens=1000,
+                                 output_tokens=500),
+                     session_id="s1", agent_name="a")
+        meter.record(provider="anthropic",
+                     usage=Usage(model="claude-sonnet-5", input_tokens=2000,
+                                 output_tokens=100),
+                     session_id="s1", agent_name="a")
+        snap = meter.snapshot()
+        assert snap["calls"] == 2
+        assert snap["usage"]["input_tokens"] == 3000
+        assert snap["usage"]["output_tokens"] == 600
+        assert snap["cost_usd"] > 0
+        assert snap["pending_records"] == 2
+
+    def test_record_shape_matches_the_telemetry_wire_contract(self):
+        meter = UsageMeter(flush_interval=9999)
+        record = meter.record(provider="openai",
+                              usage=Usage(model="gpt-5", input_tokens=10,
+                                          output_tokens=2),
+                              session_id="s9", agent_name="svc",
+                              latency_ms=123)
+        assert record["type"] == "llm_usage"
+        assert record["verdict"] == "observed"
+        assert record["session_id"] == "s9"
+        assert record["provider"] == "openai"
+        assert record["tool_name"] == "llm__openai__gpt-5"
+        assert record["usage"]["total_tokens"] == 12
+        assert record["latency_ms"] == 123
+        assert record["redacted"] is True
+        # Every record must be independently addressable for at-least-once
+        # upload dedupe, exactly like finding records.
+        assert record["event_id"]
+
+    def test_blocked_calls_are_still_metered(self):
+        meter = UsageMeter(flush_interval=9999)
+        record = meter.record(provider="anthropic", usage=Usage(model="m"),
+                              session_id="s", agent_name="a", blocked=True)
+        assert record["verdict"] == "blocked"
+
+    def test_flush_is_debounced_then_forced(self, monkeypatch):
+        sent = []
+        monkeypatch.setattr("prismor.runtime.sinks.upload_telemetry",
+                            lambda batch, *a, **k: sent.append(list(batch)))
+        meter = UsageMeter(flush_interval=9999)
+        meter.record(provider="openai", usage=Usage(model="gpt-5"),
+                     session_id="s", agent_name="a")
+        assert meter.maybe_flush() == 0        # debounced
+        assert meter.maybe_flush(force=True) == 1
+        assert len(sent) == 1 and len(sent[0]) == 1
+        assert meter.snapshot()["pending_records"] == 0
+
+    def test_upload_failure_never_propagates(self, monkeypatch):
+        def _boom(batch, *a, **k):
+            raise RuntimeError("control plane down")
+        monkeypatch.setattr("prismor.runtime.sinks.upload_telemetry", _boom)
+        meter = UsageMeter(flush_interval=0)
+        meter.record(provider="openai", usage=Usage(model="gpt-5"),
+                     session_id="s", agent_name="a")
+        assert meter.maybe_flush(force=True) == 1  # swallowed, not raised
+
+
+# ── [G] transport (real sockets, fake upstream) ──────────────────────────────
+
+class _FakeUpstream:
+    """A minimal stand-in provider: echoes auth headers, streams on demand."""
+
+    def __init__(self):
+        self.seen_headers = {}
+        self.seen_body = b""
+        handler = self._make_handler()
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+    def _make_handler(self):
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *a):
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                outer.seen_body = self.rfile.read(length) if length else b""
+                outer.seen_headers = {k.lower(): v for k, v in self.headers.items()}
+                if self.path.endswith("/stream"):
+                    return self._stream()
+                if self.path.endswith("/boom"):
+                    body = json.dumps({"error": {"message": "upstream sad"}}).encode()
+                    self.send_response(429)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+                body = json.dumps({
+                    "model": "claude-sonnet-5",
+                    "content": [{"type": "text", "text": "hi there"}],
+                    "usage": {"input_tokens": 11, "output_tokens": 7},
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _stream(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Transfer-Encoding", "chunked")
+                self.end_headers()
+                events = [
+                    {"type": "message_start",
+                     "message": {"model": "claude-sonnet-5",
+                                 "usage": {"input_tokens": 21}}},
+                    {"type": "content_block_delta", "delta": {"text": "streamed"}},
+                    {"type": "message_delta", "usage": {"output_tokens": 4}},
+                ]
+                for event in events:
+                    chunk = b"data: " + json.dumps(event).encode() + b"\n\n"
+                    self.wfile.write(b"%X\r\n%s\r\n" % (len(chunk), chunk))
+                    self.wfile.flush()
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+
+        return Handler
+
+
+class _GatewayHarness:
+    def __init__(self, gateway: LlmGateway):
+        self.gateway = gateway
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), llm._make_handler(gateway))
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def upstream():
+    server = _FakeUpstream()
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def allow_all(monkeypatch):
+    monkeypatch.setattr("prismor.runtime.runtime.evaluate_tool_call",
+                        lambda **kw: None)
+    monkeypatch.setattr("prismor.runtime.sinks.upload_telemetry",
+                        lambda batch, *a, **k: None)
+
+
+def _post(url: str, body: dict, headers: dict = None):
+    request = urllib.request.Request(
+        url, data=json.dumps(body).encode(), method="POST",
+        headers={"Content-Type": "application/json", **(headers or {})})
+    return urllib.request.urlopen(request, timeout=10)
+
+
+def _wait_for(predicate, timeout: float = 5.0):
+    """Await a server-side effect that lands after the client sees EOF.
+
+    On a streamed call the terminating chunk reaches the client before the
+    handler's post-stream metering runs — that ordering is deliberate (bytes
+    are never held back for accounting), so the test waits rather than
+    assuming the two finish together.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+class TestTransport:
+    def test_buffered_call_is_relayed_and_metered(self, upstream, allow_all,
+                                                  monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-broker")
+        gateway = LlmGateway(_cfg(provider="anthropic",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            response = _post(f"{harness.url}/v1/messages",
+                             {"model": "claude-sonnet-5"})
+            payload = json.loads(response.read())
+            assert payload["content"][0]["text"] == "hi there"
+            # The broker swapped in the gateway's own key.
+            assert upstream.seen_headers.get("x-api-key") == "sk-broker"
+            snap = gateway.meter.snapshot()
+            assert snap["calls"] == 1
+            assert snap["usage"]["input_tokens"] == 11
+            assert snap["usage"]["output_tokens"] == 7
+            assert snap["cost_usd"] > 0
+        finally:
+            harness.stop()
+
+    def test_client_never_needs_a_real_key(self, upstream, allow_all, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-broker")
+        monkeypatch.setattr(llm, "_lookup_cloak_secret", lambda n: None)
+        gateway = LlmGateway(_cfg(provider="anthropic",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            _post(f"{harness.url}/v1/messages", {"model": "claude-sonnet-5"},
+                  headers={"x-api-key": "not-a-real-key"})
+            assert upstream.seen_headers.get("x-api-key") == "sk-broker"
+        finally:
+            harness.stop()
+
+    def test_streaming_relays_and_meters(self, upstream, allow_all, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-broker")
+        gateway = LlmGateway(_cfg(provider="anthropic",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            response = _post(f"{harness.url}/stream", {"model": "claude-sonnet-5",
+                                                       "stream": True})
+            body = response.read().decode()
+            assert "streamed" in body
+            assert _wait_for(lambda: gateway.meter.snapshot()["calls"] == 1), \
+                "streamed call was never metered"
+            snap = gateway.meter.snapshot()
+            assert snap["usage"]["input_tokens"] == 21
+            assert snap["usage"]["output_tokens"] == 4
+        finally:
+            harness.stop()
+
+    def test_policy_block_returns_provider_shaped_error(self, upstream,
+                                                        monkeypatch):
+        monkeypatch.setattr(
+            "prismor.runtime.runtime.evaluate_tool_call",
+            lambda **kw: _Decision({"title": "secret in payload",
+                                    "severity": "critical",
+                                    "ruleId": "secret-exfiltration"}))
+        monkeypatch.setattr("prismor.runtime.sinks.upload_telemetry",
+                            lambda batch, *a, **k: None)
+        gateway = LlmGateway(_cfg(provider="anthropic", mode="enforce",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            with pytest.raises(urllib.error.HTTPError) as excinfo:
+                _post(f"{harness.url}/v1/messages", {"model": "claude-sonnet-5"})
+            assert excinfo.value.code == 403
+            payload = json.loads(excinfo.value.read())
+            assert payload["error"]["type"] == "permission_error"
+            assert "secret in payload" in payload["error"]["message"]
+            # Blocked before egress: upstream never saw the body.
+            assert upstream.seen_body == b""
+            # ...and the attempt is still metered, so blocked calls appear in
+            # the spend view rather than vanishing.
+            assert gateway.meter.snapshot()["calls"] == 1
+        finally:
+            harness.stop()
+
+    def test_upstream_error_is_relayed_verbatim(self, upstream, allow_all,
+                                                monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-broker")
+        gateway = LlmGateway(_cfg(provider="anthropic",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            with pytest.raises(urllib.error.HTTPError) as excinfo:
+                _post(f"{harness.url}/boom", {"model": "claude-sonnet-5"})
+            assert excinfo.value.code == 429
+            assert "upstream sad" in excinfo.value.read().decode()
+        finally:
+            harness.stop()
+
+    def test_health_and_metrics_endpoints(self, upstream, allow_all):
+        gateway = LlmGateway(_cfg(provider="anthropic",
+                                  base_url_override=upstream.base_url))
+        harness = _GatewayHarness(gateway)
+        try:
+            health = json.loads(urllib.request.urlopen(
+                f"{harness.url}/healthz", timeout=5).read())
+            assert health["status"] == "ok"
+            assert health["session_id"] == gateway.session_id
+            metrics = json.loads(urllib.request.urlopen(
+                f"{harness.url}/metrics", timeout=5).read())
+            assert metrics["calls"] == 0
+        finally:
+            harness.stop()
+
+    def test_unroutable_path_is_a_clear_404(self, allow_all):
+        gateway = LlmGateway(_cfg())  # no pinned provider
+        harness = _GatewayHarness(gateway)
+        try:
+            with pytest.raises(urllib.error.HTTPError) as excinfo:
+                _post(f"{harness.url}/nonsense", {})
+            assert excinfo.value.code == 404
+            assert "no provider matches" in excinfo.value.read().decode()
+        finally:
+            harness.stop()


### PR DESCRIPTION
## Why

The gateway has governed the **tool** lane since the MCP aggregator shipped: one connector in front of every MCP server, every `tools/call` policy-evaluated before it forwards, every result scanned before the model sees it.

Model traffic had no equivalent. An agent could be fully governed on the tool side and still paste a live credential straight into a prompt, and there was no attribution for what any of it cost.

This adds the **model lane**, and makes `prismor gateway` the umbrella command over both.

```
prismor gateway mcp    # tools  — the existing aggregator, unchanged
prismor gateway llm    # models — new
prismor mcp-gateway    # still works, alias for `gateway mcp`
```

Both lanes share one policy engine and one session id, so a session's tool calls and model calls land on the same trace.

## What the model lane does

A local HTTP proxy an SDK points at instead of the provider. Per request:

1. **Policy** — evaluated as a `network` event carrying the outbound payload. Reusing the existing event type is the whole trick: the egress allowlist, secret-in-payload rules, and taint escalation apply to model calls with **no new policy surface to configure**. A block is refused before egress, so the provider never receives the body.
2. **Credential brokering** — the real key is resolved server-side, from a Cloak placeholder or the gateway's own environment. Clients can hold a dummy value or nothing at all.
3. **Metering** — tokens and cost come from the provider's own usage accounting, attributed per session/agent, flushed as `llm_usage` records through the shared uploader, inheriting its offline spool and at-least-once dedupe.
4. **Response scan** — the completion is re-evaluated as untrusted content before being returned.

Only the base URL changes on the client:

```python
client = Anthropic(base_url="http://127.0.0.1:8787", api_key="unused")
```

## Design notes worth reviewing

**Streaming is a first-class path.** Agent traffic is overwhelmingly SSE; a proxy that only handled buffered JSON would be useless. Bytes relay unbuffered (time-to-first-token unchanged) while a tap recovers the usage block and assistant text. Usage is only knowable at end-of-stream, so the response scan on a streamed call is post-hoc **by construction** — the pre-call check has already run and the scan still reaches telemetry. Flagged in the code and docs rather than papered over.

**Fail-closed in enforce.** A policy engine that errors denies the call rather than waving model traffic through — same stance as the MCP lane.

**Denials wear the provider's error shape** (HTTP 403, `permission_error`), so SDKs surface a readable refusal instead of crashing on an unexpected body.

**Cost is attribution, not invoicing.** Built-in USD/1M-token table matched by longest model-id prefix, cache reads discounted. An unknown model falls back to a conservative non-zero rate — a silent `$0` reads as "this model is free". Override with `--pricing`.

**Bind is loopback-only by default.** The gateway is a credential-bearing egress point; `--host` is available but documented as needing an authenticating proxy in front.

## Second commit: a real bug this surfaced

`cloaked-secret-in-mcp-args` fires on any event with an `outbound_payload`. That was only ever remote MCP calls, so the hardcoded title "outbound MCP tool arguments" was accurate. The LLM lane reaches the same check with a *prompt* — so an operator blocked while pasting a token into a chat message was being pointed at the wrong subsystem.

Fixed the title to name the surface it saw. **Deliberately did not rename the ruleId** — the enforcement floor and existing `RuleExemptions` key on it, so renaming would silently drop both protections and admin-granted exemptions.

Found by running the real gateway against an enrolled secret on a real box, not in unit tests.

## Testing

**48 unit + transport tests** (`tests/test_llm_gateway.py`). Transport tests run the real handler against a fake upstream on loopback, so the streaming relay, header rewriting, and credential swap are exercised rather than mocked.

**End to end on st3ve** (Ubuntu, Python 3.12 — vs 3.14 locally), real CLI process, real sockets, isolated Cloak store via `PRISMOR_SECRETS_DIR`:

```
=== enforce: enrolled secret in a model prompt ===
  PASS  call refused (403)
  PASS  payload never reached the provider
  PASS  provider-shaped error
  PASS  names the secret, never the value
    -> Blocked by Prismor: [CRITICAL] Enrolled secret (placeholder for
       E2E_TEST_TOKEN) detected in an outbound model prompt
       (rule: cloaked-secret-in-mcp-args)

=== control: same prompt without the secret ===
  PASS  benign call still allowed (200)
  PASS  benign call reached the provider
  PASS  both calls metered (blocked + allowed)
```

Note the finding names the secret but never its value — asserted as an invariant in the unit tests too.

Also verified on st3ve: credential brokered server-side (the client's key is never forwarded), tokens metered from provider usage, cost attributed, blocked attempts still metered so they appear in spend rather than vanishing.

**Regression:** 231 passed / 2 skipped across `test_policy_engine`, `test_enforcement_floor`, `test_egress`, `test_mcp_gateway`, `test_cloak_secret_guard`.

The 4 failures in `test_cli.py` (3 x analyze, 1 x cloak env import) **pre-exist on clean `origin/main`** — verified by stashing and re-running.

## Not in this PR

- Bedrock provider (PrivateLink deployment) — next
- Wiring `llm_usage` into the control plane's ingest + spend dashboards — separate prismor-web PR
- Joining hook and gateway events into one rendered trace — depends on the above
