### PR TITLE
feat(headless): workspace-scope escape hatch + authenticated verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Added
+
+- **`PRISMOR_WORKSPACE_SCOPE` — an explicit scope for deployed, repo-less agents.** Workspace scope is inferred from the git remote, and it gates the org policy overlay, which is what carries the telemetry sink. A container or CI runner has no remote, so for an org that claims repo patterns the workspace fell through to `local`: no org policy, no telemetry, no heartbeat, no fleet registration, and not one line of output saying so. A production agent looked healthy and reported nothing. Set `PRISMOR_WORKSPACE_SCOPE=managed` (or `personal`/`local` to opt out) and the question is settled from the environment, so it needs no writable `$PRISMOR_HOME`. It is ranked below an org-claimed pattern, so a deployment can never use it to downgrade a repo the org governs.
+
+### Fixed
+
+- **`prismor enroll-status` and `prismor doctor` now verify against the control plane instead of trusting the local file.** Both reported "Enrolled" from `identity.json` alone, so a revoked, mistyped, or wrong-org key still read as healthy — and a `PRISMOR_AGENT_KEY` identity carries no org/device/label fields, so a perfectly working deployed agent printed `org: None / device id: None / label: None`. Both commands now make one authenticated call to `/api/policy/version` and print what the server resolved, or the reason it refused. `doctor`'s telemetry-sink check moved off the unauthenticated `/api/health` (up for anyone, so it passed with an invalid key) onto the same authenticated probe, and reports the org's capture mode alongside it.
+- **`prismor doctor` fails on a `local` workspace scope**, the quietest way to see nothing at all, and names the fix for both the deployed and the dev-machine case.
+
 ## [1.36.0] — 2026-08-02
 
 ### Added

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -355,10 +355,24 @@ def main(argv: Optional[List[str]] = None) -> None:
             print("  still applies (last good policy). Re-link with: prismor enroll <token>")
         else:
             print("Enrolled")
-        print(f"  org:        {ident.get('org_name') or ident.get('org_id')}")
-        print(f"  device id:  {ident.get('device_id')}")
-        print(f"  label:      {ident.get('label')}")
+        # An env key (PRISMOR_AGENT_KEY) carries no org/device/label, so the
+        # local view alone prints "org: None" on a perfectly healthy deployed
+        # agent - and prints "Enrolled" for a revoked one. Ask the server.
+        verified = _identity.verify_remote()
+        if verified.get("ok"):
+            print(f"  org:        {ident.get('org_name') or verified.get('org') or ident.get('org_id')}")
+            print(f"  device id:  {ident.get('device_id') or verified.get('device_id')}")
+            print(f"  label:      {ident.get('label') or '(from key)'}"
+                  + (f"  [{verified.get('kind')}]" if verified.get("kind") else ""))
+        else:
+            print(f"  org:        {ident.get('org_name') or ident.get('org_id')}")
+            print(f"  device id:  {ident.get('device_id')}")
+            print(f"  label:      {ident.get('label')}")
         print(f"  api base:   {ident.get('api_base')}")
+        if verified.get("ok"):
+            print(f"  verified:   ✓ control plane accepted this key (policy v{verified.get('version')})")
+        else:
+            print(f"  verified:   ✗ {verified.get('error')}")
         try:
             from prismor.runtime.enterprise import remote_policy as _remote
             meta_path = _remote._meta_path()
@@ -3658,7 +3672,18 @@ def _run_doctor(workspace: Path, as_json: bool = False) -> None:
                 f"enrolled to {ident.get('org_name') or ident.get('org_id')} but the control plane rejected this device "
                 f"({revoked.get('reason') or '401/403'}) — likely revoked; local protection continues")
         else:
