### PR TITLE
feat(approvals): user-configurable headless approvals + event-loop-safe waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- **Headless approvals are now user-configurable and event-loop-safe.** New `PRISMOR_APPROVALS` master switch (default on; `0`/`false`/`off` disables escalation fleet-wide - a STEP_UP verdict then fails closed exactly like an unenrolled install, without a control-plane round trip) plus a per-guard `approvals=False` keyword on every adapter surface that escalates (`prismor_guard_tool`/`guard_tools` and `PrismorCallbackHandler` for LangChain, `prismor_guard_tool` for CrewAI, `guard_controller` for browser-use, `prismor_guard`/`guard_agent` for OpenAI Agents). New `await_step_up_async()` runs the approval poll in a worker thread; the async adapters (LangChain `coroutine` path, browser-use, OpenAI Agents) now use it, so a pending approval no longer parks the event loop - previously a step-up froze every concurrent tool, LLM stream, and (for browser-use) the CDP socket for up to `PRISMOR_APPROVAL_TIMEOUT` seconds, which could time the browser out before a human ever decided. Approval outcomes and fail-closed semantics are unchanged.
+
 ## [1.35.0] — 2026-07-29
 
 ### Added

--- a/adapters/browser-use/prismor_browser_use/__init__.py
+++ b/adapters/browser-use/prismor_browser_use/__init__.py
@@ -135,6 +135,7 @@ def guard_controller(
     mode: str = "observe",
     session_id: Optional[str] = None,
     raise_on_block: bool = False,
+    approvals: bool = True,
     goal: Optional[str] = None,
 ) -> Any:
     """Patch ``controller.registry.execute_action`` to route every browser
@@ -191,12 +192,16 @@ def guard_controller(
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             # Headless STEP_UP → post an approval request and block until an admin
             # decides. Approve → proceed; deny/timeout/not-enrolled → fail closed.
-            try:
-                from prismor.runtime.enterprise import approvals as _approvals
-                if _approvals.await_step_up(decision, agent=agent, session_id=sid):
-                    return await original_execute(action_name, params, **kwargs)
-            except Exception:
-                pass
+            if approvals:
+                try:
+                    from prismor.runtime.enterprise import approvals as _approvals
+                    # async variant: the poll must not park the event loop that
+                    # is also driving the CDP socket, or the browser times out
+                    # before the human decides.
+                    if await _approvals.await_step_up_async(decision, agent=agent, session_id=sid):
+                        return await original_execute(action_name, params, **kwargs)
+                except Exception:
+                    pass
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)

--- a/adapters/crewai/prismor_crewai/__init__.py
+++ b/adapters/crewai/prismor_crewai/__init__.py
@@ -88,6 +88,7 @@ def prismor_guard_tool(
     session_id: Optional[str] = None,
     event_type: str = "shell",
     raise_on_block: bool = False,
+    approvals: bool = True,
 ) -> Any:
     """Wrap a CrewAI tool's implementation so calls are policy-checked."""
     if getattr(tool, "__prismor_guarded__", False):
@@ -106,12 +107,13 @@ def prismor_guard_tool(
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             # Headless STEP_UP → post an approval request and block until an admin
             # decides. Approve → proceed; deny/timeout/not-enrolled → fail closed.
-            try:
-                from prismor.runtime.enterprise import approvals as _approvals
-                if _approvals.await_step_up(decision, agent=agent, session_id=sid):
-                    return None  # approved → allowed
-            except Exception:
-                pass
+            if approvals:
+                try:
+                    from prismor.runtime.enterprise import approvals as _approvals
+                    if _approvals.await_step_up(decision, agent=agent, session_id=sid):
+                        return None  # approved → allowed
+                except Exception:
+                    pass
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)

