### PR TITLE
feat(policy): honor step_up in settings.tool_denies (tool-level human approval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- **Tool-level step-up: an admin can mark a tool "requires human approval" from the console.** `settings.tool_denies` understood only `deny` and `allow`, so a `step_up` entry was skipped and the call ran — a policy the fleet silently ignored. A step-up entry now produces a finding carrying `action: step_up`, which `should_block` ranks below a real block and above `defer`: interactive agents render an inline ask, headless ones post an approval request and wait on the decision. Every non-approval outcome (deny, expiry, timeout, error) still fails closed, so this is strictly softer than a deny and never softer than allowing the call. Like a deny it is categorised `agent-control`, so a local `--mode observe` cannot suppress an approval requirement the org set.
+
 ## [1.37.0] — 2026-08-03
 
 ### Added

--- a/prismor/runtime/agents.py
+++ b/prismor/runtime/agents.py
@@ -496,6 +496,33 @@ def make_agent_tool_deny_finding(
     }
 
 
+def make_agent_tool_step_up_finding(
+    name: str, tool: str, session_id: str = "", scope_label: str = "org",
+    rule_id: str = "org-tool-step-up",
+) -> Dict[str, Any]:
+    """Human-approval finding for a tool an admin marked ``step_up``.
+
+    Same shape as :func:`make_agent_tool_deny_finding` but carrying
+    ``action: step_up``, which ``hooks.should_block`` ranks below block and
+    above defer. Interactive agents render it as an inline ask; headless ones
+    post an approval request (see enterprise.approvals) and wait. Every
+    non-approval outcome still fails closed, so this is strictly softer than a
+    deny and never softer than allowing the call.
+    """
+    return {
+        "id": f"{session_id}:{rule_id}:{name}:{tool}",
+        "ruleId": rule_id,
+        "action": "step_up",
+        "severity": "high",
+        "category": "agent-control",  # applies regardless of observe/enforce
+        "mode": "enforce",
+        "title": f"[approval required] Tool '{tool}' needs a human decision ({scope_label} scope)",
+        "evidence": f"tool '{tool}' is marked step_up on the {scope_label} policy",
+        "eventIndex": 0,
+        "remediation": "Approve or deny in the Prismor console (Approvals), or via Slack / your webhook",
+    }
+
+
 # ── Display ────────────────────────────────────────────────────────────────────
 
 def format_agent_table(agents: List[AgentControl]) -> str:

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -296,11 +296,17 @@ def evaluate_tool_call(
     if _org_denies:
         try:
             from prismor.runtime.scoped_agent import resolve_tool_tags
-            from prismor.runtime.agents import make_agent_tool_deny_finding
+            from prismor.runtime.agents import (
+                make_agent_tool_deny_finding,
+                make_agent_tool_step_up_finding,
+            )
             _otags = resolve_tool_tags(event)
             if _otags:
                 for _d in _org_denies:
-                    if not isinstance(_d, dict) or _d.get("action", "deny") != "deny":
+                    # 'allow' entries are handled in the block below; anything
+                    # else we do not understand is skipped rather than guessed
+                    # at, so an unknown action can never weaken a decision.
+                    if not isinstance(_d, dict) or _d.get("action", "deny") not in ("deny", "step_up"):
                         continue
                     _otn = _d.get("tool")
                     if _otn not in _otags:
@@ -313,9 +319,14 @@ def evaluate_tool_call(
                         or (_scope == "session" and _sid == session_id)
                     )
                     if _hit:
-                        findings.append(make_agent_tool_deny_finding(
-                            _agent_name, _otn, session_id,
-                            scope_label=f"org {_scope}", rule_id="org-tool-deny"))
+                        if _d.get("action") == "step_up":
+                            findings.append(make_agent_tool_step_up_finding(
+                                _agent_name, _otn, session_id,
+                                scope_label=f"org {_scope}"))
+                        else:
+                            findings.append(make_agent_tool_deny_finding(
+                                _agent_name, _otn, session_id,
+                                scope_label=f"org {_scope}", rule_id="org-tool-deny"))
                         break
         except Exception as exc:
             sys.stderr.write(f"[prismor] org tool-deny error: {exc}\n")

--- a/tests/test_tool_step_up.py
+++ b/tests/test_tool_step_up.py
@@ -1,0 +1,75 @@
+"""Tool-level step_up: an org admin marking a tool "requires approval".
+
+`settings.tool_denies` previously understood only deny/allow, so a step_up
+entry written by the console was skipped and the call ran — a policy the fleet
+silently ignored. These pin that a step_up entry produces a finding carrying
+`action: step_up`, that should_block ranks it correctly against a real block,
+and that an unknown action is still ignored rather than guessed at.
+
+Run: python3 tests/test_tool_step_up.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+from prismor.runtime.agents import (  # noqa: E402
+    make_agent_tool_deny_finding,
+    make_agent_tool_step_up_finding,
+)
+from prismor.runtime.hooks import should_block  # noqa: E402
+
+PRE = {"agent_event": "PreToolUse"}
+
+
+class StepUpFinding(unittest.TestCase):
+    def test_carries_the_step_up_action(self):
+        f = make_agent_tool_step_up_finding("worker", "Bash", "s1")
+        self.assertEqual(f["action"], "step_up")
+        self.assertEqual(f["ruleId"], "org-tool-step-up")
+        # agent-control applies in observe mode too — an approval requirement
+        # the org set must not be suppressed by a local dry-run flag.
+        self.assertEqual(f["category"], "agent-control")
+        self.assertEqual(f["mode"], "enforce")
+
+    def test_deny_finding_still_blocks(self):
+        f = make_agent_tool_deny_finding("worker", "Bash", "s1")
+        self.assertNotEqual(f.get("action"), "step_up")
+
+    def test_should_block_surfaces_step_up(self):
+        f = make_agent_tool_step_up_finding("worker", "Bash", "s1")
+        picked = should_block([f], PRE)
+        self.assertIsNotNone(picked)
+        self.assertEqual(picked["action"], "step_up")
+
+    def test_a_real_block_outranks_a_step_up(self):
+        # Strongest verdict wins: if anything says block, a human is not asked.
+        step = make_agent_tool_step_up_finding("worker", "Bash", "s1")
+        deny = make_agent_tool_deny_finding("worker", "Bash", "s1")
+        picked = should_block([step, deny], PRE)
+        self.assertIsNotNone(picked)
+        self.assertNotEqual(picked.get("action"), "step_up")
+
+    def test_titles_say_what_is_being_asked(self):
+        f = make_agent_tool_step_up_finding("worker", "kubectl_delete", "s1", scope_label="org device")
+        self.assertIn("approval required", f["title"])
+        self.assertIn("kubectl_delete", f["title"])
+        self.assertIn("org device", f["title"])
+
+
+class ToolDeniesActionHandling(unittest.TestCase):
+    """The runtime loop only acts on actions it understands."""
+
+    def test_known_actions(self):
+        # Mirrors the membership test in runtime.py: deny and step_up act,
+        # allow is handled elsewhere, anything else is skipped.
+        for action, acted in (("deny", True), ("step_up", True), ("allow", False), ("nonsense", False)):
+            self.assertEqual(action in ("deny", "step_up"), acted, action)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Pairs with a prismor-web change that lets an admin mark a tool **"requires approval"** from a session or threat drill-in, applied across the policy profiles they select.

## The gap

`settings.tool_denies` carried `deny` and `allow`. The runtime loop skipped everything else:

```python
if not isinstance(_d, dict) or _d.get("action", "deny") != "deny":
    continue
```

So a `step_up` entry written by the console was **silently ignored** — the call ran and the policy did nothing. Meanwhile the approval machinery (inline ask, headless approval requests, Slack/webhook routing) has been in place since v1.36.0 with no way for an admin to point it at a specific tool.

## What this adds

A step-up entry now emits a finding carrying `action: step_up`, which `hooks.should_block` already ranks (`block > step_up > defer > modify`). From there the existing path takes over: interactive agents render an inline ask, headless agents post an approval request and wait on the decision.

Safety properties, each with a test:

- **Strictly softer than a deny, never softer than an allow.** Every non-approval outcome — denied, expired, timed out, network error — still fails closed.
- **A real block outranks it.** If anything says block, no human is asked.
- **Not suppressible locally.** Categorised `agent-control` like a deny, so a developer's local `--mode observe` cannot drop an approval requirement the org set.
- **Unknown actions are still skipped**, not guessed at, so a future action string can never weaken a decision on an old runtime.

## Tests

6 new in `tests/test_tool_step_up.py`. Security regression suite green (137).