-            add("ok", "enrollment", f"enrolled to {ident.get('org_name') or ident.get('org_id')} as {ident.get('label')}")
+            # Authenticated round-trip: the local file says "enrolled" even when
+            # the key is revoked, mistyped, or points at another org - and an
+            # env key has no org/label to print at all.
+            v = _identity.verify_remote()
+            if v.get("ok"):
+                who = ident.get("org_name") or v.get("org") or ident.get("org_id")
+                label = ident.get("label") or f"key-authenticated {v.get('kind') or 'device'}"
+                add("ok", "enrollment", f"verified with the control plane — org {who}, as {label}")
+            else:
+                add("fail", "enrollment",
+                    f"the control plane did not accept this key: {v.get('error')} — "
+                    "nothing this agent does will reach the console")
         try:
             from prismor.runtime.enterprise import remote_policy as _remote
             cached = _remote.cached_policy_path()
@@ -3678,16 +3703,24 @@ def _run_doctor(workspace: Path, as_json: bool = False) -> None:
             add("fail", "remote policy", f"verification error: {exc}")
 
     # 5. Telemetry sink reachability + spool backlog.
+    #
+    # Reachability was checked against the UNAUTHENTICATED /api/health, which is
+    # up for anyone - so "sink ok" was true with a completely invalid key. Reuse
+    # the authenticated probe above: it answers the question that matters, which
+    # is whether THIS key can deliver.
     if ident:
         api_base = str(ident.get("api_base") or "").rstrip("/")
-        try:
-            import urllib.request
-            req = urllib.request.Request(f"{api_base}/api/health", method="GET")
-            with urllib.request.urlopen(req, timeout=3) as resp:
-                resp.read(16)
-            add("ok", "telemetry sink", f"control plane reachable ({api_base})")
-        except Exception as exc:
-            add("warn", "telemetry sink", f"control plane unreachable ({exc.__class__.__name__}) — events spool locally")
+        _v = _identity.verify_remote()
+        if _v.get("ok"):
+            add("ok", "telemetry sink", f"authenticated to {api_base} (policy v{_v.get('version')})")
+            add("ok" if _v.get("full_capture") else "warn", "capture",
+                "FULL — flagged events carry scrubbed content"
+                if _v.get("full_capture")
+                else "redacted — metadata and hashes only; enable full capture in Org Settings for content")
+        elif "unreachable" in str(_v.get("error", "")):
+            add("warn", "telemetry sink", f"control plane unreachable — events spool locally ({_v.get('error')})")
+        else:
+            add("fail", "telemetry sink", f"cannot deliver: {_v.get('error')}")
         try:
             from prismor.runtime.enterprise import telemetry_spool as _spool
             pending = _spool.pending_count()
@@ -3697,6 +3730,28 @@ def _run_doctor(workspace: Path, as_json: bool = False) -> None:
                 add("ok", "telemetry spool", "empty")
         except Exception:
             pass
+
+        # 5b. Workspace scope — the quietest way to see nothing at all. Scope is
+        # inferred from the git remote; a container has none, so an org that
+        # claims repo patterns leaves it "local": no org policy overlay, hence
+        # no telemetry sink, no heartbeat, no fleet registration, and not one
+        # log line about it. Fail loudly with the fix.
+        try:
+            from prismor.runtime.enterprise import workspace_scope as _scope
+            info = _scope.resolve_scope(workspace)
+            reason = info.get("reason")
+            if info.get("scope") == "managed":
+                add("ok", "workspace scope", f"managed ({reason}) — org policy and telemetry apply here")
+            elif reason == "env_opt_out":
+                add("warn", "workspace scope",
+                    "local by PRISMOR_WORKSPACE_SCOPE — deliberate opt-out; nothing is reported")
+            else:
+                add("fail", "workspace scope",
+                    f"local ({reason}) — no org policy, no telemetry, no heartbeat from this workspace. "
+                    "For a deployed agent set PRISMOR_WORKSPACE_SCOPE=managed; on a dev machine run "
+                    "`prismor workspace managed` or have an admin claim the repo pattern")
+        except Exception as exc:
+            add("warn", "workspace scope", f"could not resolve: {exc}")
     else:
         add("warn", "telemetry sink", "n/a (not enrolled)")
 