--- a/adapters/langchain/prismor_langchain/__init__.py
+++ b/adapters/langchain/prismor_langchain/__init__.py
@@ -119,6 +119,7 @@ def prismor_guard_tool(
     session_id: Optional[str] = None,
     event_type: str = "shell",
     raise_on_block: bool = False,
+    approvals: bool = True,
 ) -> Any:
     """Wrap a LangChain ``BaseTool``'s implementation so calls are policy-checked.
 
@@ -142,12 +143,13 @@ def prismor_guard_tool(
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             # Headless STEP_UP → post an approval request and block until an admin
             # decides. Approve → proceed; deny/timeout/not-enrolled → fail closed.
-            try:
-                from prismor.runtime.enterprise import approvals as _approvals
-                if _approvals.await_step_up(decision, agent=agent, session_id=sid):
-                    return None  # approved → allowed
-            except Exception:
-                pass
+            if approvals:
+                try:
+                    from prismor.runtime.enterprise import approvals as _approvals
+                    if _approvals.await_step_up(decision, agent=agent, session_id=sid):
+                        return None  # approved → allowed
+                except Exception:
+                    pass
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)
@@ -166,7 +168,12 @@ def prismor_guard_tool(
     if callable(original_coro):
         @functools.wraps(original_coro)
         async def guarded_coro(*args: Any, **kwargs: Any) -> Any:
-            denial = _decide(args, kwargs)
+            # A STEP_UP inside _decide can wait minutes for a human; run the
+            # whole decision in a worker thread so this event loop keeps
+            # servicing other tools/streams instead of sleeping with it.
+            import asyncio
+
+            denial = await asyncio.to_thread(_decide, args, kwargs)
             return denial if denial is not None else await original_coro(*args, **kwargs)
         tool.coroutine = guarded_coro
 
@@ -238,6 +245,7 @@ class PrismorCallbackHandler(_BaseCB):  # type: ignore[misc]
         mode: str = "observe",
         session_id: Optional[str] = None,
         event_type: str = "shell",
+        approvals: bool = True,
     ) -> None:
         self._subject = subject
         self._ws = Path(workspace) if workspace else Path.cwd()
@@ -245,6 +253,7 @@ class PrismorCallbackHandler(_BaseCB):  # type: ignore[misc]
         self._mode = mode
         self._sid = session_id or f"langchain-cb-{os.getpid()}"
         self._event_type = event_type
+        self._approvals = approvals
 
     def on_tool_start(self, serialized: dict, input_str: str, **kwargs: Any) -> None:
         name = (serialized or {}).get("name", "tool")
@@ -263,10 +272,11 @@ class PrismorCallbackHandler(_BaseCB):  # type: ignore[misc]
         )
         log_observe_findings(decision, mode=self._mode, tool_name=name)
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
-            try:
-                from prismor.runtime.enterprise import approvals as _approvals
-                if _approvals.await_step_up(decision, agent=self._agent, session_id=self._sid):
-                    return  # approved → allowed
-            except Exception:
-                pass
+            if self._approvals:
+                try:
+                    from prismor.runtime.enterprise import approvals as _approvals
+                    if _approvals.await_step_up(decision, agent=self._agent, session_id=self._sid):
+                        return  # approved → allowed
+                except Exception:
+                    pass
             raise PrismorBlocked(decision.reason or "policy violation", decision)

--- a/adapters/openai-agents/prismor_openai/__init__.py
+++ b/adapters/openai-agents/prismor_openai/__init__.py
@@ -126,6 +126,7 @@ def prismor_guard(
     event_type: str = "shell",
     command_builder: Optional[Callable[[tuple, dict], str]] = None,
     raise_on_block: bool = True,
+    approvals: bool = True,
 ) -> Callable[..., Any]:
     """Wrap ``tool`` so each call is evaluated by Prismor before it runs.
 
@@ -160,6 +161,7 @@ def prismor_guard(
             session_id=session_id,
             event_type=event_type,
             raise_on_block=raise_on_block,
+            approvals=approvals,
         )
 
     ws = Path(workspace) if workspace else Path.cwd()
@@ -239,6 +241,7 @@ def _guard_function_tool(
     session_id: Optional[str],
     event_type: str,
     raise_on_block: bool,
+    approvals: bool = True,
 ) -> Any:
     """Wrap a FunctionTool's ``on_invoke_tool`` so the call is evaluated first.
 
@@ -293,14 +296,17 @@ def _guard_function_tool(
             # post an approval request to the control plane and block until an
             # admin approves. Approve → proceed; deny/timeout/not-enrolled → fail
             # closed to the block below.
-            try:
-                from prismor.runtime.enterprise import approvals as _approvals
-                if _approvals.step_up_finding(decision) is not None and _approvals.await_step_up(
-                    decision, event=event, agent=agent, session_id=sid
-                ):
-                    return await original(ctx, input_str)
-            except Exception:
-                pass  # any approval-path error fails closed
+            if approvals:
+                try:
+                    from prismor.runtime.enterprise import approvals as _approvals
+                    # async variant: the wait runs in a worker thread so this
+                    # event loop keeps servicing concurrent tools and streams.
+                    if await _approvals.await_step_up_async(
+                        decision, event=event, agent=agent, session_id=sid
+                    ):
+                        return await original(ctx, input_str)
+                except Exception:
+                    pass  # any approval-path error fails closed
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)
@@ -323,6 +329,7 @@ def guard_agent(
     session_id: Optional[str] = None,
     event_type: str = "shell",
     raise_on_block: bool = False,
+    approvals: bool = True,
     goal: Optional[str] = None,
 ) -> Any:
     """Guard **every** FunctionTool on an Agent in one call — the easy path.
