### PR TITLE
fix: reporting blocked by the prod WAF; unhookable agents read as governed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Fixed
+
+- **Automatic reporting never worked against the production console.** `send_report` was the only control-plane call in the runtime that did not set a `User-Agent`, so its request went out as bare `Python-urllib/3.x` and the WAF in front of prod rejected it with a 403 (Cloudflare error 1010). It worked perfectly against a local server, which is exactly why nothing caught it until a real enrolled device reported to the real console. Now uses the shared `http_ua.user_agent()` like `identity`, `remote_policy`, `sinks` and `approvals` already did.
+- **Agents Prismor cannot hook were reported as governed, inflating fleet coverage.** `hooks._config_path` falls through to the Windsurf path for any agent it does not recognise, so asking `hook_installed` about Warp, Trae or Antigravity returned *Windsurf's* answer — every unhookable agent inherited Windsurf's hook status. On a machine with Windsurf hooked, coverage read 91% while counting four agents Prismor cannot govern at all. `hook_installed` now refuses an agent outside `_SUPPORTED_AGENTS` instead of borrowing another agent's config path.
+
 ## [1.40.0] — 2026-08-10
 
 ### Added

--- a/prismor/runtime/discover.py
+++ b/prismor/runtime/discover.py
@@ -1065,6 +1065,13 @@ def send_report(report: Dict[str, Any], *, timeout: int = 5) -> bool:
             },
             method="POST",
         )
