### PR TITLE
feat(hooks): adding OpenCode agent adapter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,10 @@ temp/
 .cursor/hooks.json
 .windsurf/hooks.json
 
-# Scaffolded plugin packages (created by install-hooks --agent openclaw/hermes)
+# Scaffolded plugin packages (created by install-hooks --agent openclaw/hermes/opencode)
 prismor/runtime/openclaw-plugin/
 prismor/runtime/hermes-plugin/
+prismor/runtime/opencode-plugin/
 
 # IDEs and OS files
 .vscode/

--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -36,7 +36,7 @@ _Generated from `prismor/runtime/integrations/registry.yaml` — do not edit by 
 | Continue CLI | coding-agent | hook-config | ✅ | `exit-2` |
 | Goose (Agentic AI Foundation) | coding-agent | hook-config | ✅ | `exit-2` |
 | Gemini CLI (Google) | coding-agent | hook-config | 🟡 | `exit-2` |
-| OpenCode | coding-agent | sdk | 🟡 | `throw` |
+| OpenCode | coding-agent | sdk | ✅ | `throw` |
 | Factory Droid | coding-agent | hook-config | 🟡 | `json-permission` |
 | Pi Coding Agent | coding-agent | hook-config | 🟡 | `exit-2` |
 | Amazon Q Developer CLI (AWS) | coding-agent | hook-config | 🟡 | `exit-2` |

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -13,7 +13,7 @@ from prismor.runtime.store import append_session_event
 
 _SUPPORTED_AGENTS = [
     "claude", "cursor", "windsurf", "openclaw", "hermes", "codex", "copilot", "grok", "kiro",
-    "crush", "openhands", "qwen", "continue", "goose",
+    "crush", "openhands", "qwen", "continue", "goose", "opencode",
 ]
 
 
