### PR TITLE
fix(scope): broaden static edit/network heuristics; update notice only for strictly newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+- Static (no-API-key) session-scope heuristic missed common edit verbs (`append`, `insert`, `rename`, `replace`, `delete`, `patch`, `generate`, …) and network hints (`curl`, `web`, `publish`, …), so "append a line to README.md" stayed write-denied. Verified live with Codex.
+- The passive update notice used `!=`, so a fresh release (or a day-old cache) told users on a *newer* version that an older one was "available" and to run `prismor update`. Now only strictly-newer versions trigger it.
+
+## [Unreleased]
+
 ## [1.42.1] — 2026-08-15
 
 ### Fixed

--- a/prismor/runtime/immunity_cli.py
+++ b/prismor/runtime/immunity_cli.py
@@ -73,6 +73,30 @@ def _deprecation_notice() -> None:
     )
 
 
+def _version_key(v: str):
+    """Numeric-aware sort key: '1.42.10' > '1.42.9'; non-numeric parts sort low."""
+    parts = []
+    for p in str(v).strip().lstrip("v").split("."):
+        num = ""
+        for ch in p:
+            if ch.isdigit():
+                num += ch
+            else:
+                break
+        parts.append((int(num) if num else -1, p))
+    return parts
+
+
+def _is_newer(latest: str, current: str) -> bool:
+    """True only when PyPI's latest is strictly newer than the running version.
+    A plain `!=` told users on a fresh release (or with a day-old cache) that an
+    OLDER version was 'available' and to run `prismor update`."""
+    try:
+        return _version_key(latest) > _version_key(current)
+    except Exception:
+        return False
+
+
 def _update_notice() -> None:
     """Passive nag when a newer prismor is on PyPI. The actual PyPI check is
     debounced (see version_check.latest_known_version — at most once/day), so
@@ -87,7 +111,7 @@ def _update_notice() -> None:
         latest = latest_known_version()
     except Exception:
         return
-    if not latest or latest == __version__:
+    if not latest or not _is_newer(latest, __version__):
         return
     sys.stderr.write(
         f"\033[33mnote:\033[0m prismor {latest} is available (you're on {__version__}). "

--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -262,9 +262,22 @@ def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, A
     deny_network = True
 
     # Detect task intent from keywords
-    edit_keywords = {"edit", "fix", "refactor", "update", "change", "modify", "add", "implement", "create", "write"}
-    test_keywords = {"test", "run", "execute", "build", "compile", "lint", "check"}
-    network_keywords = {"fetch", "download", "install", "deploy", "push", "pull", "clone", "api", "http", "url"}
+    # Substring matches (so "appending", "patched", "renamed" all hit). Kept
+    # deliberately broad: a missed verb here means a blocked Edit later, and
+    # the base policy — not this heuristic — is what guards dangerous writes.
+    edit_keywords = {
+        "edit", "fix", "refactor", "update", "change", "modify", "add", "implement", "create", "write",
+        "append", "insert", "remove", "delete", "rename", "replace", "patch", "apply", "generate",
+        "scaffold", "migrate", "bump", "revert", "rewrite", "clean up", "cleanup", "format", "save",
+        "set up", "setup", "configure", "convert", "move", "extract", "inline", "document", "comment",
+        "translate", "port", "upgrade", "downgrade", "make ", "put ", "touch", "mkdir", "new file",
+    }
+    test_keywords = {"test", "run", "execute", "build", "compile", "lint", "check", "verify", "debug", "bench"}
+    network_keywords = {
+        "fetch", "download", "install", "deploy", "push", "pull", "clone", "api", "http", "url",
+        "curl", "wget", "web", "internet", "online", "browse", "request", "endpoint", "publish",
+        "release", "npm", "pip", "webfetch", "websearch", "search the", "look up",
+    }
     search_keywords = {"search", "find", "grep", "look"}
 
     if any(kw in goal_lower for kw in edit_keywords):

--- a/tests/test_scope_ux.py
+++ b/tests/test_scope_ux.py
@@ -205,3 +205,23 @@ def test_scope_flag_accepts_both_spellings(home, tmp_path):
     assert _cli("install-hooks", "--agent", "claude", "--scope", "global", cwd=ws).returncode == 0
     assert _cli("uninstall-hooks", "--agent", "claude", "--scope", "global", cwd=ws).returncode == 0
     assert _cli("cloak", "status", "--scope", "global", cwd=ws).returncode == 0
+
+
+def test_static_rules_recognise_common_edit_verbs():
+    tools = ["Bash", "Read", "Edit", "MultiEdit", "Write", "WebFetch", "WebSearch"]
+    for goal in ("Now append the line 'x' to README.md (use apply_patch), then cat it",
+                 "insert a docstring", "rename foo to bar", "replace hello with hi",
+                 "delete the unused import", "generate a config file", "patch the parser"):
+        r = sa._static_fallback_rules(goal, tools)
+        assert "Edit" in r["allowed_tools"], goal
+    r = sa._static_fallback_rules("curl the changelog and summarise it", tools)
+    assert r["deny_network"] is False and "WebFetch" in r["allowed_tools"]
+
+
+def test_update_notice_only_for_strictly_newer():
+    from prismor.runtime.immunity_cli import _is_newer
+    assert _is_newer("1.42.1", "1.42.0")
+    assert not _is_newer("1.42.0", "1.42.1")
+    assert not _is_newer("1.42.1", "1.42.1")
+    assert _is_newer("1.42.10", "1.42.9")
+    assert not _is_newer("garbage", "1.42.1") or True  # never raises


### PR DESCRIPTION
Follow-up from re-testing the released **1.42.1** on st3ve (fresh sandbox, real Codex sessions).

- **Static scope heuristic missed common verbs.** Codex session: prompt 1 "What does this repo do?" (→ Bash+Read), prompt 2 "Now append the line … to README.md, then cat it" → scope did **not** widen (`append`/`patch` weren't keywords) and `apply_patch` was blocked. Keyword lists broadened (append, insert, remove, delete, rename, replace, patch, apply, generate, …; network: curl, wget, web, publish, …). Verified live: same two prompts now widen to Edit/Write and the append succeeds.
- **Update notice used `!=`.** Right after the release, a stale (≤24h) cache printed `note: prismor 1.42.0 is available (you're on 1.42.1). Run prismor update`. Now compares numerically and only nags for strictly newer.

Also re-ran the full scope battery (setup/scope/status/doctor/global/uninstall/status --all) against the PyPI 1.42.1 wheel — all green; PR #291 behaviour holds in the released build.

Tests: +2 in tests/test_scope_ux.py; full suite unchanged vs main (same pre-existing env failures).

https://claude.ai/code/session_01CNu2aSDhTAKpwVVKVTRadH