### PR TITLE
Policy support for GUI agents: ui_action event type, allowlist vetoes, and policy export

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -113,6 +113,7 @@ Modes (`observe` vs `enforce`): [Prismor](prismor-runtime.md).
 | `prismor semantic-check [TEXT]` | `--mode <hybrid\|heuristic\|api>`, `--json`, `--cli-path` | Run the semantic prompt-injection guard on text or stdin. See [Semantic Guard](semantic-guard.md). |
 | `prismor policy init` | `--workspace` | Scaffold `.prismor/policy.yaml`. |
 | `prismor policy show` | `--workspace` | Print active rules after merging defaults + project overrides. |
+| `prismor policy export` | `--json`, `--output PATH`, `--workspace` | Print the effective merged policy as stable, sorted JSON — patterns already resolved and disabled rules dropped — for non-Python consumers and for committing/diffing. |
 | `prismor policy edit` | `--workspace` | Interactive TUI to toggle rules on/off. |
 | `prismor policy validate <file>` | — | Static-validate a policy YAML file. |
 | `prismor policy test` | `--file` | Run declarative policy tests (falls back to the bundled OWASP LLM starter pack). |

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -2090,6 +2090,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         if args.policy_command == "show":
             _policy_show(workspace)
             return
+        if args.policy_command == "export":
+            _policy_export(workspace, output=getattr(args, "output", None))
+            return
         if args.policy_command == "edit":
             _policy_edit(workspace)
             return
@@ -2099,10 +2102,11 @@ def main(argv: Optional[List[str]] = None) -> None:
         # No action given → print usage instead of the cryptic
         # "Unsupported command: policy" (the command IS supported; it needs an action).
         sys.stderr.write(
-            "Usage: prismor policy {init|validate|show|edit|test}\n"
+            "Usage: prismor policy {init|validate|show|export|edit|test}\n"
             "  init      Write a starter .prismor/policy.yaml\n"
             "  validate  Check a policy file against the schema + floor\n"
             "  show      Print the effective policy for this workspace\n"
+            "  export    Print the effective policy as JSON (for non-Python consumers)\n"
             "  edit      Open the policy in $EDITOR\n"
             "  test      Run policy-tests.yaml against the engine\n"
         )
@@ -2586,6 +2590,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     policy_edit = policy_sub.add_parser("edit", help="Interactive rule toggle — select which rules to enable/disable")
     policy_edit.add_argument("--workspace", help="Workspace path")
+
+    policy_export = policy_sub.add_parser(
+        "export", help="Print the effective merged policy as JSON (stable, diffable)")
+    policy_export.add_argument("--json", action="store_true",
+                               help="Output raw JSON (the only format; accepted for symmetry)")
+    policy_export.add_argument("--output", help="Write to PATH instead of stdout")
+    policy_export.add_argument("--workspace", help="Workspace path")
 
     policy_test = policy_sub.add_parser("test", help="Run declarative policy tests from policy-tests.yaml")
     policy_test.add_argument("--file", help="Path to policy-tests.yaml (default: .prismor/policy-tests.yaml)")
@@ -3755,6 +3766,28 @@ def _policy_show(workspace: Path) -> None:
         for al in engine.allowlists:
             targets = ", ".join(al.rule_ids) if "*" not in al.rule_ids else "all rules"
             print(f"  {al.id}: {targets}" + (f"  — {al.reason}" if al.reason else ""))
+
+
+def _policy_export(workspace: Path, output: Optional[str] = None) -> None:
+    """Write the effective merged policy as JSON, for non-Python consumers.
+
+    Sorted keys and a trailing newline so the output can be committed and
+    diffed: a policy change should show up as a reviewable diff, not as a
+    reshuffle of an unordered dict.
+    """
+    from prismor.runtime.policy_engine import export_effective_policy
+
+    text = json.dumps(
+        export_effective_policy(PolicyEngine(workspace=workspace)),
+        indent=2, sort_keys=True,
+    ) + "\n"
+    if output:
+        path = Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        print(f"Wrote {path}", file=sys.stderr)
+        return
+    sys.stdout.write(text)
 
 
 def _policy_edit(workspace: Path) -> None:

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -86,6 +86,15 @@ _DEFAULT_FIELDS: Dict[str, List[str]] = {
     # of its own; evaluate() routes it through the agent-I/O content rules.
     # See PrismorSec/prismor#163.
     "text": ["combined_text"],
+    # A GUI agent operating an on-screen control (click, key press, typing).
+    # The canonical field is the control's accessibility label because that is
+    # what names the act — "Send", "Buy now", "Delete account". The role
+    # (ax_role), owning app (app_name) and text about to be committed
+    # (typed_text) are matchable but secondary: a rule that matches on the role
+    # catches a password box whatever it is labelled, and one that matches on
+    # the app catches a whole surface, but neither answers "what does pressing
+    # this do?", which is the question a GUI guardrail is asking.
+    "ui_action": ["control_label"],
 }
 
 # Default field(s) checked by a rule that opts in via the `mcp` event-type