--- a/prismor/runtime/enterprise/identity.py
+++ b/prismor/runtime/enterprise/identity.py
@@ -166,6 +166,63 @@ def revoked_info() -> Optional[Dict[str, Any]]:
         return None
 
 
+def verify_remote(timeout: float = 6.0) -> Dict[str, Any]:
+    """Ask the control plane who this key actually is. One authenticated call.
+
+    ``prismor enroll-status`` and ``doctor`` historically reported "Enrolled"
+    from the *local* identity alone, so a typo'd, revoked, or wrong-org key
+    still read as healthy - and an env key (``PRISMOR_AGENT_KEY``) carries no
+    org/device fields at all, printing ``org: None``. A deployed agent then
+    looks fine and reports nothing. This round-trips ``/api/policy/version``
+    (device-authenticated, also bumps ``lastSeenAt``) and returns what the
+    SERVER resolved.
+
+    Returns ``{ok: True, org, device_id, kind, version, full_capture}`` or
+    ``{ok: False, error: <short reason>}``. Never raises: verification failing
+    must not break the command reporting it.
+    """
+    ident = load_identity()
+    if not ident:
+        return {"ok": False, "error": "not enrolled"}
+    key = str(ident.get("device_key") or "")
+    if not key:
+        return {"ok": False, "error": "no device key in identity"}
+
+    import urllib.error
+    import urllib.request
+
+    base = str(ident.get("api_base") or api_base()).rstrip("/")
+    url = f"{base}/api/policy/version"
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {key}"}, method="GET"
+    )
+    try:
+        from prismor.runtime.http_ua import user_agent as _ua
+        req.add_header("User-Agent", _ua())
+    except Exception:
+        pass
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            return {"ok": False, "error": f"control plane rejected this key (HTTP {exc.code}) - revoked or wrong key"}
+        return {"ok": False, "error": f"HTTP {exc.code} from {base}"}
+    except (urllib.error.URLError, OSError) as exc:
+        return {"ok": False, "error": f"unreachable ({exc.__class__.__name__})"}
+    except ValueError:
+        return {"ok": False, "error": "malformed response from the control plane"}
+
+    return {
+        "ok": True,
+        "org": data.get("org"),
+        "device_id": data.get("deviceId"),
+        "kind": data.get("deviceKind"),
+        "version": data.get("version"),
+        "full_capture": data.get("fullCapture"),
+    }
+
+
 def revoked_backoff_active() -> bool:
     """True while we should skip control-plane calls after a revocation."""
     import time

--- a/prismor/runtime/enterprise/workspace_scope.py
+++ b/prismor/runtime/enterprise/workspace_scope.py
@@ -19,11 +19,21 @@ Concretely, "managed" gates two things at the runtime: the org policy overlay
 merge (see policy_engine) — which also carries the org telemetry sink — and the
 per-call heartbeat (see cli hook-dispatch). Personal workspaces therefore emit
 no findings, no volume, and apply no org policy; the org never sees them.
+
+**Deployed workloads.** Scope is inferred from the git remote, which a container
+or CI runner does not have. With no remote and an org that claims patterns, such
+a workspace falls through to local — correct for a laptop, silently wrong for a
+production agent that reports nothing and says so nowhere. ``PRISMOR_WORKSPACE_SCOPE``
+settles it explicitly (``managed`` | ``personal``) for exactly that case: it is
+read from the environment, so it needs no writable ``$PRISMOR_HOME``, and it is
+ranked below an org-claimed pattern — a deployment cannot use it to downgrade a
+repo the org claims.
 """
 from __future__ import annotations
 
 import fnmatch
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -119,15 +129,32 @@ def _matches(remote: str, pattern: str) -> bool:
     return fnmatch.fnmatch(remote, pattern) or fnmatch.fnmatch(remote.split("/", 1)[-1], pattern)
 
 
+def _env_scope() -> Optional[str]:
+    """``PRISMOR_WORKSPACE_SCOPE`` — explicit scope for repo-less workloads.
+
+    ``managed`` (org policy + telemetry apply) or ``personal``/``local`` (opt
+    out). Anything else is ignored rather than raising: a typo in a container
+    env must not take the runtime down.
+    """
+    val = str(os.environ.get("PRISMOR_WORKSPACE_SCOPE", "")).strip().lower()
+    if val == "managed":
+        return "managed"
+    if val in ("personal", "local"):
+        return "personal"
+    return None
+
+
 def resolve_scope(workspace: Path) -> Dict[str, Any]:
     """Classify a workspace. Returns {scope: 'managed'|'local', reason, remote,
     org_id}. Decision order:
       1. not enrolled → local (nothing to report to).
       2. remote matches an org-claimed pattern → managed, FORCED (a developer
          cannot downgrade a company/client repo).