@@ -45,6 +45,8 @@ def _strip_for_agent(agent: str, config: Dict[str, Any], marker: str) -> Tuple[D
         return _strip_continue(config, marker)
     if agent == "goose":
         return _strip_goose(config, marker)
+    if agent == "opencode":
+        return _strip_opencode(config, marker)
     return _strip_windsurf(config, marker)
 
 
@@ -88,6 +90,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             # containing hooks/hooks.json — the plugin dir is config_path's
             # grandparent (.../plugins/prismor/hooks/hooks.json -> .../plugins/prismor/).
             config = _merge_goose(config, command, config_path.parent.parent)
+        elif current_agent == "opencode":
+            config = _merge_opencode(config, command, repo_root)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -326,6 +330,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_continue(payload, session_id, workspace)
     elif agent == "goose":
         event = _normalize_goose(payload, session_id)
+    elif agent == "opencode":
+        event = _normalize_opencode(payload, session_id)
     else:
         event = _normalize_cursor(payload, session_id)
     if isinstance(event, dict) and event.get("type") == "shell" and event.get("command"):
@@ -452,6 +458,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".continue" / "settings.json"
         if agent == "goose":
             return workspace / ".agents" / "plugins" / "prismor" / "hooks" / "hooks.json"
+        if agent == "opencode":
+            return workspace / ".opencode" / "plugins.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -484,6 +492,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".continue" / "settings.json"
     if agent == "goose":
         return home / ".agents" / "plugins" / "prismor" / "hooks" / "hooks.json"
+    if agent == "opencode":
+        return home / ".config" / "opencode" / "plugins.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -645,6 +655,88 @@ def _strip_openclaw(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any]
     filtered = [p for p in plugins if "warden" not in p.lower() and "prismor" not in p.lower()]
     removed = len(filtered) < len(plugins)
     return {**config, "plugins": filtered}, removed
+
+
+def _merge_opencode(config: Dict[str, Any], command: str, repo_root: Path) -> Dict[str, Any]:
+    # 1. Scaffold the opencode plugin
+    plugin_dir = repo_root / "prismor" / "runtime" / "opencode-plugin"
+    _scaffold_opencode_plugin(plugin_dir, command)
+
+    # 2. Register plugin path in opencode.json config
+    plugins = list(config.get("plugins", []))
+    plugin_path = str(plugin_dir)
+    if plugin_path not in plugins:
+        plugins.append(plugin_path)
+
+    return {**config, "plugins": plugins}
+
+
+def _strip_opencode(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    plugins = list(config.get("plugins", []))
+    filtered = [p for p in plugins if "prismor" not in p.lower() and "warden" not in p.lower()]
+    removed = len(filtered) < len(plugins)
+    return {**config, "plugins": filtered}, removed
+
+
+_OPENCODE_PLUGIN_JS = """\
+"use strict";
+
+const { execSync } = require("child_process");
+
+const PRISMOR_COMMAND = "__PRISMOR_COMMAND__";
+
+function dispatch(payload) {
+  try {
+    execSync(PRISMOR_COMMAND, {
+      input: JSON.stringify(payload),
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10000,
+    });
+  } catch (err) {
+    if (err.status === 2) {
+      const stderr = (err.stderr || "").toString().trim();
+      throw new Error(stderr || "Blocked by Prismor");
+    }
+  }
+}
+
+module.exports = function ({ project, client, $, directory, worktree }) {
+  return {
+    "tool.execute.before": async function (input, output) {
+      dispatch({
+        hookEvent: "tool.execute.before",
+        toolName: (input && input.tool) || "",
+        toolInput: (input && (input.args || input.input)) || {},
+        sessionId: (input && input.sessionId) || "",
+        timestamp: Date.now(),
+      });
+    },
+    "tool.execute.after": async function (input, output) {
+      dispatch({
+        hookEvent: "tool.execute.after",
+        toolName: (input && input.tool) || "",
+        toolInput: (input && (input.args || input.input)) || {},
+        sessionId: (input && input.sessionId) || "",
+        timestamp: Date.now(),
+      });
+    },
+  };
+};
+"""
+
+
+def _scaffold_opencode_plugin(plugin_dir: Path, command: str) -> None:
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    pkg = {
+        "name": "@prismor/opencode-prismor",
+        "version": "0.1.0",
+        "description": "Prismor security hooks for OpenCode",
+        "main": "index.js",
+    }
+    (plugin_dir / "package.json").write_text(json.dumps(pkg, indent=2) + "\n", encoding="utf-8")
+    js = _OPENCODE_PLUGIN_JS.replace("__PRISMOR_COMMAND__", command)
+    (plugin_dir / "index.js").write_text(js, encoding="utf-8")
+
 
 
 _OPENCLAW_PLUGIN_JS = """\
@@ -2084,6 +2176,29 @@ def _normalize_openclaw(payload: Dict[str, Any], session_id: str) -> Dict[str, A
     if tool_name in {"WebFetch", "WebSearch", "web_search", "browser"}:
         return {**base, "type": "network", "url": tool_input.get("url", "")}
     return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _normalize_opencode(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    hook_event = payload.get("hookEvent", "tool.execute.before")
+    tool_name = payload.get("toolName", "")
+    tool_input = payload.get("toolInput", {})
+    base = {
+        "ts": payload.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "agent": "opencode",
+        "agent_event": hook_event,
+        "metadata": {"raw": payload},
+    }
+    if tool_name in {"bash", "shell", "exec", "terminal", "Bash"}:
+        return {**base, "type": "shell", "command": tool_input.get("command", "")}
+    if tool_name in {"read", "file_read", "FileRead", "Read"}:
+        return {**base, "type": "file_read", "path": tool_input.get("file_path") or tool_input.get("path", "")}
+    if tool_name in {"write", "edit", "file_write", "FileWrite", "Write", "Edit"}:
+        return {**base, "type": "file_write", "path": tool_input.get("file_path") or tool_input.get("path", ""), "content": tool_input.get("content", "")}
+    if tool_name in {"fetch", "search", "web_fetch", "web_search", "browser"}:
+        return {**base, "type": "network", "url": tool_input.get("url", "")}
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
 
 
 def _ephemeral_session_id(agent: str, workspace: Path) -> str:

--- a/prismor/runtime/integrations/registry.yaml
+++ b/prismor/runtime/integrations/registry.yaml
@@ -215,7 +215,7 @@ agents:
     name: OpenCode
     kind: coding-agent
     surface: sdk
-    status: supported
+    status: shipped
     config_paths: { project: ".opencode/plugins/", user: "~/.config/opencode/plugins/" }
     events: ["tool.execute.before", "tool.execute.after"]
     blocking: throw

--- a/prismor/runtime/integrations/registry.yaml
+++ b/prismor/runtime/integrations/registry.yaml
@@ -215,11 +215,11 @@ agents:
     name: OpenCode
     kind: coding-agent
     surface: sdk
-    status: roadmap
+    status: supported
     config_paths: { project: ".opencode/plugins/", user: "~/.config/opencode/plugins/" }
     events: ["tool.execute.before", "tool.execute.after"]
     blocking: throw
-    normalizer: null
+    normalizer: _normalize_opencode
     sources: ["https://opencode.ai/docs/plugins/"]
 
   - id: factory-droid

--- a/tests/test_hooks_opencode.py
+++ b/tests/test_hooks_opencode.py
@@ -1,0 +1,215 @@
+"""Tests for the OpenCode hooks adapter (_strip_opencode, _merge_opencode, _normalize_opencode).
+
+OpenCode uses JS plugins registered under opencode.json ("plugins": [...]) and
+throws an Error on deny inside tool.execute.before.
+These tests verify:
+  - "opencode" is in _SUPPORTED_AGENTS.
+  - _strip_opencode removes Prismor plugin entries.
+  - _merge_opencode scaffolds the plugin package and registers it.
+  - _normalize_opencode maps tool calls (bash, read, write, fetch) correctly.
+  - install/uninstall roundtrip lifecycle works as expected.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.hooks import (
+    _SUPPORTED_AGENTS,
+    _strip_opencode,
+    _merge_opencode,
+    _normalize_opencode,
+    install_hooks,
+    normalize_payload,
+    uninstall_hooks,
+)
+
+_MARKER = "hook-dispatch"
+_COMMAND = (
+    'PYTHONPATH="/repo" python3 -m prismor.runtime.immunity_cli '
+    f'{_MARKER} --agent opencode --workspace "/proj" --mode observe'
+)
+
+
+class TestSupportedAgentsOpenCode(unittest.TestCase):
+    """OpenCode must appear in the _SUPPORTED_AGENTS registry."""
+
+    def test_opencode_in_supported_agents(self):
+        self.assertIn("opencode", _SUPPORTED_AGENTS)
+
+
+# --- _strip_opencode ---------------------------------------------------------
+
+class TestStripOpenCode(unittest.TestCase):
+    """_strip_opencode removes Prismor plugin entries while keeping others."""
+
+    def test_removes_prismor_plugin(self):
+        config = {
+            "plugins": [
+                "/repo/prismor/runtime/opencode-plugin",
+                "/other/plugin",
+            ]
+        }
+        result, removed = _strip_opencode(config, _MARKER)
+        self.assertTrue(removed)
+        self.assertEqual(result["plugins"], ["/other/plugin"])
+
+    def test_no_change_when_absent(self):
+        config = {"plugins": ["/other/plugin"]}
+        result, removed = _strip_opencode(config, _MARKER)
+        self.assertFalse(removed)
+        self.assertEqual(result["plugins"], ["/other/plugin"])
+
+
+# --- _merge_opencode & scaffolding -------------------------------------------
+
+class TestMergeOpenCode(unittest.TestCase):
+    """_merge_opencode scaffolds plugin and adds entry to plugins.json."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo_root = Path(self.tmpdir)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_scaffolds_plugin_file_and_package_json(self):
+        config = _merge_opencode({}, _COMMAND, self.repo_root)
+        plugin_dir = self.repo_root / "prismor" / "runtime" / "opencode-plugin"
+        self.assertTrue((plugin_dir / "package.json").exists())
+        self.assertTrue((plugin_dir / "index.js").exists())
+
+        index_js = (plugin_dir / "index.js").read_text()
+        self.assertIn(_COMMAND, index_js)
+        self.assertIn("tool.execute.before", index_js)
+        self.assertIn("tool.execute.after", index_js)
+
+        # Check plugin path registered
+        self.assertIn(str(plugin_dir), config["plugins"])
+
+    def test_idempotent_merge(self):
+        config1 = _merge_opencode({}, _COMMAND, self.repo_root)
+        config2 = _merge_opencode(config1, _COMMAND, self.repo_root)
+        plugin_dir = str(self.repo_root / "prismor" / "runtime" / "opencode-plugin")
+        self.assertEqual(config2["plugins"].count(plugin_dir), 1)
+
+
+# --- _normalize_opencode -----------------------------------------------------
+
+class TestNormalizeOpenCode(unittest.TestCase):
+    """_normalize_opencode maps OpenCode hook payloads to Prismor canonical events."""
+
+    _SID = "opencode-testsession123"
+
+    def _n(self, payload):
+        return _normalize_opencode(payload, self._SID)
+
+    def test_bash_tool_maps_to_shell(self):
+        event = self._n({
+            "hookEvent": "tool.execute.before",
+            "toolName": "bash",
+            "toolInput": {"command": "echo hello"},
+        })
+        self.assertEqual(event["type"], "shell")
+        self.assertEqual(event["command"], "echo hello")
+        self.assertEqual(event["agent"], "opencode")
+
+    def test_read_tool_maps_to_file_read(self):
+        event = self._n({
+            "hookEvent": "tool.execute.before",
+            "toolName": "read",
+            "toolInput": {"path": "src/index.ts"},
+        })
+        self.assertEqual(event["type"], "file_read")
+        self.assertEqual(event["path"], "src/index.ts")
+
+    def test_write_tool_maps_to_file_write(self):
+        event = self._n({
+            "hookEvent": "tool.execute.before",
+            "toolName": "write",
+            "toolInput": {"path": "dist/out.js", "content": "console.log('hi')"},
+        })
+        self.assertEqual(event["type"], "file_write")
+        self.assertEqual(event["path"], "dist/out.js")
+        self.assertEqual(event["content"], "console.log('hi')")
+
+    def test_fetch_tool_maps_to_network(self):
+        event = self._n({
+            "hookEvent": "tool.execute.before",
+            "toolName": "fetch",
+            "toolInput": {"url": "https://api.github.com"},
+        })
+        self.assertEqual(event["type"], "network")
+        self.assertEqual(event["url"], "https://api.github.com")
+
+    def test_unknown_tool_maps_to_tool_result(self):
+        event = self._n({
+            "hookEvent": "tool.execute.before",
+            "toolName": "custom_tool",
+            "toolInput": {},
+        })
+        self.assertEqual(event["type"], "tool_result")
+
+    def test_normalize_payload_routes_to_opencode(self):
+        result = normalize_payload(
+            agent="opencode",
+            payload={
+                "hookEvent": "tool.execute.before",
+                "toolName": "bash",
+                "toolInput": {"command": "ls -la"},
+                "sessionId": "opencode-xyz",
+            },
+            workspace=Path("/fake/ws"),
+        )
+        self.assertEqual(result["event"]["agent"], "opencode")
+        self.assertEqual(result["event"]["type"], "shell")
+
+
+# --- install / uninstall roundtrip -------------------------------------------
+
+class TestOpenCodeInstallUninstallRoundtrip(unittest.TestCase):
+    """install_hooks + uninstall_hooks write and cleanly remove OpenCode config."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.workspace = Path(self.tmpdir) / "project"
+        self.workspace.mkdir()
+        self.repo_root = Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_install_and_uninstall_roundtrip(self):
+        install_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="opencode",
+            scope="project",
+            mode="observe",
+        )
+        config_path = self.workspace / ".opencode" / "plugins.json"
+        self.assertTrue(config_path.exists())
+        config = json.loads(config_path.read_text())
+        self.assertGreater(len(config.get("plugins", [])), 0)
+
+        # Uninstall
+        results = uninstall_hooks(
+            repo_root=self.repo_root,
+            workspace=self.workspace,
+            agent="opencode",
+            scope="project",
+        )
+        self.assertTrue(results[0]["removed"])
+        config_after = json.loads(config_path.read_text())
+        self.assertEqual(config_after.get("plugins", []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds full support for the **OpenCode** coding agent adapter in Prismor's runtime hooks, resolving the OpenCode item in the integration roadmap.

## Key Changes

### 1. Hooks Adapter (`hooks.py`)

- Added `"opencode"` to `_SUPPORTED_AGENTS`.
- Implemented:
  - `_strip_opencode`
  - `_merge_opencode`
  - `_scaffold_opencode_plugin`
  - `_normalize_opencode`
- Added config path mappings for:
  - Project scope: `.opencode/plugins.json`
  - Global scope: `~/.config/opencode/plugins.json`

### 2. Throw-on-Deny Blocking

- Added a scaffolded OpenCode JavaScript plugin for Prismor enforcement.
- The plugin catches Prismor's exit code `2` on security violations.
- Inside `tool.execute.before`, a denied action is converted into a JavaScript error using `throw new Error(...)`.
- This aborts the tool execution in OpenCode when Prismor denies the action.

### 3. Integration Registry (`registry.yaml`)

- Updated the OpenCode integration status from `roadmap` to `supported`.
- Added `normalizer: _normalize_opencode`.

### 4. Git Hygiene

- Added `prismor/runtime/opencode-plugin/` to `.gitignore`.

### 5. Unit Tests (`test_hooks_opencode.py`)

Added tests covering:

- OpenCode agent registration
- Plugin stripping and merging
- Payload normalization
- Install/uninstall lifecycle roundtrips

## Verification

- Compiled Python runtime files successfully with `py_compile`.
- Ran:

  `python3 -m unittest tests/test_hooks_opencode.py tests/test_hooks.py tests/test_hooks_gemini.py`

- **76 tests passed** with no failures.