@@ -343,14 +352,30 @@ class CompiledRule:
 
 
 class AllowlistEntry:
-    """A compiled allowlist entry that suppresses findings."""
+    """A compiled allowlist entry that suppresses findings.
 
-    __slots__ = ("id", "rule_ids", "patterns", "reason")
+    ``type: veto`` inverts the entry: instead of suppressing the finding it
+    disqualifies every allowlist from suppressing it. An allowlist broad enough
+    to be useful is broad enough to over-grant — "address bar" also reads on
+    "Email address" — and the only safe way to carve that back was previously to
+    make the allowlist pattern itself narrower and more brittle. A veto keeps the
+    exception readable and states the carve-out as its own auditable entry.
+    ``type`` is a field on the existing entry rather than a new top-level
+    section because a veto is scoped by ``rule_ids`` and matched by ``patterns``
+    exactly like an allow, and reusing the shape keeps both halves of a
+    carve-out visible in the same list.
+    """
+
+    __slots__ = ("id", "rule_ids", "patterns", "raw_patterns", "reason", "type")
 
     def __init__(self, raw: Dict[str, Any]) -> None:
         self.id: str = raw["id"]
         self.rule_ids: set[str] = set(raw["rule_ids"])
         self.reason: str = raw.get("reason", "")
+        # Absent means allow, so every pre-existing entry keeps its behaviour.
+        _t = str(raw.get("type", "allow")).lower()
+        self.type: str = _t if _t in ("allow", "veto") else "allow"
+        self.raw_patterns: List[str] = [str(p) for p in raw["patterns"]]
         joined = "|".join(f"(?:{p})" for p in raw["patterns"])
         self.patterns: re.Pattern[str] = re.compile(joined, re.IGNORECASE)
 
@@ -1638,8 +1663,16 @@ class PolicyEngine:
         return self.evaluate(event, 0)
 
     def _is_allowlisted(self, rule_id: str, evidence: str) -> bool:
+        # Vetoes are resolved first and unconditionally: a veto that matches
+        # means no allowlist may suppress this finding, whatever order the
+        # entries appear in the merged policy. Without the two passes a
+        # carve-out would silently depend on file ordering, and a later
+        # project-level allowlist could out-rank an org-level veto.
         for entry in self.allowlists:
-            if entry.applies_to(rule_id) and entry.patterns.search(evidence):
+            if entry.type == "veto" and entry.applies_to(rule_id) and entry.patterns.search(evidence):
+                return False
+        for entry in self.allowlists:
+            if entry.type == "allow" and entry.applies_to(rule_id) and entry.patterns.search(evidence):
                 return True
         return False
 
@@ -1831,6 +1864,13 @@ def _extract_fields(event: Dict[str, Any]) -> Dict[str, str]:
         "content": str(event.get("content", "")),
         "stdout": str(event.get("stdout", "")),
         "stderr": str(event.get("stderr", "")),
+        # GUI-agent surface (event type ui_action). Populated only on ui_action
+        # events; empty elsewhere, which is what keeps a ui_action rule inert
+        # against shell/file/network traffic without any extra gating.
+        "control_label": str(event.get("control_label", "")),
+        "ax_role": str(event.get("ax_role", "")),
+        "app_name": str(event.get("app_name", "")),
+        "typed_text": str(event.get("typed_text", "")),
     }
 
 
@@ -2044,6 +2084,15 @@ def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
         return None
 
 
+# Event types and fields a rule may name. Derived from the engine's own
+# dispatch tables rather than hand-listed, so the validator can never accept an
+# event type evaluate() will not route or reject one it will. A typo'd
+# event_type is otherwise invisible: the rule loads, matches nothing, and the
+# policy looks enforced.
+_VALID_EVENT_TYPES: frozenset[str] = frozenset(set(_DEFAULT_FIELDS) | {"mcp"})
+_VALID_FIELDS: frozenset[str] = frozenset(_extract_fields({}))
+
+
 def validate_policy(path: Path) -> List[str]:
     """Validate a policy YAML file. Returns a list of error messages (empty = valid)."""
     errors: List[str] = []