-      3. developer override (opt-in 'managed' / opt-out 'personal') for a
+      3. PRISMOR_WORKSPACE_SCOPE env override for a non-claimed workspace →
+         honored (the deployed-workload path: no git remote, no writable home).
+      4. developer override (opt-in 'managed' / opt-out 'personal') for a
          non-claimed repo → honored.
-      4. default: if the org has claimed NO patterns, manage everything
+      5. default: if the org has claimed NO patterns, manage everything
          (backward-compatible "cover all dev machines"); if the org HAS claimed
          patterns, a non-matching repo is the developer's personal space.
     """
@@ -145,6 +172,12 @@ def resolve_scope(workspace: Path) -> Dict[str, Any]:
         for pat in patterns:
             if _matches(remote, pat):
                 return {"scope": "managed", "reason": "org_claimed", "remote": remote, "org_id": org_id, "pattern": pat}
+
+    env_scope = _env_scope()
+    if env_scope == "managed":
+        return {"scope": "managed", "reason": "env_override", "remote": remote, "org_id": org_id}
+    if env_scope == "personal":
+        return {"scope": "local", "reason": "env_opt_out", "remote": remote, "org_id": None}
 
     override = _load_overrides().get(str(workspace.resolve()))
     if override == "managed":

--- a/tests/test_workspace_scope_env.py
+++ b/tests/test_workspace_scope_env.py
@@ -1,0 +1,92 @@
+"""PRISMOR_WORKSPACE_SCOPE — the escape hatch for repo-less deployed workloads.
+
+Scope decides whether the org policy overlay merges, and that overlay is what
+carries the telemetry sink. A container has no git remote, so an org that claims
+repo patterns leaves it 'local' and it reports nothing, silently. The env var
+settles it — but it must NOT let a deployment downgrade a repo the org claims.
+Run: python3 tests/test_workspace_scope_env.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+from prismor.runtime.enterprise import workspace_scope as ws  # noqa: E402
+
+
+class EnvScopeOverride(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("PRISMOR_WORKSPACE_SCOPE", None)
+        self._ident = {"org_id": "org_1", "device_key": "k", "api_base": "https://cp.example"}
+        ws._identity.load_identity = lambda: self._ident
+        ws._identity.revoked_info = lambda: None
+        ws.detect_git_remote = lambda _w: None      # a container: no remote
+        ws.org_managed_patterns = lambda: ["github.com/acme/*"]
+        ws._load_overrides = lambda: {}
+
+    def tearDown(self):
+        os.environ.pop("PRISMOR_WORKSPACE_SCOPE", None)
+
+    def test_repoless_workload_is_local_without_the_override(self):
+        # The status quo this exists to fix: silent, total non-reporting.
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "local")
+        self.assertEqual(r["reason"], "personal")
+
+    def test_managed_opts_a_repoless_workload_in(self):
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "managed"
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "managed")
+        self.assertEqual(r["reason"], "env_override")
+        self.assertEqual(r["org_id"], "org_1")
+
+    def test_personal_and_local_opt_out(self):
+        for val in ("personal", "local"):
+            os.environ["PRISMOR_WORKSPACE_SCOPE"] = val
+            r = ws.resolve_scope(Path("/srv/agent"))
+            self.assertEqual(r["scope"], "local", val)
+            self.assertEqual(r["reason"], "env_opt_out", val)
+
+    def test_case_and_whitespace_tolerant(self):
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "  MANAGED  "
+        self.assertEqual(ws.resolve_scope(Path("/srv/agent"))["scope"], "managed")
+
+    def test_garbage_value_is_ignored_not_fatal(self):
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "yes-please"
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "local")
+        self.assertEqual(r["reason"], "personal")  # fell through, did not raise
+
+    def test_cannot_downgrade_a_repo_the_org_claims(self):
+        # The security property: an org-claimed remote outranks the env var, so
+        # a deployment cannot opt company code out of governance.
+        ws.detect_git_remote = lambda _w: "github.com/acme/payments"
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "personal"
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "managed")
+        self.assertEqual(r["reason"], "org_claimed")
+
+    def test_unenrolled_stays_local_regardless(self):
+        ws._identity.load_identity = lambda: None
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "managed"
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "local")
+        self.assertEqual(r["reason"], "not_enrolled")
+
+    def test_env_outranks_the_on_disk_override(self):
+        # A container's $PRISMOR_HOME is often read-only, so the env var has to
+        # win over a stale file written into the image.
+        ws._load_overrides = lambda: {str(Path("/srv/agent").resolve()): "personal"}
+        os.environ["PRISMOR_WORKSPACE_SCOPE"] = "managed"
+        r = ws.resolve_scope(Path("/srv/agent"))
+        self.assertEqual(r["scope"], "managed")
+        self.assertEqual(r["reason"], "env_override")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Onboarding a production agent currently fails **silently** in two places. This fixes both.

