### PR TITLE
feat(hooks): flag unmapped tools instead of silently bucketing them

### DIFF
--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -1237,6 +1237,39 @@ def _strip_goose(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], b
     return {**config, "hooks": hooks}, removed
 
 
+def _unmapped_tool_event(base: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Fall-through for a tool this adapter does not map to a canonical type.
+
+    The event still normalizes to ``tool_result`` so its payload is scanned by
+    the untrusted-content rules; dropping it would be strictly worse. But a
+    tool that lands here is evaluated against the handful of ``tool_result``
+    rules rather than the ``shell`` / ``file_write`` / ``network`` rules its
+    actual behaviour warrants — for example Claude Code's ``NotebookEdit``,
+    which writes a file but reaches policy as an opaque JSON blob. That is a
+    coverage hole, not coverage.
+
+    Tagging the event makes the hole countable (``prismor tags list`` renders
+    an UNMAPPED kind) instead of being silently indistinguishable from a
+    genuine tool response. Deliberately does NOT change the event type: this
+    is an observability signal, so it can never loosen or tighten what the
+    policy engine already decides about a payload.
+
+    A fall-through with no tool name at all (session/notification hook events)
+    is not an unmapped *tool*, so it is left untagged.
+
+    Known limitation: the ``cursor`` and ``windsurf`` adapters dispatch on the
+    hook EVENT name and their payloads carry no tool identity, so their
+    coverage holes cannot surface through this signal. Measuring those needs a
+    separate event-name-keyed signal.
+    """
+    event = {**base, "type": "tool_result", "response": json.dumps(payload)}
+    metadata = base.get("metadata") or {}
+    tool_name = str(metadata.get("tool_name") or "")
+    if tool_name:
+        event["metadata"] = {**metadata, "unmapped_tool": tool_name}
+    return event
+
+
 def _normalize_copilot(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
     hook_event = payload.get("hookEventName") or payload.get("hook_event_name") or "unknown"
     tool_name = payload.get("toolName") or payload.get("tool_name") or ""
@@ -1279,7 +1312,7 @@ def _normalize_copilot(payload: Dict[str, Any], session_id: str, workspace: Path
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_codex(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -1333,7 +1366,7 @@ def _normalize_codex(payload: Dict[str, Any], session_id: str, workspace: Path) 
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_grok(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -1382,7 +1415,7 @@ def _normalize_grok(payload: Dict[str, Any], session_id: str, workspace: Path) -
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_kiro(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -1423,7 +1456,7 @@ def _normalize_kiro(payload: Dict[str, Any], session_id: str, workspace: Path) -
         return {**base, "type": "file_write", "path": path, "content": content}
     if tool_name in {"web_fetch", "web_search"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_crush(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -1453,7 +1486,7 @@ def _normalize_crush(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]
         }
     if tool_name in {"fetch", "download", "sourcegraph"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_openhands(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -1483,7 +1516,7 @@ def _normalize_openhands(payload: Dict[str, Any], session_id: str) -> Dict[str, 
         }
     if tool_name in {"web_fetch", "web_search"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_qwen(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -1525,7 +1558,7 @@ def _normalize_qwen(payload: Dict[str, Any], session_id: str, workspace: Path) -
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_continue(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -1573,7 +1606,7 @@ def _normalize_continue(payload: Dict[str, Any], session_id: str, workspace: Pat
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_goose(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -1604,7 +1637,7 @@ def _normalize_goose(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]
             "path": tool_input.get("path", ""),
             "content": tool_input.get("after", ""),
         }
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _merge_claude_entries(entries: List[Dict[str, Any]], new_entry: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -2180,7 +2213,7 @@ def _normalize_claude(payload: Dict[str, Any], session_id: str, workspace: Path)
     )
     if mcp_event is not None:
         return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_windsurf(payload: Dict[str, Any], session_id: str, workspace: Path) -> Dict[str, Any]:
@@ -2220,7 +2253,7 @@ def _normalize_windsurf(payload: Dict[str, Any], session_id: str, workspace: Pat
                 if inline:
                     mcp_event["url"] = inline
             return mcp_event
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_cursor(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -2247,7 +2280,7 @@ def _normalize_cursor(payload: Dict[str, Any], session_id: str) -> Dict[str, Any
         return {**base, "type": "file_write", "path": payload.get("path") or payload.get("filePath") or "", "content": payload.get("content", "")}
     if "read" in hook_event.lower():
         return {**base, "type": "file_read", "path": payload.get("path") or payload.get("filePath") or ""}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_hermes(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -2259,7 +2292,14 @@ def _normalize_hermes(payload: Dict[str, Any], session_id: str) -> Dict[str, Any
         "session_id": session_id,
         "agent": "hermes",
         "agent_event": hook_event,
-        "metadata": {"gatewayId": payload.get("gatewayId"), "raw": payload},
+        # tool_name is what `prismor tags list` / tag-rule classification key
+        # off (trifecta._tool_name); omitting it made every hermes tool
+        # invisible to tool-tagging and to the unmapped-tool signal.
+        "metadata": {
+            "gatewayId": payload.get("gatewayId"),
+            "tool_name": tool_name,
+            "raw": payload,
+        },
     }
     if hook_event == "message_received":
         return {**base, "type": "prompt", "prompt": tool_input.get("content", "")}
@@ -2273,7 +2313,7 @@ def _normalize_hermes(payload: Dict[str, Any], session_id: str) -> Dict[str, Any
         return {**base, "type": "file_write", "path": tool_input.get("file_path") or tool_input.get("path", ""), "content": tool_input.get("content", "")}
     if tool_name in {"WebFetch", "WebSearch", "web_search", "browser"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _normalize_openclaw(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
@@ -2285,7 +2325,13 @@ def _normalize_openclaw(payload: Dict[str, Any], session_id: str) -> Dict[str, A
         "session_id": session_id,
         "agent": "openclaw",
         "agent_event": hook_event,
-        "metadata": {"agentId": payload.get("agentId"), "raw": payload},
+        # See the hermes adapter: tool_name must be recorded here or the tool
+        # is invisible to tag classification and the unmapped-tool signal.
+        "metadata": {
+            "agentId": payload.get("agentId"),
+            "tool_name": tool_name,
+            "raw": payload,
+        },
     }
     if hook_event == "message_received":
         return {**base, "type": "prompt", "prompt": tool_input.get("content", "")}
@@ -2299,7 +2345,7 @@ def _normalize_openclaw(payload: Dict[str, Any], session_id: str) -> Dict[str, A
         return {**base, "type": "file_write", "path": tool_input.get("file_path") or tool_input.get("path", ""), "content": tool_input.get("content", "")}
     if tool_name in {"WebFetch", "WebSearch", "web_search", "browser"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 # ── Gemini CLI adapter ────────────────────────────────────────────────────────
@@ -2499,7 +2545,7 @@ def _normalize_gemini(payload: Dict[str, Any], session_id: str, workspace: Path)
     if mcp_event is not None:
         return mcp_event
 
-    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+    return _unmapped_tool_event(base, payload)
 
 
 def _ephemeral_session_id(agent: str, workspace: Path) -> str:

--- a/prismor/runtime/tags_cli.py
+++ b/prismor/runtime/tags_cli.py
@@ -173,23 +173,50 @@ def _resolve_with_tier(
 def tags_list(workspace: Path, last: int = 50) -> None:
     tt = _effective_tool_tags(workspace)
     seen: Dict[str, Tuple[Set[str], str]] = {}
+    # Normalized event kind per tool. A tool whose adapter has no branch for it
+    # falls through to a tool_result tagged with ``unmapped_tool`` (see
+    # hooks._unmapped_tool_event) — surface that as UNMAPPED so a coverage hole
+    # is visible rather than looking like an ordinary tool response. Tracked
+    # across every event, not just the first: one adapter mapping a tool name
+    # must not mask another adapter that doesn't.
+    kinds: Dict[str, Set[str]] = {}
     for sid, _ in _recent_sessions(workspace, last):
         for ev in _session_events(workspace, sid):
             tool = _tool_name(ev)
-            if not tool or tool in seen:
+            if not tool:
                 continue
             etype = str(ev.get("type") or "")
+            meta = ev.get("metadata") or {}
+            kinds.setdefault(tool, set()).add(
+                "UNMAPPED" if meta.get("unmapped_tool") else etype
+            )
+            if tool in seen:
+                continue
             seen[tool] = _resolve_with_tier(ev, etype, tt)
     if not seen:
         print("no tools recorded yet — run some agent sessions first")
         return
-    print(_c(f"{'TOOL':44s} {'TAGS':34s} TIER", _BOLD))
+    print(_c(f"{'TOOL':36s} {'KIND':14s} {'TAGS':30s} TIER", _BOLD))
     for tool in sorted(seen):
         tags, tier = seen[tool]
         tag_s = ", ".join(sorted(tags)) if tags else _c("(untagged)", _DIM)
         tier_c = {"explicit": _GREEN, "_meta": _CYAN,
                   "default": _YELLOW}.get(tier, _DIM)
-        print(f"{tool:44s} {tag_s:34s} {_c(tier, tier_c)}")
+        tool_kinds = kinds.get(tool) or set()
+        kind_s = ", ".join(sorted(tool_kinds)) or "-"
+        kind_c = _RED if "UNMAPPED" in tool_kinds else _DIM
+        print(f"{tool:36s} {_c(f'{kind_s:14s}', kind_c)} {tag_s:30s} "
+              f"{_c(tier, tier_c)}")
+    unmapped = sorted(t for t, k in kinds.items() if "UNMAPPED" in k and t in seen)
+    if unmapped:
+        print(_c(
+            f"\n{len(unmapped)} of {len(seen)} tools UNMAPPED — reaching policy as "
+            f"opaque tool_result, not as shell/file_write/network:",
+            _RED,
+        ))
+        print(_c(f"  {', '.join(unmapped)}", _RED))
+        print(_c("  each needs a branch in its agent's normalizer "
+                 "(prismor/runtime/hooks.py)", _DIM))
     enabled = "enabled" if tt.get("enabled") else "disabled"
     print(_c(f"\ntool_tags: {enabled}, mode={tt.get('mode', 'observe')}", _DIM))
 

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -1104,5 +1104,119 @@ class TestNormalizePayloadGoose(unittest.TestCase):
         self.assertEqual(event["command"], "sudo ls /root")
 
 
+class TestUnmappedToolSignal(unittest.TestCase):
+    """A tool with no branch in its adapter must be *flagged*, not silently
+    absorbed into the generic tool_result bucket.
+
+    Such an event is evaluated against the few tool_result rules instead of the
+    shell/file_write/network rules its behaviour warrants, so it is a coverage
+    hole. Tagging it makes the hole countable in `prismor tags list`.
+    """
+
+    def _event(self, agent, payload):
+        return normalize_payload(
+            agent=agent, payload=payload, workspace=Path("/tmp")
+        )["event"]
+
+    def test_unmapped_tool_is_flagged(self):
+        # NotebookEdit writes a file but has no branch in _normalize_claude.
+        event = self._event("claude", {
+            "hook_event_name": "PreToolUse",
+            "session_id": "c-1",
+            "tool_name": "NotebookEdit",
+            "tool_input": {"notebook_path": "/w/a.ipynb", "new_source": "x = 1"},
+        })
+        self.assertEqual(event["type"], "tool_result")
+        self.assertEqual(event["metadata"]["unmapped_tool"], "NotebookEdit")
+
+    def test_mapped_tool_is_not_flagged(self):
+        event = self._event("claude", {
+            "hook_event_name": "PreToolUse",
+            "session_id": "c-2",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+        })
+        self.assertEqual(event["type"], "shell")
+        self.assertNotIn("unmapped_tool", event.get("metadata") or {})
+
+    def test_toolless_event_is_not_flagged(self):
+        """A fall-through with no tool name is a session/notification event,
+        not an unmapped tool — flagging it would inflate the hole count."""
+        event = self._event("claude", {
+            "hook_event_name": "Notification",
+            "session_id": "c-3",
+        })
+        self.assertNotIn("unmapped_tool", event.get("metadata") or {})
+
+    def test_signal_does_not_alter_event_type(self):
+        """The flag is observability only: it must never change what the policy
+        engine sees, or it could silently loosen/tighten enforcement."""
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "session_id": "k-1",
+            "tool_name": "use_aws",
+            "tool_input": {"service": "s3"},
+        }
+        event = self._event("kiro", payload)
+        self.assertEqual(event["type"], "tool_result")
+        self.assertEqual(event["response"], json.dumps(payload))
+
+    def test_every_tool_dispatched_adapter_flags_unmapped_tools(self):
+        """Every adapter that dispatches on a tool NAME must report unknown
+        tools — none may stay silent while the others report.
+
+        Payload key casing differs per agent (hermes/openclaw use camelCase
+        ``toolName``), so each is exercised with its own real shape rather than
+        a single synthetic one that would pass vacuously.
+
+        `cursor` and `windsurf` are excluded deliberately: they dispatch on the
+        hook EVENT name and carry no tool identity in the payload at all, so
+        there is nothing to flag. Their coverage holes are not visible through
+        this signal — see the class docstring in hooks._unmapped_tool_event.
+        """
+        snake = ["claude", "codex", "copilot", "grok", "kiro", "crush",
+                 "openhands", "qwen", "continue", "goose", "gemini"]
+        camel = ["hermes", "openclaw"]
+        for agent in snake:
+            with self.subTest(agent=agent):
+                event = self._event(agent, {
+                    "hook_event_name": "PreToolUse",
+                    "session_id": f"{agent}-1",
+                    "tool_name": "totally_unknown_tool",
+                    "tool_input": {"foo": "bar"},
+                })
+                self.assertEqual(
+                    (event.get("metadata") or {}).get("unmapped_tool"),
+                    "totally_unknown_tool",
+                )
+        for agent in camel:
+            with self.subTest(agent=agent):
+                event = self._event(agent, {
+                    "hookEvent": "before_tool_call",
+                    "session_id": f"{agent}-1",
+                    "toolName": "totally_unknown_tool",
+                    "toolInput": {"foo": "bar"},
+                })
+                self.assertEqual(
+                    (event.get("metadata") or {}).get("unmapped_tool"),
+                    "totally_unknown_tool",
+                )
+
+    def test_camelcase_adapters_record_tool_name(self):
+        """hermes/openclaw must record tool_name in metadata — tag
+        classification (trifecta._tool_name) reads it from there, so omitting
+        it made every tool from those two agents invisible to `prismor tags`."""
+        for agent in ("hermes", "openclaw"):
+            with self.subTest(agent=agent):
+                event = self._event(agent, {
+                    "hookEvent": "before_tool_call",
+                    "session_id": f"{agent}-2",
+                    "toolName": "shell",
+                    "toolInput": {"command": "ls"},
+                })
+                self.assertEqual(event["type"], "shell")
+                self.assertEqual(event["metadata"]["tool_name"], "shell")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

A tool with no branch in its agent's normalizer falls through to a generic `tool_result` event carrying a JSON dump of the payload. That payload still gets scanned by the untrusted-content rules, so it isn't unprotected — but it is evaluated against the **5** `tool_result` rules rather than the **13** `file_write` / **52** `shell` / **4** `network` rules its actual behaviour warrants.

Worse, it was indistinguishable from a genuine tool response, so the hole was invisible in telemetry: it looked like coverage.

Claude Code's `NotebookEdit` is the clearest case — it writes a file, and reached policy as an opaque blob.

## Change

- **`_unmapped_tool_event()`** in `hooks.py`, used by all 15 adapter fall-throughs. Tags `metadata.unmapped_tool` and **deliberately does not change the event type**, so this is observability only and cannot loosen or tighten what the policy engine already decides.
- **`tool_name` recorded in hermes/openclaw metadata.** Both parsed `toolName` but never stored it. Since tag classification reads `metadata.tool_name` (`trifecta._tool_name`), every tool from those two agents was invisible to `prismor tags list` and tag-rule matching entirely — a separate pre-existing blind spot found while testing this.
- **`prismor tags list`** grows a `KIND` column plus an `UNMAPPED` summary naming the tools that need adapter branches.

```
TOOL                KIND        TAGS                TIER
Bash                shell       critical_action     inference
Grep                UNMAPPED    untrusted_content   inference
NotebookEdit        UNMAPPED    untrusted_content   inference
Read                file_read   untrusted_content   inference
Skill               UNMAPPED    untrusted_content   inference
WebFetch            network     untrusted_content   default

3 of 6 tools UNMAPPED — reaching policy as opaque tool_result, not as
shell/file_write/network:
  Grep, NotebookEdit, Skill
  each needs a branch in its agent's normalizer (prismor/runtime/hooks.py)
```

## Why measurement first

This is step one of closing adapter coverage. Rather than working blind down a list of tool names, `prismor tags list` against real sessions now says which branches are actually worth writing, ranked by what agents genuinely call.

## Known limitation

`cursor` and `windsurf` dispatch on hook **event** name and carry no tool identity in the payload, so their coverage holes cannot surface through this signal. Measuring those needs a separate event-keyed signal. Documented in the helper docstring and the test rather than faking coverage for them.

## Tests

6 new tests in `test_hooks_extended.py`: the tag itself, mapped tools unaffected, toolless events left untagged, event type provably unchanged, all 13 tool-dispatched adapters (each with its own payload casing), and the hermes/openclaw `tool_name` fix.

Full suite **1631 passed** vs **1625** on baseline, same 24 pre-existing environment/enrollment-dependent failures verified against clean `main` before and after.