@@ -2106,6 +2155,17 @@ def validate_policy(path: Path) -> List[str]:
         if rule_id in _NON_OVERRIDABLE_RULE_IDS and rule.get("disable_patterns"):
             errors.append(f"{prefix}: rule '{rule_id}' is a core protection — disable_patterns is not allowed")
 
+        for j, et in enumerate(rule.get("event_types", []) or []):
+            if et not in _VALID_EVENT_TYPES:
+                errors.append(
+                    f"{prefix}.event_types[{j}]: unknown event type '{et}' "
+                    f"(one of {', '.join(sorted(_VALID_EVENT_TYPES))})")
+        for j, fname in enumerate(rule.get("fields", []) or []):
+            if fname not in _VALID_FIELDS:
+                errors.append(
+                    f"{prefix}.fields[{j}]: unknown field '{fname}' "
+                    f"(one of {', '.join(sorted(_VALID_FIELDS))})")
+
         action = rule.get("action", "")
         if action and action not in ("block", "warn", "log", "modify", "step_up", "defer"):
             errors.append(f"{prefix}: invalid action '{action}' (must be block, warn, log, modify, step_up, or defer)")
@@ -2115,6 +2175,9 @@ def validate_policy(path: Path) -> List[str]:
         for field in ("id", "rule_ids", "patterns"):
             if field not in entry:
                 errors.append(f"{prefix}: missing required field '{field}'")
+        entry_type = entry.get("type")
+        if entry_type is not None and entry_type not in ("allow", "veto"):
+            errors.append(f"{prefix}: invalid type '{entry_type}' (must be allow or veto)")
         for j, pattern in enumerate(entry.get("patterns", [])):
             try:
                 re.compile(pattern)
@@ -2144,3 +2207,68 @@ def validate_policy(path: Path) -> List[str]:
                 errors.append(f"settings.tool_tags.incompatible[{i}]: needs at least 2 distinct tags")
 
     return errors
+
+
+def export_effective_policy(engine: "PolicyEngine") -> Dict[str, Any]:
+    """Serialize a loaded engine as the effective policy, ready for JSON.
+
+    Non-Python consumers (a GUI agent's Swift evaluator, a CI diff) otherwise
+    have to re-implement the merge — defaults + project/remote overrides,
+    add_patterns/disable_patterns, enabled: false — from this module's source,
+    and that reimplementation drifts silently. This emits what the engine
+    actually resolved, so there is nothing left to re-derive: patterns are the
+    post-customization set, disabled rules are absent rather than flagged, and
+    event_types carry the untrusted-content aliases the loader folded in.
+
+    Lists are sorted only where their order carries no meaning; pattern order is
+    preserved because it is the order findings report a match in.
+
+    A rule's ``fields`` stays as declared (often empty) and the canonical
+    per-event-type defaults ship alongside as ``default_fields``. Collapsing the
+    two would be a lie for a rule spanning several event types: the fallback is
+    resolved per *event*, so the same rule checks ``command`` on a shell event
+    and ``path`` on a file one.
+    """
+    return {
+        "version": "1.0",
+        "default_fields": {k: list(v) for k, v in _DEFAULT_FIELDS.items()},
+        "settings": {
+            "default_mode": engine.default_mode,
+            "device_mode": engine.device_mode,
+            "block_categories": sorted(engine.block_categories),
+            "egress_allowlist": list(engine.egress_allowlist),
+            "mcp_transport_action": engine.mcp_transport_action,
+            "supply_chain_install_check": engine.supply_chain_install_check,
+            "supply_chain_transitive_scan": engine.supply_chain_transitive_scan,
+            "semantic_guard": engine.semantic_guard_config,
+            "sandbox": engine.sandbox_config,
+            "tool_tags": engine.tool_tags,
+        },
+        "rules": [
+            {
+                "id": rule.id,
+                "severity": rule.severity,
+                "category": rule.category,
+                "title": rule.title,
+                "event_types": sorted(rule.event_types),
+                "fields": list(rule.fields),
+                "patterns": list(rule.raw_patterns),
+                "action": rule.action,
+                "transform": rule.transform,
+                "mode": rule.mode,
+                "severity_on_write": rule.severity_on_write,
+                "severity_on_manifest": rule.severity_on_manifest,
+            }
+            for rule in sorted(engine.rules, key=lambda r: r.id)
+        ],
+        "allowlists": [
+            {
+                "id": entry.id,
+                "type": entry.type,
+                "rule_ids": sorted(entry.rule_ids),
+                "patterns": list(entry.raw_patterns),
+                "reason": entry.reason,
+            }
+            for entry in sorted(engine.allowlists, key=lambda e: e.id)
+        ],
+    }