@@ -350,6 +357,7 @@ def guard_agent(
                 session_id=session_id,
                 event_type=event_type,
                 raise_on_block=raise_on_block,
+                approvals=approvals,
             )
             guarded.append(getattr(tool, "name", "tool"))
     agent_obj.__prismor_guarded_tools__ = guarded  # type: ignore[attr-defined]

--- a/prismor/runtime/enterprise/approvals.py
+++ b/prismor/runtime/enterprise/approvals.py
@@ -55,6 +55,19 @@ def _poll_interval() -> float:
         return DEFAULT_POLL
 
 
+def enabled() -> bool:
+    """Master switch for headless approvals (``PRISMOR_APPROVALS``).
+
+    Defaults to on. Set ``PRISMOR_APPROVALS=0`` (or ``false``/``off``/``no``)
+    to disable escalation entirely: a STEP_UP verdict is then not posted to the
+    control plane and the caller fails closed - exactly the posture of an
+    unenrolled install. Per-guard opt-out is available via the adapters'
+    ``approvals=False`` keyword; this env var is the fleet-wide override.
+    """
+    val = str(os.environ.get("PRISMOR_APPROVALS", "1")).strip().lower()
+    return val not in ("0", "false", "off", "no")
+
+
 def step_up_finding(decision: Any) -> Optional[Dict[str, Any]]:
     """The blocking finding iff it is a STEP_UP verdict, else None."""
     blocking = getattr(decision, "blocking", None)
