### PR TITLE
feat(hooks): add Gemini CLI agent adapter

### DIFF
--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -13,7 +13,7 @@ from prismor.runtime.store import append_session_event
 
 _SUPPORTED_AGENTS = [
     "claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro",
-    "crush", "openhands", "qwen", "continue", "goose",
+    "crush", "openhands", "qwen", "continue", "goose", "gemini",
 ]
 
 
@@ -45,6 +45,8 @@ def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[D
         return _strip_continue(config, marker)
     if agent == "goose":
         return _strip_goose(config, marker)
+    if agent == "gemini":
+        return _strip_gemini(config, marker)
     return _strip_windsurf(config, marker)
 
 
@@ -88,6 +90,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             # containing hooks/hooks.json — the plugin dir is config_path's
             # grandparent (.../plugins/prismor/hooks/hooks.json -> .../plugins/prismor/).
             config = _merge_goose(config, command, config_path.parent.parent)
+        elif current_agent == "gemini":
+            config = _merge_gemini(config, command)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -326,6 +330,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_continue(payload, session_id, workspace)
     elif agent == "goose":
         event = _normalize_goose(payload, session_id)
+    elif agent == "gemini":
+        event = _normalize_gemini(payload, session_id, workspace)
     else:
         event = _normalize_cursor(payload, session_id)
     if isinstance(event, dict) and event.get("type") == "shell" and event.get("command"):
@@ -452,6 +458,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".continue" / "settings.json"
         if agent == "goose":
             return workspace / ".agents" / "plugins" / "prismor" / "hooks" / "hooks.json"
+        if agent == "gemini":
+            return workspace / ".gemini" / "settings.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -484,6 +492,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".continue" / "settings.json"
     if agent == "goose":
         return home / ".agents" / "plugins" / "prismor" / "hooks" / "hooks.json"
+    if agent == "gemini":
+        return home / ".gemini" / "settings.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -2086,10 +2096,209 @@ def _normalize_openclaw(payload: Dict[str, Any], session_id: str) -> Dict[str, A
     return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 
+# ── Gemini CLI adapter ────────────────────────────────────────────────────────
+#
+# Gemini CLI (google-gemini/gemini-cli) uses the same Claude-style nested hook
+# config shape:
+#
+#   settings.json -> {"hooks": {"BeforeTool": [{"matcher": "...", "hooks":
+#                       [{"type": "command", "name": "prismor", "command": "..."}]}]}}
+#
+# Config locations:
+#   project:  <workspace>/.gemini/settings.json
+#   global:   ~/.gemini/settings.json
+#
+# Blocking: exit 2 blocks the tool call; stderr is surfaced to the user as the
+# rejection reason. Same convention as Claude Code / Codex / Grok.
+#
+# Not yet verified against a live `gemini` binary. Built from the public
+# Gemini CLI hooks documentation at https://geminicli.com/docs/hooks/reference/
+# and the Google Developers Blog launch post. Before relying on this in
+# `enforce` mode, run `gemini` and confirm a deliberately blocked command is
+# actually denied end-to-end.
+
+
+def _strip_gemini(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    """Remove Prismor hook entries from a Gemini CLI settings.json config.
+
+    Gemini CLI uses the same nested Claude-shape hook entries
+    (list of {matcher, hooks:[{type, command}]} per event), so the
+    strip logic mirrors _strip_claude but operates on Gemini's event names.
+    """
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        cleaned = []
+        for entry in entries:
+            inner_hooks = entry.get("hooks", [])
+            filtered = [h for h in inner_hooks if marker not in h.get("command", "")]
+            if len(filtered) < len(inner_hooks):
+                removed = True
+            if filtered:
+                cleaned.append({**entry, "hooks": filtered})
+        hooks[event_name] = cleaned
+    return {**config, "hooks": hooks}, removed
+
+
+def _merge_gemini(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    """Inject Prismor hooks into a Gemini CLI settings.json config.
+
+    Hooks three event types:
+      BeforeTool   -- pre-action; exit-2 blocks the tool call.
+      AfterTool    -- post-action; recorded for session audit.
+      SessionStart -- scans project-memory files (GEMINI.md / AGENTS.md) on
+                      session open, same as the Claude Code SessionStart hook.
+
+    Matcher covers all built-in Gemini CLI tools plus MCP tools
+    (mcp__<server>__<tool> namespace).
+    """
+    hooks = dict(config.get("hooks", {}))
+    # BeforeTool is the only blocking event: exit-2 from the hook stops
+    # the tool call before execution. AfterTool fires after and is
+    # recorded for audit only.
+    for event_name in ["BeforeTool", "AfterTool"]:
+        hooks[event_name] = _merge_claude_entries(
+            hooks.get(event_name, []),
+            {
+                "matcher": "run_shell_command|read_file|write_file|replace_in_file|web_fetch|web_search|mcp__.*",
+                "hooks": [{"type": "command", "name": "prismor", "command": command}],
+            },
+        )
+    # SessionStart: scan project-memory files (GEMINI.md / AGENTS.md) for
+    # injected directives at the start of every session, same rationale as
+    # the Claude Code SessionStart hook (see PrismorSec/prismor#155).
+    hooks["SessionStart"] = _merge_claude_entries(
+        hooks.get("SessionStart", []),
+        {
+            "matcher": "*",
+            "hooks": [{"type": "command", "name": "prismor", "command": command}],
+        },
+    )
+    return {**config, "hooks": hooks}
+
+
+def _normalize_gemini(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
+    """Translate a Gemini CLI hook stdin payload into a Prismor event.
+
+    Gemini CLI sends JSON on stdin with these fields:
+      hook_event_name  -- "BeforeTool" | "AfterTool" | "SessionStart" | ...
+      tool_name        -- built-in tool name or mcp__<server>__<tool>
+      tool_input       -- dict of tool arguments
+      session_id       -- stable session identifier
+      transcript_path  -- path to the session transcript file
+      cwd              -- working directory at hook-dispatch time
+      timestamp        -- ISO-8601 string
+
+    Built-in tool names and their Prismor event-type mappings:
+      run_shell_command  -> shell     (field: command)
+      read_file          -> file_read (fields: absolute_path, file_path, path)
+      write_file         -> file_write (fields: file_path, content)
+      replace_in_file    -> file_write (fields: file_path, diff)
+      web_fetch          -> network   (field: url)
+      web_search         -> network   (field: query)
+    """
+    hook_event = payload.get("hook_event_name", "unknown")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+    base = {
+        "ts": payload.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "agent": "gemini",
+        "agent_event": hook_event,
+        "metadata": {
+            "cwd": payload.get("cwd"),
+            "tool_name": tool_name,
+            "transcript_path": payload.get("transcript_path"),
+            "raw": payload,
+        },
+    }
+
+    if hook_event == "SessionStart":
+        # Scan project-memory files (GEMINI.md / AGENTS.md) for injected
+        # directives, same as the Claude Code SessionStart hook.
+        raw_cwd = payload.get("cwd")
+        memory_root = Path(raw_cwd) if raw_cwd else workspace
+        memory = _read_project_memory(memory_root)
+        base["metadata"]["memory_files"] = memory["files"]
+        base["metadata"]["memory_digests"] = memory["digests"]
+        return {**base, "type": "memory", "content": memory["content"]}
+
+    if hook_event in {"BeforeAgent", "AfterAgent"}:
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+
+    if tool_name == "run_shell_command":
+        return {
+            **base,
+            "type": "shell",
+            "command": tool_input.get("command", ""),
+            "stdout": payload.get("stdout", ""),
+            "stderr": payload.get("stderr", ""),
+        }
+
+    if tool_name == "read_file":
+        return {
+            **base,
+            "type": "file_read",
+            # Gemini CLI exposes the path as "absolute_path" on read_file
+            # and falls back to "file_path" / generic "path" for consistency.
+            "path": (
+                tool_input.get("absolute_path")
+                or tool_input.get("file_path")
+                or tool_input.get("path", "")
+            ),
+        }
+
+    if tool_name in {"write_file", "replace_in_file"}:
+        return {
+            **base,
+            "type": "file_write",
+            "path": (
+                tool_input.get("file_path")
+                or tool_input.get("absolute_path")
+                or tool_input.get("path", "")
+            ),
+            # replace_in_file sends a unified diff in "diff"; write_file
+            # sends the full file body in "content".
+            "content": tool_input.get("content") or tool_input.get("diff", ""),
+        }
+
+    if tool_name == "web_fetch":
+        return {
+            **base,
+            "type": "network",
+            "url": tool_input.get("url", ""),
+            "response": payload.get("response", ""),
+        }
+
+    if tool_name == "web_search":
+        return {
+            **base,
+            "type": "network",
+            # web_search has no URL; use the query string so policy rules
+            # that match on `url` can still inspect the search terms.
+            "url": tool_input.get("query", ""),
+        }
+
+    mcp_event = _classify_mcp_event(
+        base=base,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        response=payload.get("tool_response", payload.get("response")),
+        is_post=(hook_event == "AfterTool"),
+        workspace=workspace,
+    )
+    if mcp_event is not None:
+        return mcp_event
+
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
 def _ephemeral_session_id(agent: str, workspace: Path) -> str:
     digest = hashlib.sha1(f"{agent}:{workspace}:{os.getpid()}".encode("utf-8")).hexdigest()[:12]
     return f"{agent}-{digest}"
-
 
 def _join_edits(edits: List[Dict[str, Any]]) -> str:
     return "\n".join(edit.get("new_string") or edit.get("newText") or "" for edit in edits if isinstance(edit, dict))

--- a/tests/test_hooks_gemini.py
+++ b/tests/test_hooks_gemini.py
@@ -1,0 +1,450 @@
+"""Tests for the Gemini CLI hooks adapter (_strip_gemini, _merge_gemini, _normalize_gemini).
+
+Gemini CLI uses the same Claude-style nested hook config shape and exit-2
+blocking convention.  These tests verify:
+  - _strip_gemini  removes Prismor entries and leaves others intact.
+  - _merge_gemini  writes all expected events (BeforeTool, AfterTool,
+                   SessionStart) with the correct matcher.
+  - _normalize_gemini converts every built-in tool name to the right
+                   Prismor event type with the right fields.
+  - install/uninstall roundtrip writes and then cleanly removes the config.
+  - "gemini" appears in _SUPPORTED_AGENTS.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.hooks import (
+    _SUPPORTED_AGENTS,
+    _strip_gemini,
+    _merge_gemini,
+    _normalize_gemini,
+    install_hooks,
+    normalize_payload,
+    uninstall_hooks,
+)
+
+_MARKER = "hook-dispatch"
+_COMMAND = (
+    'PYTHONPATH="/repo" python3 -m prismor.runtime.immunity_cli '
+    f'{_MARKER} --agent gemini --workspace "/proj" --mode observe'
+)
+
+
+class TestSupportedAgents(unittest.TestCase):
+    """Gemini CLI must appear in the _SUPPORTED_AGENTS registry."""
+
+    def test_gemini_in_supported_agents(self):
+        self.assertIn("gemini", _SUPPORTED_AGENTS)
+
+
+# --- _strip_gemini -----------------------------------------------------------
+
+class TestStripGemini(unittest.TestCase):
+    """_strip_gemini removes Prismor hook entries while preserving others."""
+
+    def _config(self, command):
+        return {
+            "hooks": {
+                "BeforeTool": [
+                    {
+                        "matcher": "run_shell_command",
+                        "hooks": [
+                            {"type": "command", "name": "prismor", "command": command},
+                            {"type": "command", "name": "other", "command": "other-linter --check"},
+                        ],
+                    }
+                ]
+            }
+        }
+
+    def test_removes_prismor_entry(self):
+        config = self._config(_COMMAND)
+        result, removed = _strip_gemini(config, _MARKER)
+        self.assertTrue(removed)
+        before_tool = result["hooks"]["BeforeTool"]
+        self.assertEqual(len(before_tool), 1)
+        inner = before_tool[0]["hooks"]
+        self.assertEqual(len(inner), 1)
+        self.assertEqual(inner[0]["name"], "other")
+
+    def test_removes_entire_entry_when_only_prismor(self):
+        config = {
+            "hooks": {
+                "BeforeTool": [
+                    {
+                        "matcher": "*",
+                        "hooks": [{"type": "command", "name": "prismor", "command": _COMMAND}],
+                    }
+                ]
+            }
+        }
+        result, removed = _strip_gemini(config, _MARKER)
+        self.assertTrue(removed)
+        self.assertEqual(result["hooks"]["BeforeTool"], [])
+
+    def test_no_change_when_marker_absent(self):
+        config = {
+            "hooks": {
+                "BeforeTool": [
+                    {"matcher": "*", "hooks": [{"type": "command", "name": "other", "command": "unrelated"}]}
+                ]
+            }
+        }
+        result, removed = _strip_gemini(config, _MARKER)
+        self.assertFalse(removed)
+
+    def test_empty_config(self):
+        result, removed = _strip_gemini({}, _MARKER)
+        self.assertFalse(removed)
+        self.assertEqual(result.get("hooks", {}), {})
+
+    def test_strips_all_event_types(self):
+        config = {
+            "hooks": {
+                event: [
+                    {"matcher": "*", "hooks": [{"type": "command", "name": "prismor", "command": _COMMAND}]}
+                ]
+                for event in ["BeforeTool", "AfterTool", "SessionStart"]
+            }
+        }
+        result, removed = _strip_gemini(config, _MARKER)
+        self.assertTrue(removed)
+        for event in ["BeforeTool", "AfterTool", "SessionStart"]:
+            self.assertEqual(result["hooks"][event], [])
+
+
+# --- _merge_gemini -----------------------------------------------------------
+
+class TestMergeGemini(unittest.TestCase):
+    """_merge_gemini inserts the correct hook structure into settings.json."""
+
+    def setUp(self):
+        self.result = _merge_gemini({}, _COMMAND)
+
+    def test_before_tool_present(self):
+        self.assertIn("BeforeTool", self.result["hooks"])
+        self.assertGreater(len(self.result["hooks"]["BeforeTool"]), 0)
+
+    def test_after_tool_present(self):
+        self.assertIn("AfterTool", self.result["hooks"])
+        self.assertGreater(len(self.result["hooks"]["AfterTool"]), 0)
+
+    def test_session_start_present(self):
+        self.assertIn("SessionStart", self.result["hooks"])
+        self.assertGreater(len(self.result["hooks"]["SessionStart"]), 0)
+
+    def test_command_contains_marker(self):
+        for event_name, entries in self.result["hooks"].items():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    self.assertIn(_MARKER, h["command"],
+                                  f"hook-dispatch marker missing in {event_name}")
+
+    def test_matcher_covers_shell_tool(self):
+        for entry in self.result["hooks"]["BeforeTool"]:
+            self.assertIn("run_shell_command", entry.get("matcher", ""))
+
+    def test_matcher_covers_mcp_tools(self):
+        for entry in self.result["hooks"]["BeforeTool"]:
+            self.assertIn("mcp__", entry.get("matcher", ""))
+
+    def test_hook_type_is_command(self):
+        for event_name, entries in self.result["hooks"].items():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    self.assertEqual(h.get("type"), "command")
+
+    def test_name_field_is_prismor(self):
+        for event_name, entries in self.result["hooks"].items():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    self.assertEqual(h.get("name"), "prismor")
+
+    def test_preserves_existing_hooks(self):
+        existing = {
+            "hooks": {
+                "BeforeTool": [
+                    {"matcher": "my_tool", "hooks": [{"type": "command", "name": "other", "command": "other-script"}]}
+                ]
+            }
+        }
+        result = _merge_gemini(existing, _COMMAND)
+        commands = [
+            h["command"]
+            for e in result["hooks"]["BeforeTool"]
+            for h in e.get("hooks", [])
+        ]
+        self.assertTrue(any("other-script" in c for c in commands))
+        self.assertTrue(any(_MARKER in c for c in commands))
+
+    def test_idempotent(self):
+        first = _merge_gemini({}, _COMMAND)
+        stripped, _ = _strip_gemini(first, _MARKER)
+        second = _merge_gemini(stripped, _COMMAND)
+        prismor_commands = [
+            h["command"]
+            for entry in second["hooks"].get("BeforeTool", [])
+            for h in entry.get("hooks", [])
+            if _MARKER in h["command"]
+        ]
+        self.assertEqual(len(prismor_commands), 1,
+                         "hook-dispatch must appear exactly once after strip+re-merge")
+
+
+# --- _normalize_gemini -------------------------------------------------------
+
+class TestNormalizeGemini(unittest.TestCase):
+    """_normalize_gemini maps each Gemini CLI payload to a Prismor event."""
+
+    _WS = Path("/fake/workspace")
+    _SID = "gemini-testsession123"
+
+    def _n(self, payload):
+        return _normalize_gemini(payload, self._SID, self._WS)
+
+    def test_run_shell_command_before_tool(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "rm -rf /tmp/test"},
+            "cwd": "/fake/workspace",
+            "session_id": self._SID,
+        })
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "rm -rf /tmp/test")
+        self.assertEqual(event["agent"], "gemini")
+        self.assertEqual(event["agent_event"], "BeforeTool")
+        self.assertEqual(event["session_id"], self._SID)
+
+    def test_run_shell_command_carries_stdout(self):
+        event = self._n({
+            "hook_event_name": "AfterTool",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "ls"},
+            "stdout": "file.txt\n",
+            "stderr": "",
+        })
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["stdout"], "file.txt\n")
+
+    def test_read_file_absolute_path(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "read_file",
+            "tool_input": {"absolute_path": "/home/user/.env"},
+        })
+        self.assertEqual(event["type"], "file_read")
+        self.assertEqual(event["path"], "/home/user/.env")
+
+    def test_read_file_fallback_to_file_path(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "read_file",
+            "tool_input": {"file_path": "src/main.py"},
+        })
+        self.assertEqual(event["type"], "file_read")
+        self.assertEqual(event["path"], "src/main.py")
+
+    def test_write_file(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "write_file",
+            "tool_input": {"file_path": "output.txt", "content": "hello world"},
+        })
+        self.assertEqual(event["type"], "file_write")
+        self.assertEqual(event["path"], "output.txt")
+        self.assertEqual(event["content"], "hello world")
+
+    def test_replace_in_file_uses_diff_field(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "replace_in_file",
+            "tool_input": {"file_path": "app.py", "diff": "--- a/app.py\n+++ b/app.py"},
+        })
+        self.assertEqual(event["type"], "file_write")
+        self.assertEqual(event["path"], "app.py")
+        self.assertEqual(event["content"], "--- a/app.py\n+++ b/app.py")
+
+    def test_web_fetch(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "web_fetch",
+            "tool_input": {"url": "https://example.com/api"},
+        })
+        self.assertEqual(event["type"], "network")
+        self.assertEqual(event["url"], "https://example.com/api")
+
+    def test_web_search_uses_query_as_url(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "web_search",
+            "tool_input": {"query": "how to exfiltrate data"},
+        })
+        self.assertEqual(event["type"], "network")
+        self.assertEqual(event["url"], "how to exfiltrate data")
+
+    def test_session_start_returns_memory_type(self):
+        event = self._n({
+            "hook_event_name": "SessionStart",
+            "cwd": str(self._WS),
+        })
+        self.assertEqual(event["type"], "memory")
+        self.assertEqual(event["agent_event"], "SessionStart")
+
+    def test_before_agent_returns_prompt_type(self):
+        event = self._n({
+            "hook_event_name": "BeforeAgent",
+            "prompt": "Refactor this entire codebase",
+        })
+        self.assertEqual(event["type"], "prompt")
+        self.assertEqual(event["prompt"], "Refactor this entire codebase")
+
+    def test_unknown_tool_returns_tool_result(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "some_future_tool",
+            "tool_input": {},
+        })
+        self.assertEqual(event["type"], "tool_result")
+
+    def test_metadata_carries_transcript_path(self):
+        event = self._n({
+            "hook_event_name": "BeforeTool",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "ls"},
+            "transcript_path": "/tmp/gemini/session123/transcript.jsonl",
+        })
+        self.assertEqual(event["metadata"]["transcript_path"],
+                         "/tmp/gemini/session123/transcript.jsonl")
+
+    def test_normalize_payload_routes_to_gemini(self):
+        result = normalize_payload(
+            agent="gemini",
+            payload={
+                "hook_event_name": "BeforeTool",
+                "tool_name": "run_shell_command",
+                "tool_input": {"command": "echo hi"},
+                "session_id": "gemini-abc",
+            },
+            workspace=self._WS,
+        )
+        self.assertEqual(result["event"]["agent"], "gemini")
+        self.assertEqual(result["event"]["type"], "shell")
+
+
+# --- install / uninstall roundtrip -------------------------------------------
+
+class TestGeminiInstallUninstallRoundtrip(unittest.TestCase):
+    """install_hooks + uninstall_hooks write and cleanly remove Gemini config."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.workspace = Path(self.tmpdir) / "project"
+        self.workspace.mkdir()
+        self.repo_root = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_install_creates_settings_json(self):
+        install_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="gemini",
+            scope="project",
+            mode="observe",
+        )
+        config_path = self.workspace / ".gemini" / "settings.json"
+        self.assertTrue(config_path.exists())
+        config = json.loads(config_path.read_text())
+        hooks = config.get("hooks", {})
+        self.assertIn("BeforeTool", hooks)
+        self.assertIn("AfterTool", hooks)
+        self.assertIn("SessionStart", hooks)
+        self.assertGreater(len(hooks["BeforeTool"]), 0)
+
+    def test_install_contains_marker(self):
+        install_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="gemini",
+            scope="project",
+            mode="observe",
+        )
+        config_path = self.workspace / ".gemini" / "settings.json"
+        self.assertIn(_MARKER, config_path.read_text())
+
+    def test_install_is_idempotent(self):
+        for _ in range(2):
+            install_hooks(
+                repo_root=self.repo_root,
+                workspace=self.workspace,
+                agent="gemini",
+                scope="project",
+                mode="observe",
+            )
+        config_path = self.workspace / ".gemini" / "settings.json"
+        config = json.loads(config_path.read_text())
+        for event_name, entries in config["hooks"].items():
+            prismor_cmds = [
+                h["command"]
+                for entry in entries
+                for h in entry.get("hooks", [])
+                if _MARKER in h.get("command", "")
+            ]
+            self.assertLessEqual(len(prismor_cmds), 1,
+                                 f"hook-dispatch duplicated in {event_name}")
+
+    def test_uninstall_clears_hooks(self):
+        install_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="gemini",
+            scope="project",
+            mode="observe",
+        )
+        results = uninstall_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="gemini",
+            scope="project",
+        )
+        self.assertTrue(results[0]["removed"])
+        config_path = self.workspace / ".gemini" / "settings.json"
+        config = json.loads(config_path.read_text())
+        for entries in config.get("hooks", {}).values():
+            if isinstance(entries, list):
+                for entry in entries:
+                    for h in entry.get("hooks", []):
+                        self.assertNotIn(_MARKER, h.get("command", ""))
+
+    def test_install_preserves_existing_settings(self):
+        config_path = self.workspace / ".gemini" / "settings.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "theme": "dark",
+            "model": "gemini-2.0-flash",
+        }))
+        install_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="gemini",
+            scope="project",
+            mode="observe",
+        )
+        config = json.loads(config_path.read_text())
+        self.assertEqual(config.get("theme"), "dark")
+        self.assertEqual(config.get("model"), "gemini-2.0-flash")
+        self.assertIn("BeforeTool", config.get("hooks", {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds full adapter support for **Gemini CLI** (`google-gemini/gemini-cli`) in `prismor/runtime/hooks.py`, implementing the roadmap item tracked in `AGENT_INTEGRATIONS.md` and `TODO.md`.

## Changes Made

- **Registry**: Added `"gemini"` to `_SUPPORTED_AGENTS`.

- **Config Paths (`_config_path`)**: Resolves `.gemini/settings.json` at project scope and `~/.gemini/settings.json` at global scope.

- **Config Merge (`_merge_gemini`)**: Hooks `BeforeTool` (pre-action, exit-2 blocking), `AfterTool` (post-action audit), and `SessionStart` (scans project memory files `GEMINI.md` / `AGENTS.md`). Uses Claude-style nested hook entries matching built-in tool names + `mcp__.*`.

- **Config Strip (`_strip_gemini`)**: Idempotently removes Prismor entries while preserving user-defined third-party hooks.

- **Payload Normalization (`_normalize_gemini`)**: Maps Gemini CLI payload tool names to standard Prismor event types:
  - `run_shell_command` ➔ `type: "shell"` (`command`, `stdout`, `stderr`)
  - `read_file` ➔ `type: "file_read"` (`path` from `absolute_path` / `file_path`)
  - `write_file` ➔ `type: "file_write"` (`path`, `content`)
  - `replace_in_file` ➔ `type: "file_write"` (`path`, `diff`)
  - `web_fetch` ➔ `type: "network"` (`url`, `response`)
  - `web_search` ➔ `type: "network"` (`url` mapped from `query`)
  - `SessionStart` ➔ `type: "memory"` (scans `GEMINI.md` / `AGENTS.md`)
  - `BeforeAgent` / `AfterAgent` ➔ `type: "prompt"` (`prompt`)

- **Tests**: Created `tests/test_hooks_gemini.py` containing 34 unit and integration tests covering `_strip_gemini`, `_merge_gemini`, `_normalize_gemini`, and the full `install_hooks` / `uninstall_hooks` roundtrip lifecycle.

## Testing & Verification

- `pytest tests/test_hooks_gemini.py -v` ➔ **34 passed** (0.13s)
- `pytest tests/test_hooks.py tests/test_hooks_extended.py -v` ➔ **111 passed** (3.65s, 0 regressions)

> **Note:** Built from the public Gemini CLI hooks spec. Before relying on `enforce` mode in production, test against a live binary.