## 1. A deployed agent can report nothing, and say nothing about it

Workspace scope is inferred from the git remote (`workspace_scope.py:120-160`), and it gates the org policy overlay (`policy_engine.py:787-800`) — **which is what carries the telemetry sink**. A container or CI runner has no remote, so for any org that has claimed repo patterns the workspace falls through to `local`: no org policy, no telemetry, no heartbeat, no fleet registration, and **not one line of output**. The agent guards correctly and the console stays empty.

New `PRISMOR_WORKSPACE_SCOPE=managed` (or `personal`/`local`) settles it from the environment — no writable `$PRISMOR_HOME` required, which matters because the recommended container config is `--read-only`.

**Security property preserved**: the env var ranks *below* an org-claimed pattern, so a deployment can never use it to downgrade a repo the org governs. Covered by a test.

## 2. Verification reported health it had not checked

- `enroll-status` and `doctor` read `identity.json` only — a revoked, mistyped, or wrong-org key still printed **"Enrolled"**.
- A `PRISMOR_AGENT_KEY` identity carries no org/device/label, so a perfectly working deployed agent printed `org: None / device id: None / label: None`.
- `doctor`'s telemetry-sink check pinged the **unauthenticated** `/api/health` (`cli.py:3448`) — up for anyone, so it passed with a completely invalid key.

Both commands now make one authenticated call to `/api/policy/version` (device-authenticated, also bumps `lastSeenAt`) via a new `identity.verify_remote()`, and print what the **server** resolved — or the reason it refused. The sink check uses the same probe and now also reports the org's capture mode. A `local` workspace scope is a hard **fail** naming the fix for both the deployed and dev-machine cases.

Pairs with a prismor-web change echoing `org`/`deviceId`/`deviceKind` from `/api/policy/version` (backwards compatible — older runtimes ignore the extra fields).

## Tests

8 new cases in `tests/test_workspace_scope_env.py`: override, opt-out spellings, whitespace/case, garbage-is-ignored-not-fatal, unenrolled, on-disk-override precedence, and the org-claimed-wins security property. Security regression suite green (137). The 4 unrelated `test_cli.py` failures are pre-existing (verified against a stashed baseline).