### PR TITLE
fix(scope): make `prismor scope clear` stick and let session scopes name MCP tools

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1337,11 +1337,19 @@ def main(argv: Optional[List[str]] = None) -> None:
                     format_scoped_rules_box as _format_scoped_box,
                     merge_scoped_rules as _merge_scoped,
                     apply_agent_invariants as _agent_invariants,
+                    available_tools_for_scope as _available_tools_for_scope,
                 )
                 _existing_scoped = _load_scoped(workspace, normalized["sessionId"])
                 _sc = _existing_scoped or {}
-                if event.get("prompt") and not _sc.get("paused") and not _sc.get("operator_edited"):
-                    _available_tools = ["Bash", "Read", "Edit", "MultiEdit", "Write", "WebFetch", "WebSearch"]
+                # `prismor scope clear` leaves a cleared marker (operator_edited)
+                # rather than deleting the file, so a cleared session is NOT
+                # re-scoped here on the next prompt.
+                if event.get("prompt") and not _sc.get("paused") and not _sc.get("operator_edited") and not _sc.get("cleared"):
+                    # Built-in tags plus the MCP servers this agent can reach
+                    # (as mcp__<server>__* families) — otherwise the synthesiser
+                    # can never put an MCP tool in scope and every MCP call is
+                    # denied by omission, whatever the prompt asks for.
+                    _available_tools = _available_tools_for_scope(workspace, args.agent)
                     _scoped_rules = _synthesize_scoped(
                         goal=event["prompt"],
                         available_tools=_available_tools,
@@ -2497,9 +2505,11 @@ def main(argv: Optional[List[str]] = None) -> None:
                 tools = ", ".join(s["rules"].get("allowed_tools", []))
                 when = _dt.fromtimestamp(s["updated"]).strftime("%b %d %H:%M")
                 flags = []
+                if s["rules"].get("cleared"):
+                    flags.append("cleared")
                 if s["rules"].get("paused"):
                     flags.append("paused")
-                if s["rules"].get("operator_edited"):
+                if s["rules"].get("operator_edited") and not s["rules"].get("cleared"):
                     flags.append("hand-edited")
                 if s["rules"].get("prompts_seen"):
                     flags.append(f"{s['rules']['prompts_seen']} prompts")
@@ -2565,9 +2575,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         if sub == "clear":
             sid = args.session_id
             if clear_scoped_rules(workspace, sid):
-                print(_color("Cleared", _GREEN) + f" scoped rules for session '{sid}'")
+                print(_color("Cleared", _GREEN) + f" scoped rules for session '{sid}' "
+                      "— every tool is allowed and auto-scoping is off for the rest of this session.")
             else:
-                print(f"No scoped rules for session '{sid}'")
+                print(f"Session '{sid}' had no active scope; recorded it as cleared so none is synthesized later.")
             return
         # No action → print usage instead of dumping every session's full box.
         sys.stderr.write(
@@ -2575,7 +2586,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "  list             List active scoped sessions (newest first)\n"
             "  show [session]   Show rules — compact for all, full for one session\n"
             "  edit <session>   Edit a session's scoped rules in $EDITOR (turns off auto-widening)\n"
-            "  clear <session>  Remove a session's scoped rules\n"
+            "  clear <session>  Stop scoping a session (all tools allowed; auto-scoping off)\n"
             "  A session may be given as `latest` or any unique prefix of its id.\n"
         )
         raise SystemExit(2)

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -216,7 +216,9 @@ def evaluate_tool_call(
             _capabilities.append({"name": str(_tool), "source": "declared"})
         _scoped = load_scoped_rules(workspace, session_id) if session_id else None
         for _tool in (_scoped or {}).get("allowed_tools") or []:
-            if _tool != "*":
+            # Skip wildcards ("*" and mcp__<server>__* families): they are
+            # permissions, not tools the agent has been seen to hold.
+            if "*" not in str(_tool):
                 _capabilities.append({"name": str(_tool), "source": "scoped"})
         record_seen(
             _agent_name, framework=agent, workspace=workspace,

--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -569,13 +569,16 @@ def check_scoped_rules(
         # prior allowlist, so the deny does not silently turn into an allowlist
         # that blocks every other tool.
         if "*" not in allowed:
-            if is_mcp_tool(tool_name) and not _mentions_mcp(allowed, denied):
-                # The scope has no opinion on MCP at all — it was synthesised
-                # from a tool list that never included this server (undiscovered
-                # plugin, server added mid-session). Denying tools the
-                # synthesiser could not even name is not a control anyone chose;
-                # the call still goes through the base policy and the MCP
-                # gateway's own screening.
+            if (is_mcp_tool(tool_name) and not _mentions_mcp(allowed, denied)
+                    and not rules.get("operator_edited")):
+                # An auto-synthesised scope with no opinion on MCP at all — it
+                # came from a tool list that never included this server
+                # (undiscovered plugin, server added mid-session). Denying tools
+                # the synthesiser could not even name is not a control anyone
+                # chose; the call still goes through the base policy and the
+                # MCP gateway's own screening. A hand-edited scope is different:
+                # a human shaped it, so its allowlist is authoritative and MCP
+                # tools it does not name stay blocked.
                 pass
             elif _tool_matches(tool_name, allowed):
                 pass

--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -27,6 +27,139 @@ _EVENT_TYPE_TO_TOOL = {
 
 _KNOWN_TOOLS = {"Read", "Write", "Edit", "MultiEdit", "Bash", "WebFetch", "WebSearch"}
 
+# The seven built-in tool tags every scope is synthesised over. MCP tool
+# families (``mcp__<server>__*``) are appended per machine by
+# ``available_tools_for_scope``.
+BUILTIN_SCOPE_TOOLS = ["Bash", "Read", "Edit", "MultiEdit", "Write", "WebFetch", "WebSearch"]
+
+# ── MCP tool families ──────────────────────────────────────────────────────
+# MCP tools arrive under the tag ``mcp__<server>__<tool>`` (Claude Code
+# rewrites ``:`` in a plugin server name — ``plugin:posthog:posthog`` — to
+# ``_``, keeping hyphens). Individual tool names are only known once the agent
+# calls one, so a scope names a *family* per server: ``mcp__<server>__*``.
+
+_MCP_PREFIX = "mcp__"
+_MAX_MCP_CONFIG_BYTES = 8 * 1024 * 1024
+
+
+def is_mcp_tool(tool: str) -> bool:
+    return isinstance(tool, str) and tool.startswith(_MCP_PREFIX)
+
+
+def is_mcp_family(entry: str) -> bool:
+    return is_mcp_tool(entry) and entry.endswith("__*")
+
+
+def mcp_family_for_server(server: str) -> str:
+    """``plugin:posthog:posthog`` → ``mcp__plugin_posthog_posthog__*``."""
+    return f"{_MCP_PREFIX}{server.replace(':', '_')}__*"
+
+
+def _mcp_family_tokens(family: str) -> List[str]:
+    """Human-recognisable words in a family name, for keyword matching:
+    ``mcp__plugin_posthog_posthog__*`` → ["posthog"] (drops "plugin"/"mcp")."""
+    core = family[len(_MCP_PREFIX):-len("__*")] if is_mcp_family(family) else family
+    toks = set()
+    for part in core.replace("-", "_").split("_"):
+        part = part.strip().lower()
+        if len(part) >= 3 and part not in {"plugin", "mcp", "server", "api", "docs"}:
+            toks.add(part)
+    return sorted(toks)
+
+
+def _tool_matches(tool: str, entries: List[str]) -> bool:
+    """Exact tag match, or a glob entry (``mcp__posthog__*``) that covers it."""
+    for e in entries:
+        if not isinstance(e, str):
+            continue
+        if e == tool:
+            return True
+        if "*" in e and e != "*" and fnmatch(tool, e):
+            return True
+    return False
+
+
+def _mentions_mcp(*lists: List[str]) -> bool:
+    """Does any allow/deny list name an MCP tool or family?"""
+    return any(is_mcp_tool(e) for lst in lists for e in (lst or []) if isinstance(e, str))
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        if path.stat().st_size > _MAX_MCP_CONFIG_BYTES:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _mcp_server_names_in(obj: Any) -> List[str]:
+    """Server names from a ``{"mcpServers": {...}}`` blob or a bare map."""
+    if not isinstance(obj, dict):
+        return []
+    servers = obj.get("mcpServers", obj)
+    if not isinstance(servers, dict):
+        return []
+    return [str(k) for k in servers.keys() if isinstance(k, str) and k]
+
+
+def discover_mcp_families(workspace: Path, agent: str = "claude") -> List[str]:
+    """Best-effort inventory of the MCP servers this agent can reach, as
+    ``mcp__<server>__*`` families. Cheap on purpose (a handful of JSON reads —
+    this runs on every prompt) and never raises. Servers it cannot see are
+    not denied by the scope: see ``check_scoped_rules``."""
+    families: List[str] = []
+    seen: set = set()
+
+    def _add(server: str) -> None:
+        fam = mcp_family_for_server(server)
+        if fam not in seen:
+            seen.add(fam)
+            families.append(fam)
+
+    try:
+        home = Path.home()
+        # Workspace-level .mcp.json (Claude Code, Codex, Cursor share the shape).
+        for name in _mcp_server_names_in(_read_json(workspace / ".mcp.json")):
+            _add(name)
+        if agent in ("claude", "claude-code", "claude_code"):
+            cfg = _read_json(home / ".claude.json")
+            if isinstance(cfg, dict):
+                for name in _mcp_server_names_in(cfg.get("mcpServers")):
+                    _add(name)
+                projects = cfg.get("projects")
+                if isinstance(projects, dict):
+                    ws = str(workspace.resolve())
+                    for proj_path, proj in projects.items():
+                        if isinstance(proj, dict) and (proj_path == ws or ws.startswith(proj_path.rstrip("/") + "/")):
+                            for name in _mcp_server_names_in(proj.get("mcpServers")):
+                                _add(name)
+            # Plugin-provided servers: tag is plugin:<plugin>:<server>.
+            installed = _read_json(home / ".claude" / "plugins" / "installed_plugins.json")
+            plugins = installed.get("plugins") if isinstance(installed, dict) else None
+            if isinstance(plugins, dict):
+                for key, entries in plugins.items():
+                    plugin = str(key).split("@", 1)[0]
+                    for entry in entries if isinstance(entries, list) else []:
+                        if not isinstance(entry, dict):
+                            continue
+                        scope = entry.get("scope")
+                        if scope in ("project", "local") and entry.get("projectPath") not in (None, str(workspace.resolve())):
+                            continue
+                        install = entry.get("installPath")
+                        if not install:
+                            continue
+                        for name in _mcp_server_names_in(_read_json(Path(install) / ".mcp.json")):
+                            _add(f"plugin:{plugin}:{name}")
+    except Exception:
+        pass
+    return families
+
+
+def available_tools_for_scope(workspace: Path, agent: str = "claude") -> List[str]:
+    """Built-in tool tags plus the MCP families reachable from this workspace."""
+    return list(BUILTIN_SCOPE_TOOLS) + discover_mcp_families(workspace, agent)
+
 
 def _resolve_tool_name(event: Dict[str, Any]) -> Optional[str]:
     """Resolve the concrete tool name for an event.
@@ -117,6 +250,10 @@ Rules:
 - If the task involves reading/editing code, allow Read/Edit/Write for relevant paths
 - If the task does NOT mention network, web, fetch, install, or download, set deny_network: true
 - Always include Read in allowed_tools (agents need to read files to orient)
+- Entries of the form mcp__<server>__* are MCP tool families (one per connected
+  MCP server). Include a family in allowed_tools when the task needs that
+  service (e.g. an analytics/PostHog task needs the *posthog* family); put the
+  rest in deny_tools like any other unneeded tool.
 - If the task prompt contains @@SECRET:name@@ placeholders, include Bash so shell-based secret use can go through the agent's decloak hook or `prismor cloak run`.
 """
 
@@ -277,6 +414,13 @@ def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, A
     if any(kw in goal_lower for kw in search_keywords):
         allowed.update({"Bash"})  # for grep/find
 
+    # MCP tool families: allow a family when the prompt names its server
+    # ("query posthog for ..." → mcp__plugin_posthog_posthog__*).
+    for fam in available_tools:
+        if is_mcp_family(fam) and any(tok in goal_lower for tok in _mcp_family_tokens(fam)):
+            allowed.add(fam)
+            deny_network = False
+
     deny = [t for t in available_tools if t not in allowed]
 
     rules = {
@@ -321,13 +465,34 @@ def load_scoped_rules(workspace: Path, session_id: str) -> Optional[Dict[str, An
         return None
 
 
+# What ``prismor scope clear`` leaves behind. Deleting the sidecar used to be
+# the whole implementation — and the next UserPromptSubmit saw "no scope yet"
+# and synthesised a fresh one, so the user was back to blocked one prompt
+# later (and told, again, to run `scope clear`). A cleared session is instead
+# recorded as allow-everything with auto-scoping switched off, and stays that
+# way until the session ends or an operator edits it again.
+CLEARED_SCOPE: Dict[str, Any] = {
+    "allowed_tools": ["*"],
+    "allowed_paths": ["**"],
+    "deny_tools": [],
+    "deny_network": False,
+    "cleared": True,
+    "operator_edited": True,
+}
+
+
 def clear_scoped_rules(workspace: Path, session_id: str) -> bool:
-    """Remove scoped rules for a session. Returns True if file was deleted."""
-    path = _scoped_path(workspace, session_id)
-    if path.exists():
-        path.unlink()
-        return True
-    return False
+    """Stop scoping a session: replace its rules with ``CLEARED_SCOPE`` so the
+    prompt hook does not re-synthesise them. Returns True if the session had
+    a scope that was not already cleared."""
+    existing = load_scoped_rules(workspace, session_id)
+    had_scope = existing is not None and not existing.get("cleared")
+    save_scoped_rules(workspace, session_id, dict(CLEARED_SCOPE))
+    return had_scope
+
+
+def is_cleared(rules: Optional[Dict[str, Any]]) -> bool:
+    return bool(rules and rules.get("cleared"))
 
 
 def list_scoped_sessions(workspace: Path) -> List[Dict[str, Any]]:
@@ -390,7 +555,9 @@ def check_scoped_rules(
         # deny_tools takes precedence over allowed_tools: an explicitly denied
         # tool is blocked even when a broader allow-rule would otherwise permit
         # it (e.g. allowed_tools:[Read,Edit] + deny_tools:[Write] blocks Write).
-        if tool_name in denied:
+        # Entries may be globs — ``mcp__posthog__*`` covers every tool of that
+        # MCP server.
+        if _tool_matches(tool_name, denied):
             return _scoped_finding(
                 session_id,
                 f"Tool '{tool_name}' is explicitly denied for this session",
@@ -402,19 +569,29 @@ def check_scoped_rules(
         # prior allowlist, so the deny does not silently turn into an allowlist
         # that blocks every other tool.
         if "*" not in allowed:
-            if event_type == "file_write":
+            if is_mcp_tool(tool_name) and not _mentions_mcp(allowed, denied):
+                # The scope has no opinion on MCP at all — it was synthesised
+                # from a tool list that never included this server (undiscovered
+                # plugin, server added mid-session). Denying tools the
+                # synthesiser could not even name is not a control anyone chose;
+                # the call still goes through the base policy and the MCP
+                # gateway's own screening.
+                pass
+            elif _tool_matches(tool_name, allowed):
+                pass
+            elif event_type == "file_write":
                 # A write may arrive as Write, Edit, or MultiEdit. Permit it only if
                 # the concrete tool is allowed, or — when the event carries no
                 # tool name — any write-family tool is allowed and not denied.
                 write_family = ("Write", "Edit", "MultiEdit")
                 permitted = [t for t in write_family if t in allowed and t not in denied]
-                if tool_name not in allowed and not permitted:
+                if not permitted:
                     return _scoped_finding(
                         session_id,
                         f"Tool '{tool_name}' is not in scope for this session",
                         event_type,
                     )
-            elif tool_name not in allowed:
+            else:
                 return _scoped_finding(
                     session_id,
                     f"Tool '{tool_name}' is not in scope for this session",
@@ -478,20 +655,38 @@ def format_scoped_rules_box(rules: Dict[str, Any]) -> str:
     _use_color = sys.stdout.isatty() and not _os.environ.get("NO_COLOR")
     _C = _CYAN if _use_color else ""
     _N = _NC if _use_color else ""
-    allowed = ", ".join(rules.get("allowed_tools", []))
-    paths = ", ".join(rules.get("allowed_paths", []))
-    denied = ", ".join(rules.get("deny_tools", []))
     network = "denied" if rules.get("deny_network", True) else "allowed"
 
+    def _field(label: str, items: List[str]) -> List[str]:
+        # Wrap long lists (a machine with ten MCP servers has ten families in
+        # deny_tools) so the box stays terminal-width instead of one huge line.
+        head = f"  {label:<15} ["
+        indent = " " * len(head)
+        out, cur = [], head
+        for i, item in enumerate(items):
+            piece = str(item) + ("," if i < len(items) - 1 else "")
+            if len(cur) + len(piece) + 1 > 78 and cur.strip() not in ("", head.strip()):
+                out.append(cur.rstrip())
+                cur = indent + piece
+            else:
+                cur = cur + (" " if cur not in (head, indent) else "") + piece if cur != head else cur + piece
+        out.append(cur + "]")
+        return out
+
     content_lines = [
-        f"  allowed_tools:  [{allowed}]",
-        f"  allowed_paths:  [{paths}]",
-        f"  deny_tools:     [{denied}]",
+        *_field("allowed_tools:", rules.get("allowed_tools", [])),
+        *_field("allowed_paths:", rules.get("allowed_paths", [])),
+        *_field("deny_tools:", rules.get("deny_tools", [])),
         f"  deny_network:   {network}",
         "",
         "  Session-only; widened on each new prompt. Stored in $PRISMOR_HOME/scoped/.",
-        "  Adjust: prismor scope show|edit|clear <session-id>",
+        "  Adjust: prismor scope show|edit <session-id>   Stop scoping: prismor scope clear <session-id>",
     ]
+    if rules.get("cleared"):
+        content_lines = [
+            "  cleared — every tool allowed for this session; auto-scoping is off.",
+            "  Re-enable by starting a new session.",
+        ]
 
     max_width = max(len(line) for line in content_lines) + 4
     border = max_width + 2

--- a/tests/test_scope_clear_sticky_mcp.py
+++ b/tests/test_scope_clear_sticky_mcp.py
@@ -210,6 +210,16 @@ def test_mcp_fallthrough_only_when_scope_is_silent_on_mcp():
     assert sa.check_scoped_rules(silent, _ev("Bash", "shell")) is None
 
 
+def test_hand_edited_scope_does_not_fall_through_for_mcp():
+    """Operator narrowed the scope to Read+Bash without mentioning MCP: that
+    allowlist is authoritative — MCP tools stay blocked (found by the
+    multi-prompt scenario run; auto-synthesised scopes still fall through)."""
+    edited = {"allowed_tools": ["Read", "Bash"], "deny_tools": ["Edit", "Write"], "operator_edited": True}
+    assert sa.check_scoped_rules(edited, _ev(POSTHOG_TOOL)) is not None
+    auto = {"allowed_tools": ["Read", "Bash"], "deny_tools": ["Edit", "Write"]}
+    assert sa.check_scoped_rules(auto, _ev(POSTHOG_TOOL)) is None
+
+
 def test_cleared_scope_allows_everything():
     assert sa.check_scoped_rules(dict(sa.CLEARED_SCOPE), _ev(POSTHOG_TOOL)) is None
     assert sa.check_scoped_rules(dict(sa.CLEARED_SCOPE), _ev("Write", "file_write")) is None

--- a/tests/test_scope_clear_sticky_mcp.py
+++ b/tests/test_scope_clear_sticky_mcp.py
@@ -1,0 +1,257 @@
+"""Session scope: `prismor scope clear` must stick, and MCP tools must be
+scope-able.
+
+Regression for the transcript where every prompt re-blocked the PostHog MCP
+tool and the user was told to run `prismor scope clear` four times:
+
+- ``scope clear`` deleted the sidecar; the next UserPromptSubmit saw "no scope"
+  and synthesised a fresh one — clear meant "reset and guess again", not
+  "stop scoping". Now clear leaves an allow-all, operator_edited marker.
+- The synthesiser was handed a hardcoded 7-tool list and clamped its output to
+  it, so ``mcp__<server>__<tool>`` could *never* be in allowed_tools; every
+  MCP call was denied by omission on every prompt regardless of what the
+  prompt asked for. Now the reachable MCP servers are passed as
+  ``mcp__<server>__*`` families, allow/deny entries may be globs, and MCP
+  tools the scope has no opinion on fall through to the base policy.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from prismor.runtime import scoped_agent as sa
+
+POSTHOG_TOOL = "mcp__plugin_posthog_posthog__exec"
+POSTHOG_FAMILY = "mcp__plugin_posthog_posthog__*"
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    ph = tmp_path / "prismor-home"
+    ph.mkdir()
+    monkeypatch.setenv("PRISMOR_HOME", str(ph))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    # Force the static synthesiser: the test must not depend on an API key.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    return ph
+
+
+_REPO_ROOT = Path(sa.__file__).parents[2]
+
+
+def _env(extra=None):
+    env = dict(os.environ)
+    env.pop("PRISMOR_WORKSPACE", None)
+    env.pop("ANTHROPIC_API_KEY", None)
+    env["PYTHONPATH"] = str(_REPO_ROOT) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env.update(extra or {})
+    return env
+
+
+def _cli(*argv: str, cwd: Path, stdin: str = "") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "prismor.runtime.immunity_cli", *argv],
+        cwd=str(cwd), env=_env(), input=stdin, capture_output=True, text=True, timeout=120,
+    )
+
+
+def _ws(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    return ws
+
+
+def _prompt(ws: Path, text: str, sid: str):
+    payload = {"session_id": sid, "cwd": str(ws), "hook_event_name": "UserPromptSubmit", "prompt": text}
+    r = _cli("hook-dispatch", "--agent", "claude", "--workspace", str(ws), "--mode", "enforce",
+             cwd=ws, stdin=json.dumps(payload))
+    assert r.returncode == 0, r.stderr
+    return r
+
+
+def _mcp_call(ws: Path, sid: str, tool: str = POSTHOG_TOOL):
+    payload = {"session_id": sid, "cwd": str(ws), "hook_event_name": "PreToolUse",
+               "tool_name": tool, "tool_input": {"command": "query trends"}}
+    return _cli("hook-dispatch", "--agent", "claude", "--workspace", str(ws), "--mode", "enforce",
+                cwd=ws, stdin=json.dumps(payload))
+
+
+def _blocked_by_scope(r: subprocess.CompletedProcess) -> bool:
+    return r.returncode == 2 and "scoped agent" in (r.stderr + r.stdout)
+
+
+# ── 1. `scope clear` sticks ───────────────────────────────────────────────
+
+def test_scope_clear_survives_the_next_prompt(home, tmp_path):
+    ws = _ws(tmp_path)
+    sid = "sess-clear"
+    _prompt(ws, "What does this repo do?", sid)
+    rules = sa.load_scoped_rules(ws, sid)
+    assert rules and "*" not in rules["allowed_tools"]
+
+    r = _cli("scope", "clear", sid, cwd=ws)
+    assert r.returncode == 0, r.stderr
+    assert "Cleared" in r.stdout and "auto-scoping is off" in r.stdout
+    assert sa.is_cleared(sa.load_scoped_rules(ws, sid))
+
+    # The bug: this prompt used to re-synthesise a fresh restrictive scope.
+    _prompt(ws, "Tell me data for signed-up users, what are they doing in the platform", sid)
+    rules = sa.load_scoped_rules(ws, sid)
+    assert sa.is_cleared(rules), rules
+    assert rules["allowed_tools"] == ["*"]
+    assert "prompts_seen" not in rules  # nothing was merged in
+
+    r = _cli("scope", "list", cwd=ws)
+    assert "cleared" in r.stdout and "hand-edited" not in r.stdout
+
+
+def test_scope_clear_on_unknown_session_still_prevents_later_scoping(home, tmp_path):
+    ws = _ws(tmp_path)
+    sid = "sess-preclear"
+    r = _cli("scope", "clear", sid, cwd=ws)
+    assert r.returncode == 0
+    assert "recorded it as cleared" in r.stdout
+    _prompt(ws, "fix the failing tests", sid)
+    assert sa.is_cleared(sa.load_scoped_rules(ws, sid))
+
+
+# ── 2. The transcript, end to end ─────────────────────────────────────────
+
+def _install_posthog_plugin(tmp_path: Path):
+    """Mimic Claude Code's installed_plugins.json for the posthog plugin."""
+    home = Path(os.environ["HOME"])
+    install = tmp_path / "plugin-cache" / "posthog"
+    install.mkdir(parents=True)
+    (install / ".mcp.json").write_text(json.dumps({"mcpServers": {"posthog": {"type": "http", "url": "https://x"}}}))
+    plugins_dir = home / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(json.dumps({
+        "version": 2,
+        "plugins": {"posthog@claude-plugins-official": [{"scope": "user", "installPath": str(install)}]},
+    }))
+
+
+def test_transcript_replay_posthog_after_web_preview_prompt(home, tmp_path):
+    """First prompt is about the web codebase, second asks for PostHog data.
+    Before: PostHog blocked on prompt 2 (and every later prompt, even after
+    `scope clear`). After: prompt 2 widens the scope to the posthog family."""
+    _install_posthog_plugin(tmp_path)
+    ws = _ws(tmp_path)
+    sid = "ae2da67a"
+
+    _prompt(ws, "look at the web preview code and summarize the layout", sid)
+    rules = sa.load_scoped_rules(ws, sid)
+    assert POSTHOG_FAMILY in rules["deny_tools"], rules  # the family was *seen*, just not needed
+    assert _blocked_by_scope(_mcp_call(ws, sid))
+
+    _prompt(ws, "can you tell me from mcp posthog on our product usage and give me a summary", sid)
+    rules = sa.load_scoped_rules(ws, sid)
+    assert POSTHOG_FAMILY in rules["allowed_tools"] and POSTHOG_FAMILY not in rules["deny_tools"], rules
+    r = _mcp_call(ws, sid)
+    assert not _blocked_by_scope(r), r.stderr
+
+    # A different MCP server the scope has seen but not been asked for stays denied…
+    # (nothing else installed here, so simulate the dashboard adding a deny)
+    rules["deny_tools"].append("mcp__node_repl__*")
+    sa.save_scoped_rules(ws, sid, rules)
+    assert _blocked_by_scope(_mcp_call(ws, sid, "mcp__node_repl__js"))
+    # …while posthog remains allowed.
+    assert not _blocked_by_scope(_mcp_call(ws, sid))
+
+
+def test_undiscovered_mcp_server_is_not_denied_by_omission(home, tmp_path):
+    """No MCP inventory at all (no plugins, no .mcp.json): a scope synthesised
+    from the 7 built-ins has no opinion on MCP, so an MCP call falls through to
+    the base policy instead of being blocked forever."""
+    ws = _ws(tmp_path)
+    sid = "sess-nomcp"
+    _prompt(ws, "What does this repo do?", sid)
+    rules = sa.load_scoped_rules(ws, sid)
+    assert not any(t.startswith("mcp__") for t in rules["allowed_tools"] + rules["deny_tools"])
+    r = _mcp_call(ws, sid)
+    assert not _blocked_by_scope(r), r.stderr
+    # …but the built-in scope is still enforced for built-in tools.
+    payload = {"session_id": sid, "cwd": str(ws), "hook_event_name": "PreToolUse",
+               "tool_name": "Write", "tool_input": {"file_path": str(ws / "a.txt"), "content": "x"}}
+    r = _cli("hook-dispatch", "--agent", "claude", "--workspace", str(ws), "--mode", "enforce",
+             cwd=ws, stdin=json.dumps(payload))
+    assert _blocked_by_scope(r), r.stderr
+
+
+# ── 3. check_scoped_rules: globs + MCP semantics ──────────────────────────
+
+def _ev(tool: str, typ: str = "mcp"):
+    return {"type": typ, "metadata": {"tool_name": tool}}
+
+
+def test_family_glob_allows_and_denies():
+    allow = {"allowed_tools": ["Read", POSTHOG_FAMILY], "deny_tools": ["mcp__github__*"]}
+    assert sa.check_scoped_rules(allow, _ev(POSTHOG_TOOL)) is None
+    assert sa.check_scoped_rules(allow, _ev("mcp__github__create_issue")) is not None
+    # explicit tool deny still beats a family allow
+    both = {"allowed_tools": [POSTHOG_FAMILY], "deny_tools": [POSTHOG_TOOL]}
+    assert sa.check_scoped_rules(both, _ev(POSTHOG_TOOL)) is not None
+
+
+def test_mcp_fallthrough_only_when_scope_is_silent_on_mcp():
+    silent = {"allowed_tools": ["Read", "Bash"], "deny_tools": ["Write"]}
+    assert sa.check_scoped_rules(silent, _ev(POSTHOG_TOOL)) is None
+    opinionated = {"allowed_tools": ["Read", "mcp__github__*"], "deny_tools": []}
+    assert sa.check_scoped_rules(opinionated, _ev(POSTHOG_TOOL)) is not None
+    # built-ins are unaffected by the fallthrough
+    assert sa.check_scoped_rules(silent, _ev("Write", "file_write")) is not None
+    assert sa.check_scoped_rules(silent, _ev("Bash", "shell")) is None
+
+
+def test_cleared_scope_allows_everything():
+    assert sa.check_scoped_rules(dict(sa.CLEARED_SCOPE), _ev(POSTHOG_TOOL)) is None
+    assert sa.check_scoped_rules(dict(sa.CLEARED_SCOPE), _ev("Write", "file_write")) is None
+
+
+# ── 4. discovery + static fallback ────────────────────────────────────────
+
+def test_discover_mcp_families_reads_claude_configs(home, tmp_path, monkeypatch):
+    ws = _ws(tmp_path)
+    hp = Path(os.environ["HOME"])
+    (hp / ".claude.json").write_text(json.dumps({
+        "mcpServers": {"get-an-expert": {}},
+        "projects": {str(ws): {"mcpServers": {"notion": {}}},
+                     str(tmp_path / "other"): {"mcpServers": {"elsewhere": {}}}},
+    }))
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": {"repo-local": {}}}))
+    _install_posthog_plugin(tmp_path)
+    fams = sa.discover_mcp_families(ws, "claude")
+    assert set(fams) == {"mcp__repo-local__*", "mcp__get-an-expert__*", "mcp__notion__*", POSTHOG_FAMILY}
+    tools = sa.available_tools_for_scope(ws, "claude")
+    assert tools[:7] == sa.BUILTIN_SCOPE_TOOLS and POSTHOG_FAMILY in tools
+
+
+def test_static_fallback_allows_family_named_in_prompt():
+    tools = sa.BUILTIN_SCOPE_TOOLS + [POSTHOG_FAMILY, "mcp__plugin_cloudflare_cloudflare-api__*"]
+    r = sa._static_fallback_rules("give me a posthog usage summary", tools)
+    assert POSTHOG_FAMILY in r["allowed_tools"]
+    assert "mcp__plugin_cloudflare_cloudflare-api__*" in r["deny_tools"]
+    assert r["deny_network"] is False
+    r = sa._static_fallback_rules("what does this repo do", tools)
+    assert POSTHOG_FAMILY in r["deny_tools"]
+
+
+def test_merge_widens_families_and_drops_them_from_deny():
+    old = {"allowed_tools": ["Read"], "deny_tools": ["Bash", POSTHOG_FAMILY], "allowed_paths": ["**"], "deny_network": True}
+    new = {"allowed_tools": ["Read", POSTHOG_FAMILY], "deny_tools": ["Bash"], "allowed_paths": ["**"], "deny_network": False}
+    m = sa.merge_scoped_rules(old, new)
+    assert POSTHOG_FAMILY in m["allowed_tools"] and POSTHOG_FAMILY not in m["deny_tools"]
+    assert m["deny_network"] is False
+
+
+def test_family_helpers():
+    assert sa.mcp_family_for_server("plugin:posthog:posthog") == POSTHOG_FAMILY
+    assert sa._mcp_family_tokens("mcp__plugin_cloudflare_cloudflare-api__*") == ["cloudflare"]
+    assert sa.is_mcp_family(POSTHOG_FAMILY) and not sa.is_mcp_family(POSTHOG_TOOL)


### PR DESCRIPTION
## Problem

A real session (Claude Code, `prismor-web-preview`, 2026‑08‑14) went like this — four times in a row:

1. User asks for PostHog data → the PostHog MCP tool is blocked by the session scope.
2. Agent tells the user to run `prismor scope clear <sid>`.
3. User runs it → tool works for the rest of that turn.
4. Next prompt → blocked again → back to step 2.

Two independent bugs combined to produce that loop.

### Bug 1 — `prismor scope clear` did not stick

`clear_scoped_rules()` just deleted `$PRISMOR_HOME/scoped/<sid>.json`. The `UserPromptSubmit` hook (`cli.py`, "synthesize rules on EVERY prompt") then saw *no scope yet* on the next prompt and synthesised a fresh restrictive one. Only `operator_edited` (set by `scope edit`) or `paused` stopped re‑synthesis; `clear` set neither. So "clear" meant *reset and guess again*, not *stop scoping this session* — and the block message pointed at it as the remedy.

### Bug 2 — MCP tools could never be in scope

The synthesiser was handed a hardcoded list:

```python
_available_tools = ["Bash", "Read", "Edit", "MultiEdit", "Write", "WebFetch", "WebSearch"]
```

and `synthesize_scoped_rules()` **clamps** the LLM output to that list. `check_scoped_rules()` resolves the real tag (`mcp__plugin_posthog_posthog__exec`) and blocks it because it's `not in allowed`. So no prompt — not even "query PostHog MCP" — could ever put an MCP tool in scope, and the per‑prompt widening from #291 could not help. **Every MCP call in every scoped session was denied by omission**, and `scope edit`/dashboard were the only real escapes.

## Fix

**`scope clear` is sticky.** It now writes a cleared marker instead of deleting the file:

```json
{"allowed_tools": ["*"], "allowed_paths": ["**"], "deny_tools": [], "deny_network": false,
 "cleared": true, "operator_edited": true}
```

The prompt hook honours it for the rest of the session; `scope list` shows `(cleared)`; the CLI message says what it means. Clearing a session that had no scope yet also records the marker so none is synthesised later. The dashboard `clear` action goes through the same function.

**Session scopes can name MCP tools, as families.**
- `available_tools_for_scope(workspace, agent)` = the 7 built‑ins + one `mcp__<server>__*` family per MCP server the agent can reach: workspace `.mcp.json`, `~/.claude.json` (global + this project's `mcpServers`), and Claude Code plugin `.mcp.json` files (tag `plugin:<plugin>:<server>` → `mcp__plugin_<plugin>_<server>__*`, hyphens kept — verified against real tags on this machine). A handful of JSON reads, never raises, since it runs on every prompt.
- The LLM system prompt and the static fallback both know about families (fallback allows a family whose server name appears in the prompt: "posthog usage" → `mcp__plugin_posthog_posthog__*`).
- `allowed_tools` / `deny_tools` entries may be globs (`fnmatch`). Explicit tool denies still beat family allows; `"*"` semantics unchanged; `merge_scoped_rules` widening moves a family from deny → allow on a later prompt exactly like built‑ins.
- **Fallthrough (auto-synthesised scopes only):** an MCP tool the scope has *no opinion on* (no `mcp__` entry in allow or deny — i.e. the server wasn't discoverable) is no longer denied by omission; it falls through to the base policy + MCP‑gateway screening. Built‑in tools keep the existing allowlist semantics, and a hand‑edited (`operator_edited`) scope keeps unnamed MCP tools blocked — a human‑shaped allowlist is authoritative (see the multi‑prompt scenario comment below). Denying tools the synthesiser could not even name was not a control anyone configured — it was an artefact of the hardcoded list, and its practical effect was users running `scope clear` (i.e. *no* scope at all).

**Cosmetic:** the scope box wraps long lists (ten families made it a 400‑column line); its hint now separates *adjust* (`show|edit`) from *stop scoping* (`clear`); runtime capability registration skips wildcard entries.

## Before / after (live replay of the transcript, isolated `PRISMOR_HOME`, real plugin config, static synthesiser)

**Before** — `origin/main` d2356ee. Blocked → clear → allowed → next prompt → blocked again:

![before](https://raw.githubusercontent.com/PrismorSec/prismor/assets/pr-scope-clear/scope-clear/scope_before.png)

**After** — this branch. Prompt 1 sees the PostHog family and denies it (not needed); prompt 2 ("from mcp posthog…") widens to it and the call is allowed; `scope clear` sticks through prompt 3; `scope list` shows `(cleared)`:

![after](https://raw.githubusercontent.com/PrismorSec/prismor/assets/pr-scope-clear/scope-clear/scope_after.png)

## Tests

New `tests/test_scope_clear_sticky_mcp.py` (12 tests), all through the real `hook-dispatch` subprocess where it matters:

- `scope clear` survives the next prompt; clearing an unknown session prevents later scoping.
- **Transcript replay end‑to‑end**: web‑preview prompt → PostHog blocked; PostHog prompt → family allowed; a dashboard deny of another family still blocks; explicit tool deny beats family allow.
- Undiscovered MCP server is not denied by omission, while `Write` on the same scope still is.
- `check_scoped_rules` glob allow/deny, MCP fallthrough only when the scope is silent on MCP, cleared scope allows everything.
- `discover_mcp_families` reads `.mcp.json`, `~/.claude.json` global + per‑project (and ignores other projects), plugin `.mcp.json`.
- Static fallback picks the family named in the prompt; merge widens families; helper edge cases.

![tests](https://raw.githubusercontent.com/PrismorSec/prismor/assets/pr-scope-clear/scope-clear/scope_tests.png)

Full suite: `1923 passed, 21 failed, 12 skipped` on this branch vs `1912 passed, 21 failed` on `origin/main` (same run, same machine). The 21 failures are identical pre‑existing env‑dependent ones (`test_env_agent_key_identity`, `test_enterprise_telemetry`, `test_staged_execution`, …) plus 4 concurrency tests that flip between runs and pass in isolation; four adapter test modules can't collect here (`prismor.openai`/`prismor.langchain` not installed). No new failures.

## Notes for review

- The fallthrough for scope‑silent MCP tools is the one behavioural change worth a deliberate look. Alternative would be "deny unless family discovered", but that reintroduces the exact loop for any server discovery misses (Codex/Gemini/Cursor configs, servers added mid‑session).
- Discovery is Claude Code–shaped for now (`~/.claude.json` + plugins); other agents get workspace `.mcp.json` only, and otherwise fall through as above.
- Screenshots live on the orphan `assets/pr-scope-clear` branch, not on `main`.