@@ -156,7 +169,7 @@ def await_step_up(
     recorded on the signed audit trail.
     """
     finding = step_up_finding(decision)
-    if finding is None:
+    if finding is None or not enabled():
         return False
     ident = _identity.load_identity()
     if not ident or _identity.revoked_backoff_active():
@@ -202,6 +215,31 @@ def await_step_up(
             return False
     _record("timeout", approval_id)
     return False  # timed out → fail closed
+
+
+async def await_step_up_async(
+    decision: Any,
+    *,
+    event: Optional[Dict[str, Any]] = None,
+    agent: str = "",
+    session_id: str = "",
+) -> bool:
+    """Event-loop-safe :func:`await_step_up`.
+
+    The sync poll loop sleeps for up to ``PRISMOR_APPROVAL_TIMEOUT`` seconds;
+    called directly from an ``async def`` tool wrapper it would park the entire
+    event loop - stalling every concurrent tool, LLM stream, and (for
+    browser-use) the CDP socket - until a human decides. This variant runs the
+    wait in a worker thread instead, so the loop keeps servicing. Same
+    contract: True only on an explicit approval, everything else False.
+    """
+    if step_up_finding(decision) is None or not enabled():
+        return False
+    import asyncio
+
+    return await asyncio.to_thread(
+        await_step_up, decision, event=event, agent=agent, session_id=session_id
+    )
 
 
 def _monotonic() -> float:

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -34,6 +34,7 @@ def _decision(action="step_up"):
 
 class ApprovalClient(unittest.TestCase):
     def setUp(self):
+        os.environ.pop("PRISMOR_APPROVALS", None)
         os.environ["PRISMOR_APPROVAL_POLL"] = "0.01"
         os.environ["PRISMOR_APPROVAL_TIMEOUT"] = "2"
         self._ident = {"device_key": "prism_dev_x", "api_base": "https://cp.example"}
@@ -85,6 +86,66 @@ class ApprovalClient(unittest.TestCase):
     def test_post_failure_fails_closed(self):
         approvals._post_request = lambda ident, body, timeout: None
         self.assertFalse(approvals.await_step_up(_decision()))
+
+
+class ApprovalConfig(ApprovalClient):
+    """PRISMOR_APPROVALS master switch + the event-loop-safe async variant."""
+
+    def test_disabled_by_env_fails_closed_without_posting(self):
+        os.environ["PRISMOR_APPROVALS"] = "0"
+        try:
+            self.assertFalse(approvals.await_step_up(_decision(), session_id="s1"))
+            self.assertEqual(self._posts, [])  # never reached the control plane
+        finally:
+            os.environ.pop("PRISMOR_APPROVALS", None)
+
+    def test_enabled_accepts_common_truthy_spellings(self):
+        for val in ("1", "true", "on", "yes", ""):
+            os.environ["PRISMOR_APPROVALS"] = val
+            self.assertTrue(approvals.enabled(), val)
+        for val in ("0", "false", "off", "no"):
+            os.environ["PRISMOR_APPROVALS"] = val
+            self.assertFalse(approvals.enabled(), val)
+        os.environ.pop("PRISMOR_APPROVALS", None)
+
+    def test_async_variant_approves_off_the_event_loop(self):
+        import asyncio
+
+        self._status_seq = ["pending", "approved"]
+        loop_blocked = {"max_gap": 0.0}
+
+        async def heartbeat():
+            # If await_step_up ran ON the loop, this coroutine would starve for
+            # the full poll duration; a healthy loop keeps ticking every ~1ms.
+            import time as _t
+            last = _t.monotonic()
+            while True:
+                await asyncio.sleep(0.001)
+                now = _t.monotonic()
+                loop_blocked["max_gap"] = max(loop_blocked["max_gap"], now - last)
+                last = now
+
+        async def main():
+            hb = asyncio.ensure_future(heartbeat())
+            ok = await approvals.await_step_up_async(_decision(), session_id="s1", agent="crewai")
+            hb.cancel()
+            return ok
+
+        self.assertTrue(asyncio.run(main()))
+        self.assertLess(loop_blocked["max_gap"], 0.5)
+
+    def test_async_variant_not_step_up_short_circuits(self):
+        import asyncio
+        self.assertFalse(asyncio.run(approvals.await_step_up_async(_decision(action="block"))))
+
+    def test_async_variant_disabled_short_circuits(self):
+        import asyncio
+        os.environ["PRISMOR_APPROVALS"] = "off"
+        try:
+            self.assertFalse(asyncio.run(approvals.await_step_up_async(_decision())))
+            self.assertEqual(self._posts, [])
+        finally:
+            os.environ.pop("PRISMOR_APPROVALS", None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Companion to the control-plane webhook work (prismor-web #155/#156): approvals become something the **user configures**, at both fleet and per-integration granularity, and the wait no longer degrades the agent hosting it.

## Configuration

| Knob | Scope | Behavior |
|---|---|---|
| `PRISMOR_APPROVALS` | fleet (env) | Default on. `0`/`false`/`off` disables escalation entirely — a STEP_UP verdict fails closed exactly like an unenrolled install, with **no control-plane round trip**. |
| `approvals=False` | per guard | New keyword on every escalating adapter surface: LangChain `prismor_guard_tool`/`guard_tools`/`PrismorCallbackHandler`, CrewAI `prismor_guard_tool`, browser-use `guard_controller`, OpenAI Agents `prismor_guard`/`guard_agent`. |
| `PRISMOR_APPROVAL_TIMEOUT` / `PRISMOR_APPROVAL_POLL` | fleet (env) | Pre-existing, unchanged. |

Fail-closed semantics are unchanged everywhere: disabled ⇒ deny, never allow.

## Event-loop safety

`await_step_up()` is a sync poll loop (`time.sleep`, up to `PRISMOR_APPROVAL_TIMEOUT`s). The async adapters called it directly from `async def` wrappers, so one pending approval **parked the entire event loop** — every concurrent tool, LLM stream, and (for browser-use) the CDP socket driving the browser stalled until the human decided or the timeout hit. For browser-use that meant the browser could time out before an admin ever saw the request.

New `await_step_up_async()` runs the wait via `asyncio.to_thread` (contextvars propagate, so subject attribution is preserved). browser-use and OpenAI Agents now use it; LangChain's `coroutine` path runs its whole `_decide` off-loop the same way. Sync paths are untouched.

## Tests

`tests/test_approvals.py`: +5 — env-switch spellings, disabled-never-posts (asserts zero control-plane calls), async approval with a live heartbeat coroutine asserting the loop keeps ticking (<0.5s max gap) during a multi-poll wait, and short-circuit cases. 21 total, all green.