--- a/prismor/runtime/policy_schema.json
+++ b/prismor/runtime/policy_schema.json
@@ -360,7 +360,7 @@
         },
         "event_types": {
           "type": "array",
-          "description": "Event types this rule applies to (shell, file_read, file_write, network, prompt, tool_result, memory, skill_manifest, mcp). A rule listing tool_result is automatically applied to memory (CLAUDE.md/AGENTS.md) content too. The 'mcp' alias matches any MCP tool call regardless of whether it classifies as a remote (network) or local stdio (tool_result) event.",
+          "description": "Event types this rule applies to (shell, file_read, file_write, network, prompt, tool_result, memory, skill_manifest, ui_action, mcp). A rule listing tool_result is automatically applied to memory (CLAUDE.md/AGENTS.md) content too. The 'mcp' alias matches any MCP tool call regardless of whether it classifies as a remote (network) or local stdio (tool_result) event. 'ui_action' is a GUI agent operating an on-screen control (click, key press, typed text) rather than running a command or touching a file.",
           "items": {
             "type": "string",
             "enum": [
@@ -372,6 +372,7 @@
               "tool_result",
               "memory",
               "skill_manifest",
+              "ui_action",
               "mcp"
             ]
           },
@@ -379,7 +380,7 @@
         },
         "fields": {
           "type": "array",
-          "description": "Event fields to match against. Defaults to the canonical field for the event type (command for shell, path for file_*, url for network, combined_text for prompt/tool_result, tool_name for the mcp alias). For MCP guardrails: tool_name is the full mcp__server__tool tag, mcp_server / mcp_tool are the parsed parts, mcp_args is the serialized pre-call arguments regardless of transport, and outbound_payload is the remote-transport raw form of the same.",
+          "description": "Event fields to match against. Defaults to the canonical field for the event type (command for shell, path for file_*, url for network, combined_text for prompt/tool_result, control_label for ui_action, tool_name for the mcp alias). For MCP guardrails: tool_name is the full mcp__server__tool tag, mcp_server / mcp_tool are the parsed parts, mcp_args is the serialized pre-call arguments regardless of transport, and outbound_payload is the remote-transport raw form of the same. For GUI guardrails (ui_action): control_label is the target control's accessibility label, ax_role its accessibility role, app_name the owning application, and typed_text the text about to be committed.",
           "items": {
             "type": "string",
             "enum": [
@@ -391,7 +392,16 @@
               "mcp_server",
               "mcp_tool",
               "mcp_args",
-              "outbound_payload"
+              "outbound_payload",
+              "prompt",
+              "response",
+              "content",
+              "stdout",
+              "stderr",
+              "control_label",
+              "ax_role",
+              "app_name",
+              "typed_text"
             ]
           }
         },
@@ -497,6 +507,16 @@
             "type": "string"
           },
           "minItems": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "veto"