+        # Every other control-plane call sets this. Without it the request goes
+        # out as bare `Python-urllib/3.x`, which the WAF in front of the
+        # production console rejects with a 403 (Cloudflare 1010) — so
+        # automatic reporting silently never worked against prod, while
+        # working perfectly against a local server. See prismor/runtime/http_ua.
+        from prismor.runtime.http_ua import user_agent as _ua
+        request.add_header("User-Agent", _ua())
         with urllib.request.urlopen(request, timeout=timeout) as resp:
             return 200 <= resp.status < 300
     except Exception:

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -129,6 +129,13 @@ def hook_installed(agent: str, scope: str, workspace: Path) -> bool:
     ``scope`` ("project" | "global"). Text-based — the dispatcher command embeds
     the stable ``hook-dispatch`` marker in every agent's config format — so it
     works regardless of the JSON/TOML shape."""
+    # _config_path falls through to the Windsurf path for any agent it does
+    # not recognise, so asking it about an unhookable agent (warp, trae,
+    # antigravity) returns Windsurf's answer. That made every such agent
+    # inherit Windsurf's hook status and report as governed, inflating the
+    # coverage number with agents Prismor cannot govern at all.
+    if agent not in _SUPPORTED_AGENTS:
+        return False
     try:
         path = _config_path(agent, scope, workspace)
         return path.exists() and "hook-dispatch" in path.read_text(encoding="utf-8")

--- a/tests/test_discover_shadow.py
+++ b/tests/test_discover_shadow.py
@@ -557,3 +557,34 @@ def test_planning_failure_does_not_break_the_upload(fake_host, monkeypatch):
     assert payload["findings"]
     assert all(f["fixable"] is False for f in payload["findings"])
     assert payload["summary"]["fixable"] == 0
+
+
+def test_send_report_identifies_itself(fake_host, monkeypatch):
+    """Regression: send_report was the only control-plane call that did not
+    set a User-Agent, so it went out as bare `Python-urllib/3.x` and the WAF
+    in front of the production console rejected it with 403 (Cloudflare 1010).
+    Automatic reporting worked against a local server and silently never
+    worked against prod — the exact failure a local-only test cannot see."""
+    discover, home, ws = fake_host
+    from prismor.runtime.enterprise import identity as _identity
+    monkeypatch.setattr(_identity, "load_identity",
+                        lambda: {"device_key": "k", "api_base": "https://x.invalid"})
+    monkeypatch.setattr(_identity, "revoked_info", lambda: None)
+
+    seen = {}
+
+    class _Resp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def fake_urlopen(req, timeout=5):
+        seen["ua"] = req.get_header("User-agent")
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert discover.send_report({"summary": {}}) is True
+    assert seen["ua"], "no User-Agent set"
+    assert "urllib" not in seen["ua"].lower()
+    from prismor.runtime.http_ua import user_agent
+    assert seen["ua"] == user_agent()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -160,3 +160,38 @@ def test_project_scope_hook_also_counts(fake_host):
            '{"hooks": [{"command": "prismor hook-dispatch"}]}')
     report = discovery.discover(ws)
     assert next(a for a in report["agents"] if a["agent"] == "cursor")["governed"]
+
+
+def test_an_unhookable_agent_never_reads_as_governed(fake_host):
+    """Regression: hooks._config_path falls through to the Windsurf path for
+    any agent it does not recognise, so asking about warp/trae/antigravity
+    returned Windsurf's answer. Every unhookable agent inherited Windsurf's
+    hook status and reported as GOVERNED, inflating fleet coverage with
+    agents Prismor cannot govern at all."""
+    discovery, home, ws = fake_host
+    # Windsurf present AND hooked.
+    _write(home / ".codeium" / "windsurf" / "mcp_config.json", '{"mcpServers": {}}')
+    _write(ws / ".windsurf" / "hooks.json",
+           '{"hooks": [{"command": "prismor hook-dispatch"}]}')
+    # An agent with no hook surface, merely present.
+    (home / ".warp").mkdir(parents=True, exist_ok=True)
+    (home / ".trae").mkdir(parents=True, exist_ok=True)
+
+    report = discovery.discover(ws)
+    by = {a["agent"]: a for a in report["agents"]}
+    assert by["windsurf"]["governed"], "windsurf really is hooked"
+    for unhookable in ("warp", "trae"):
+        if unhookable in by and by[unhookable]["present"]:
+            assert not by[unhookable]["governed"], (
+                f"{unhookable} has no hook surface and must never read as governed")
+
+
+def test_hook_installed_refuses_an_unknown_agent(fake_host):
+    from prismor.runtime import hooks
+    discovery, home, ws = fake_host
+    _write(ws / ".windsurf" / "hooks.json",
+           '{"hooks": [{"command": "prismor hook-dispatch"}]}')
+    assert hooks.hook_installed("windsurf", "project", ws) is True
+    # Same path, different agent name — must not borrow the answer.
+    assert hooks.hook_installed("warp", "project", ws) is False
+    assert hooks.hook_installed("not-a-real-agent", "project", ws) is False


### PR DESCRIPTION
Two bugs found by running a real enrolled device against the real console after deploying. **Neither was visible from a local test**, which is the point worth taking from this PR.

## 1. Automatic reporting silently never worked against production

`send_report` was the only control-plane call in the runtime that did not set a `User-Agent`. Its request went out as bare `Python-urllib/3.x`, and the WAF in front of prod rejected it:

```
HTTPError 403  error code: 1010     ← Cloudflare: banned by browser signature
```

Against my local dev server it worked perfectly — that is exactly why every test passed and the feature was still broken in prod. `identity`, `remote_policy`, `sinks` and `approvals` have all used the shared `http_ua.user_agent()` from the start; discovery just never did.

## 2. Agents Prismor cannot hook were counted as governed

`hooks._config_path` ends with an unconditional fallback:

```python
return workspace / ".windsurf" / "hooks.json"   # for ANY unrecognised agent
```

So `hook_installed('warp', ...)` returned *Windsurf's* answer. On a machine with Windsurf hooked, every unhookable agent inherited that status. st3ve reported:

```
governed   Trae / Trae CN (ByteDance)   (Prismor has no hook for this agent)
governed   Warp (Agent Mode)            (Prismor has no hook for this agent)

Coverage:  91%
```

Reading "governed" and "Prismor has no hook for this agent" on the same line is the tell. That 91% counted four agents Prismor cannot govern at all — an inflated number, in the direction that matters most for a coverage metric.

Introduced by #254, where I added `_hooked()` to `enterprise/discovery.py` without the `_SUPPORTED_AGENTS` guard that the sibling `discover._hook_installed` already had. Fixed at the shared helper instead, so no future caller can hit the same trap.

## Testing

3 regression tests: `send_report` sends the shared UA (and specifically not one containing "urllib"); an unhookable agent never reads as governed even with Windsurf hooked at the same path; and `hook_installed` refuses an unknown agent while still answering correctly for a real one.

Full suite: **1734 passed, 24 failed** — the same 24 fail on clean `origin/main`. `check_oss_safe.py` passes.

## Related, not fixed here

`agents.record_seen` POSTs to `/api/agents/register` with the same missing-UA shape and is likely being rejected by the WAF too. Left alone to keep this reviewable — worth its own look.