+          ],
+          "default": "allow",
+          "description": "allow (default) suppresses a matching finding. veto does the opposite and wins: a matching veto disqualifies every allowlist from suppressing that finding, so a broad exception can be carved back without making its patterns brittle. Vetoes are resolved before any allow, independent of entry order.",
+          "$comment": "A field on the entry rather than a separate section: a veto is scoped by rule_ids and matched by patterns exactly like an allow, and sharing the shape keeps both halves of a carve-out in one list."
         },
         "reason": {
           "type": "string",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -449,5 +449,90 @@ class TestWriteAgentContext(unittest.TestCase):
         self.assertIn("unknown command", r.stderr)
 
 
+class TestPolicyExport(unittest.TestCase):
+    """`prismor policy export` — machine-readable effective policy."""
+
+    OVERRIDE = (
+        'version: "1.0"\n'
+        "rules:\n"
+        "  - id: db-modification\n"
+        "    add_patterns:\n"
+        '      - "cassandra-cli"\n'
+        "  - id: db-access\n"
+        "    enabled: false\n"
+        "allowlists:\n"
+        "  - id: form-field-guard\n"
+        '    rule_ids: ["*"]\n'
+        "    type: veto\n"
+        '    patterns: ["\\\\bbilling\\\\b"]\n'
+    )
+
+    def _export(self, workspace, *extra):
+        r = run_cli("policy", "export", "--workspace", str(workspace), *extra)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        return r
+
+    def test_export_is_valid_json_with_the_default_rules(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            payload = json.loads(self._export(tmpdir).stdout)
+            self.assertEqual(payload["version"], "1.0")
+            self.assertGreater(len(payload["rules"]), 10)
+            self.assertEqual(payload["default_fields"]["ui_action"], ["control_label"])
+
+    def test_export_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first = self._export(tmpdir).stdout
+            second = self._export(tmpdir).stdout
+            self.assertEqual(first, second)
+            # Sorted keys, so a diff is a real policy change rather than a reshuffle.
+            payload = json.loads(first)
+            self.assertEqual(list(payload), sorted(payload))
+            self.assertEqual(
+                [r["id"] for r in payload["rules"]],
+                sorted(r["id"] for r in payload["rules"]),
+            )
+
+    def test_export_resolves_add_and_disable_patterns(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            policy_dir = Path(tmpdir) / ".prismor"
+            policy_dir.mkdir()
+            (policy_dir / "policy.yaml").write_text(self.OVERRIDE, encoding="utf-8")
+            payload = json.loads(self._export(tmpdir).stdout)
+            rules = {r["id"]: r for r in payload["rules"]}
+
+            self.assertIn("cassandra-cli", rules["db-modification"]["patterns"])
+            # enabled: false is resolved by absence, not by a flag to re-interpret.
+            self.assertNotIn("db-access", rules)
+
+            baseline = json.loads(run_cli(
+                "policy", "export", "--workspace", tempfile.mkdtemp()).stdout)
+            base_rules = {r["id"]: r for r in baseline["rules"]}
+            self.assertEqual(
+                len(rules["db-modification"]["patterns"]),
+                len(base_rules["db-modification"]["patterns"]) + 1,
+            )
+
+    def test_export_carries_allowlist_type(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            policy_dir = Path(tmpdir) / ".prismor"
+            policy_dir.mkdir()
+            (policy_dir / "policy.yaml").write_text(self.OVERRIDE, encoding="utf-8")
+            payload = json.loads(self._export(tmpdir).stdout)
+            self.assertEqual(payload["allowlists"][0]["type"], "veto")
+
+    def test_export_output_flag_writes_a_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "build" / "policy.json"
+            r = self._export(tmpdir, "--output", str(target))
+            self.assertEqual(r.stdout, "")
+            self.assertEqual(
+                json.loads(target.read_text()), json.loads(self._export(tmpdir).stdout))
+
+    def test_policy_usage_lists_export(self):
+        r = run_cli("policy")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("export", r.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -733,6 +733,13 @@ class TestEvaluateEventEdgeCases(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["category"], "prompt_injection")
 
+    def test_ui_action_is_inert_on_the_hardcoded_path(self):
+        # GUI guardrails live in policy YAML, not in this hardcoded fallback
+        # set. A ui_action event reaching the legacy evaluator must stay silent
+        # rather than have its label scanned as if it were a shell command.
+        event = {"type": "ui_action", "control_label": "Delete everything", "command": "rm -rf /"}
+        self.assertEqual(evaluate_event(event, 0), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -12,6 +12,69 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from prismor.runtime.policy_engine import PolicyEngine, validate_policy, _extract_fields, _DEFAULT_FIELDS
 
 
+def _ui_rule(rule_id, field, patterns, declare_fields=True):
+    """A standalone ui_action policy document with one rule."""
+    return (
+        'version: "1.0"\n'
+        "rules:\n"
+        f"  - id: {rule_id}\n"
+        "    severity: CRITICAL\n"
+        "    category: final_action\n"
+        "    title: GUI control performs a consequential action\n"
+        "    event_types: [ui_action]\n"
+        + (f"    fields: [{field}]\n" if declare_fields else "")
+        + f"    patterns: {patterns}\n"
+        "    action: block\n"
+    )
+
+
+# A rule that fires on every label, so the allowlist/veto interaction is the
+# only thing under test.
+_RETURN_KEY_RULE = (
+    'version: "1.0"\n'
+    "rules:\n"
+    "  - id: gui-return-key\n"
+    "    severity: HIGH\n"
+    "    category: final_action\n"
+    "    title: Return key submits a field\n"
+    "    event_types: [ui_action]\n"
+    "    fields: [control_label]\n"
+    '    patterns: ["^.*$"]\n'
+    "    action: block\n"
+)
+
+_ALLOW_ENTRY = (
+    "  - id: browser-address-bar\n"
+    '    rule_ids: ["gui-return-key"]\n'
+    '    patterns: ["address and search"]\n'
+)
+
+_VETO_ENTRY = (
+    "  - id: form-field-guard\n"
+    '    rule_ids: ["gui-return-key"]\n'
+    "    type: veto\n"
+    '    patterns: ["\\\\bemail\\\\b", "\\\\bbilling\\\\b"]\n'
+)
+
+_VETO_POLICY = _RETURN_KEY_RULE + "allowlists:\n" + _VETO_ENTRY + _ALLOW_ENTRY
+
+
+def _engine_with_policy(text):
+    """Load an engine whose project policy is ``text``."""
+    holder = tempfile.TemporaryDirectory()
+    root = Path(holder.name)
+    (root / ".prismor").mkdir()
+    (root / ".prismor" / "policy.yaml").write_text(text, encoding="utf-8")
+    engine = PolicyEngine(workspace=root)
+    # Keep the directory alive for the engine's lifetime.
+    engine._test_tmpdir = holder
+    return engine
+
+
+def _ui_findings(engine, **fields):
+    return engine.evaluate({"type": "ui_action", **fields}, 0)
+
+
 class TestPolicyEngineDefaults(unittest.TestCase):
     """Test that the default policy loads and detects the same things as legacy."""
 
@@ -843,6 +906,144 @@ class TestPolicyEngineAllowlist(unittest.TestCase):
             )
             engine = PolicyEngine(workspace=Path(tmpdir))
             self.assertTrue(engine.allowlists[0].applies_to("any-rule"))
+
+    def test_entry_without_type_still_allows(self):
+        engine = _engine_with_policy(
+            'version: "1.0"\n'
+            "rules:\n"
+            "  - id: gui-return-key\n"
+            "    severity: HIGH\n"
+            "    category: final_action\n"
+            "    title: Return submits a field\n"
+            "    event_types: [ui_action]\n"
+            "    fields: [control_label]\n"
+            '    patterns: ["^.*$"]\n'
+            "    action: block\n"
+            "allowlists:\n"
+            "  - id: browser-address-bar\n"
+            '    rule_ids: ["gui-return-key"]\n'
+            '    patterns: ["address and search"]\n'
+        )
+        self.assertEqual(engine.allowlists[0].type, "allow")
+        self.assertEqual(_ui_findings(engine, control_label="Address and search bar"), [])
+
+    def test_veto_disqualifies_a_matching_allowlist(self):
+        engine = _engine_with_policy(_VETO_POLICY)
+        # Browser chrome: the allowlist applies and the finding is suppressed.
+        self.assertEqual(_ui_findings(engine, control_label="Address and search bar"), [])
+        # A form field carrying the same word: the veto wins.
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, control_label="Email address and search")],
+            ["gui-return-key"],
+        )
+
+    def test_veto_ordered_after_the_allowlist_still_wins(self):
+        # Ordering must not decide a carve-out. _VETO_POLICY declares the veto
+        # first; this declares it last, and both must block the exception.
+        engine = _engine_with_policy(_RETURN_KEY_RULE + "allowlists:\n" + _ALLOW_ENTRY + _VETO_ENTRY)
+        self.assertEqual([e.id for e in engine.allowlists][0], "browser-address-bar")
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, control_label="Billing address and search")],
+            ["gui-return-key"],
+        )
+
+    def test_veto_scoped_to_other_rules_leaves_the_allowlist_alone(self):
+        engine = _engine_with_policy(
+            _RETURN_KEY_RULE + "allowlists:\n"
+            + _VETO_ENTRY.replace('["gui-return-key"]', '["some-other-rule"]')
+            + _ALLOW_ENTRY)
+        self.assertEqual(_ui_findings(engine, control_label="Email address and search"), [])
+
+
+class TestPolicyEngineUiAction(unittest.TestCase):
+    """Test the ui_action event type used by GUI agents."""
+
+    def test_control_label_is_the_canonical_default_field(self):
+        self.assertEqual(_DEFAULT_FIELDS["ui_action"], ["control_label"])
+        engine = _engine_with_policy(
+            _ui_rule("gui-final-action", "control_label", '["\\\\bsend\\\\b"]', declare_fields=False))
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, control_label="Send message")],
+            ["gui-final-action"],
+        )
+
+    def test_matching_control_label(self):
+        engine = _engine_with_policy(_ui_rule("gui-final-action", "control_label", '["\\\\bsend\\\\b"]'))
+        findings = _ui_findings(engine, control_label="Send message")
+        self.assertEqual([f["ruleId"] for f in findings], ["gui-final-action"])
+        self.assertEqual(findings[0]["severity"], "CRITICAL")
+
+    def test_non_matching_control_label(self):
+        # Word-anchored, so the label that merely contains the letters does not fire.
+        engine = _engine_with_policy(_ui_rule("gui-final-action", "control_label", '["\\\\bsend\\\\b"]'))
+        self.assertEqual(_ui_findings(engine, control_label="Sender name"), [])
+
+    def test_matching_ax_role(self):
+        engine = _engine_with_policy(_ui_rule("gui-secure-field", "ax_role", '["^AXSecureTextField$"]'))
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, ax_role="AXSecureTextField")],
+            ["gui-secure-field"],
+        )
+        self.assertEqual(_ui_findings(engine, ax_role="AXTextField"), [])
+
+    def test_matching_app_name(self):
+        engine = _engine_with_policy(_ui_rule("gui-restricted-app", "app_name", '["\\\\bterminal\\\\b"]'))
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, app_name="Terminal")],
+            ["gui-restricted-app"],
+        )
+        self.assertEqual(_ui_findings(engine, app_name="Notes"), [])
+
+    def test_matching_typed_text(self):
+        engine = _engine_with_policy(_ui_rule("gui-typed-secret", "typed_text", '["sk-[a-z0-9]{8}"]'))
+        self.assertEqual(
+            [f["ruleId"] for f in _ui_findings(engine, typed_text="sk-abcd1234")],
+            ["gui-typed-secret"],
+        )
+
+    def test_ui_rule_ignores_shell_events(self):
+        engine = _engine_with_policy(_ui_rule("gui-final-action", "control_label", '["\\\\bsend\\\\b"]'))
+        self.assertEqual(
+            [f for f in engine.check_command("send-mail --to x") if f["ruleId"] == "gui-final-action"],
+            [],
+        )
+
+    def test_ui_fields_are_extracted(self):
+        values = _extract_fields({
+            "type": "ui_action",
+            "control_label": "Send",
+            "ax_role": "AXButton",
+            "app_name": "Mail",
+            "typed_text": "hello",
+        })
+        self.assertEqual(values["control_label"], "Send")
+        self.assertEqual(values["ax_role"], "AXButton")
+        self.assertEqual(values["app_name"], "Mail")
+        self.assertEqual(values["typed_text"], "hello")
+
+    def test_ui_action_validates(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(_ui_rule("gui-final-action", "control_label", '["\\\\bsend\\\\b"]'))
+            f.flush()
+            self.assertEqual(validate_policy(Path(f.name)), [])
+            os.unlink(f.name)
+
+    def test_unknown_event_type_is_rejected(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(_ui_rule("gui-final-action", "control_label", '["a"]')
+                    .replace("event_types: [ui_action]", "event_types: [gui_action]"))
+            f.flush()
+            errors = validate_policy(Path(f.name))
+            self.assertTrue(any("unknown event type 'gui_action'" in e for e in errors))
+            os.unlink(f.name)
+
+    def test_unknown_field_is_rejected(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(_ui_rule("gui-final-action", "widget_label", '["a"]'))
+            f.flush()
+            errors = validate_policy(Path(f.name))
+            self.assertTrue(any("unknown field 'widget_label'" in e for e in errors))
+            os.unlink(f.name)
 
 
 class TestPolicyEngineOverrides(unittest.TestCase):


### PR DESCRIPTION
Three gaps that all surfaced from the same exercise: pointing a real non-Python consumer at Warden. A macOS GUI agent ([Clippy](https://github.com/Ar9av/clippy)) moved its entire safety guardrail — what it refuses to click, type into, or submit — out of hardcoded Swift and into a Warden policy file, and hit each of these in turn.

Backwards compatible throughout: all 71 built-in rules unchanged, every existing allowlist entry behaves identically, no migration required.

## 1. A policy could not describe a GUI agent

`event_types` covers an agent that runs commands and edits files. A GUI agent's dangerous act is *"operate the control labelled Send"* — there is no shell command, no path, no URL to match on.

Adds a `ui_action` event type with `control_label`, `ax_role`, `app_name`, `typed_text`. The canonical field is the label, because that is what names the act; the role catches a password box whatever it is labelled, and the app catches a whole surface, but neither answers "what does pressing this do?". The fields are empty on other event types, which is what keeps a `ui_action` rule inert against shell traffic with no extra gating.

```yaml
- id: gui-final-action
  severity: CRITICAL
  category: final_action
  title: Control performs a consequential, non-reversible action
  event_types: [ui_action]
  fields: [control_label]
  mode: enforce
  patterns: ['\bsend\b', '\bsubmit\b', '\bbuy\b', '\bdelete\b']
```

## 2. Allowlists could not be vetoed

An allowlist broad enough to be useful is broad enough to over-grant. Allowing a browser's address bar so the agent may submit it also reads on `Email address` and `Billing address`, and the only way to carve that back was to make the allow pattern narrower and more brittle.

Adds `type: allow | veto` on the existing entry shape. Vetoes resolve in a first pass, so a carve-out never depends on the order entries were merged in — otherwise a project-level allow could out-rank an org-level veto. `type` is a field on the entry rather than a new top-level section because a veto is scoped by `rule_ids` and matched by `patterns` exactly like an allow, and reusing the shape keeps both halves of a carve-out visible in one list.

Absent `type` means `allow`, so existing entries are untouched.

Before and after, on the consumer's real policy:

```
                                      before          after
'Address and search'                  suppressed      suppressed    (intended)
'Email address and search'            suppressed      blocked       (fixed)
'Billing address'                     blocked         blocked
```

## 3. There was no machine-readable export

Non-Python consumers had to re-implement the merge — defaults plus project overrides, `add_patterns`, `disable_patterns`, `enabled: false` — by reading `policy_engine.py`, and that reimplementation drifts silently. The consumer here had written its own YAML→JSON compile script for exactly this reason.

Adds `prismor policy export [--json] [--output PATH] [--workspace]`, emitting what the engine actually resolved: post-customization patterns, disabled rules absent rather than flagged, sorted keys and a trailing newline so it can be committed and diffed.

One deliberate call: a rule's `fields` stays as declared (often empty) and the canonical per-event-type defaults ship alongside as `default_fields`. Collapsing them would be a lie for a rule spanning several event types — the fallback resolves per *event*, so `agent-config-tampering` checks `command` on a shell event and `path` on a file one.

## A fail-open found on the way

While adding the event-type check I found that **`validate_policy` never read `policy_schema.json`**. It is a hand-written validator that ignored `event_types` and `fields` entirely, so a policy naming an event type that does not exist validated clean, loaded fine, matched nothing, and looked enforced. The schema was documentation no code path consulted.

It now checks both, against sets derived from `_DEFAULT_FIELDS` and `_extract_fields` rather than a hand-maintained list, so the validator cannot drift from what `evaluate()` will actually route.

That surfaced a second one: `default_policy.yaml` matches on `prompt`, `response`, `content`, `stdout` and `stderr`, none of which were in the schema's `fields` enum. Had the schema ever been enforced, the shipped default policy would have failed its own validation. Those five are now declared.

## Testing

- **+22 tests**, added to the existing files rather than a new one: `test_policy_engine.py` (11 `ui_action` cases, 5 veto/allowlist cases), `test_cli.py` (6 export cases), `test_policies.py` (`ui_action` stays inert on the hardcoded legacy path).
- Full suite **1135 → 1157 passed**. The failing set is byte-identical before and after — verified by stashing and diffing the sorted `FAILED` lists. Those failures are environmental (they read this machine's real `~/.prismor` enrollment and session store) and predate this branch.
- `prismor policy show` still reports **71 rules**; `prismor policy validate` on stock `default_policy.yaml` still exits 0.
- Verified end to end through a real console script (`pip install -e .` into a scratch venv), not just by importing the module.

## Not included

Two larger items from the same exercise, deliberately left out as separate efforts: a long-lived daemon or socket (the heuristic path computes in 0.07ms but costs ~73ms of Python startup, which is fine for a pre-commit hook and too slow for a per-click gate), and a native client so consumers stop re-implementing evaluation semantics by hand.