### PR TITLE
feat(cloak): auto-reload sanitized prompt after a UserPromptSubmit block

### DIFF
--- a/docs/sweep-and-cloak.md
+++ b/docs/sweep-and-cloak.md
@@ -35,7 +35,8 @@ an agent from simply opening the vault files directly — so you want both.
 You mostly do nothing. The flow is automatic:
 
 - **Paste a secret into chat** → it's detected, vaulted, and your prompt is
-  blocked once so you resubmit the sanitized version. The model then sees only
+  blocked once. The sanitized version is stashed; send any follow-up (e.g.
+  `go`) and it is loaded automatically. The model then sees only
   `@@SECRET:auto_xxxx@@`.
 - **The model emits a raw secret in a command, file, or MCP call** → the call is
   denied, the value is vaulted, and the model is told to use the placeholder.

--- a/prismor/runtime/cloaking/README.md
+++ b/prismor/runtime/cloaking/README.md
@@ -144,9 +144,10 @@ Secrets live under `$PRISMOR_HOME/secrets/` (default `~/.prismor/secrets/`) with
 
 1. Detects the secret via conservative, known-prefix regex.
 2. Auto-registers it under a deterministic hashed name (`auto_<8-hex>`) in `$PRISMOR_SECRETS_DIR`.
-3. Blocks the submission with a message that shows the **sanitized** prompt, ready for you to copy and resubmit.
+3. Blocks the submission with a message that shows the **sanitized** prompt, and stashes that sanitized prompt under `$PRISMOR_HOME/prompt_stash/<session_id>` (mode 0600).
+4. On your **next clean message in the same session** (anything — `go`, a clarification, `!!allow …`) it reloads the stash as `additionalContext` and deletes it, so the model receives the sanitized request without you re-pasting anything. If you paste the sanitized text yourself, the stash is simply dropped. Stashes older than 30 minutes (`PRISMOR_PROMPT_STASH_TTL`) are discarded rather than injected into an unrelated conversation.
 
-The UX cost is one re-paste per leaked prompt. The original prompt was *not* transmitted to the upstream API.
+The original prompt was *not* transmitted to the upstream API. Image attachments on the blocked prompt are not carried over — re-attach them on the follow-up.
 
 **Bypass:** prefix any prompt with `!!allow ` to skip detection for a single message (useful when you are deliberately discussing a secret format in prose).
 

--- a/prismor/runtime/cloaking/hooks/userprompt-guard.sh
+++ b/prismor/runtime/cloaking/hooks/userprompt-guard.sh
@@ -9,12 +9,17 @@
 # placeholder, never the raw value.
 #
 # UserPromptSubmit hooks cannot rewrite the prompt (Claude Code exposes only
-# block/add-context on this event). One re-paste is the smallest achievable
-# UX cost for a leak-proof user-prompt boundary.
+# block/add-context on this event). To avoid a manual re-paste, the sanitized
+# prompt is STASHED under $PRISMOR_HOME/prompt_stash/<session_id> when we
+# block; on the user's next (clean) prompt in that session the stash is
+# auto-loaded via `additionalContext` and then deleted, so the model receives
+# the sanitized request without the user ever copying it. Any follow-up
+# message ("go", "continue", a clarification) triggers the reload.
 #
 # Stdin:  Claude Code UserPromptSubmit JSON payload
 # Stdout: JSON with decision=block and a reason (if a secret was detected),
-#         or empty (no-op) otherwise.
+#         JSON with hookSpecificOutput.additionalContext (if a stashed
+#         sanitized prompt is being reloaded), or empty (no-op) otherwise.
 set -uo pipefail
 
 # shellcheck source=_patterns.sh
@@ -24,17 +29,62 @@ SECRETS_DIR="$(prismor_secrets_dir)"
 mkdir -p "$SECRETS_DIR"
 chmod 700 "$SECRETS_DIR" 2>/dev/null || true
 
+# Stash directory for sanitized-but-blocked prompts (one file per session).
+STASH_DIR="${PRISMOR_PROMPT_STASH_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/prompt_stash}"
+# A stash older than this is ignored (and removed) rather than injected into an
+# unrelated later conversation. Seconds; overridable for tests.
+STASH_TTL="${PRISMOR_PROMPT_STASH_TTL:-1800}"
+
 command -v jq >/dev/null 2>&1 || exit 0
 
 input="$(cat)"
 prompt="$(printf '%s' "$input" | jq -r '.prompt // empty')"
 [[ -n "$prompt" ]] || exit 0
 
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty' | tr -cd 'A-Za-z0-9._-')"
+[[ -n "$session_id" ]] || session_id="default"
+stash_file="$STASH_DIR/$session_id"
+
+# prismor_stash_age_ok <file> — 0 if the stash is younger than STASH_TTL.
+prismor_stash_age_ok() {
+  local f="$1" mtime now
+  mtime="$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)"
+  now="$(date +%s)"
+  [[ $(( now - mtime )) -le "$STASH_TTL" ]]
+}
+
+# prismor_emit_stash_context — if a fresh stash exists for this session, emit
+# it as additionalContext (so the model receives the sanitized request) and
+# delete it. Called only on the pass-through paths, never on a block.
+prismor_emit_stash_context() {
+  [[ -f "$stash_file" ]] || return 0
+  if ! prismor_stash_age_ok "$stash_file"; then
+    rm -f "$stash_file"
+    return 0
+  fi
+  local stashed
+  stashed="$(cat "$stash_file")"
+  rm -f "$stash_file"
+  # If the user pasted the sanitized text themselves, the current prompt
+  # already carries it — no need to inject a duplicate copy.
+  if [[ "$(printf '%s' "$prompt" | tr -d '[:space:]')" == "$(printf '%s' "$stashed" | tr -d '[:space:]')" ]]; then
+    return 0
+  fi
+  local ctx
+  ctx="Prismor cloaking: the user's previous prompt in this session was blocked because it contained secret(s). Those values are now registered in the Prismor vault and replaced below with @@SECRET:name@@ placeholders, which are substituted with the real values at tool-call time — use the placeholders verbatim in commands and never ask the user for the raw values. Treat the sanitized prompt below as the user's actual request; the message they just sent is a follow-up to it (attachments such as images from the blocked prompt were not carried over).
+
+--- BEGIN SANITIZED PROMPT ---
+${stashed}
+--- END SANITIZED PROMPT ---"
+  jq -n --arg c "$ctx" '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $c}}'
+}
+
 # Optional user bypass: a prompt starting with `!!allow ` (ignoring leading
 # whitespace) is passed through unchanged. Useful when the user is deliberately
 # discussing a secret in prose and doesn't want auto-cloaking.
 trimmed="$(printf '%s' "$prompt" | sed 's/^[[:space:]]*//')"
 if [[ "$trimmed" == "!!allow "* ]]; then
+  prismor_emit_stash_context
   exit 0
 fi
 
@@ -75,7 +125,7 @@ fi
 # Loaded from the shared single-source-of-truth file (builtin_patterns.txt)
 # plus any org-specific patterns the user added via `prismor cloak pattern add`.
 prismor_load_patterns
-[[ "${#PATTERNS[@]}" -gt 0 ]] || exit 0
+[[ "${#PATTERNS[@]}" -gt 0 ]] || { prismor_emit_stash_context; exit 0; }
 
 # Strip already-cloaked placeholders before scanning so that @@SECRET:name@@
 # syntax in the prompt never triggers a false positive match.
@@ -88,7 +138,8 @@ matches="$(
   done | awk 'NF && !seen[$0]++'
 )"
 
-[[ -n "$matches" ]] || exit 0
+# Clean prompt: pass through, reloading any stashed sanitized prompt first.
+[[ -n "$matches" ]] || { prismor_emit_stash_context; exit 0; }
 
 # ── Cloak each match ─────────────────────────────────────────────────────
 sanitized="$prompt"
@@ -114,14 +165,27 @@ while IFS= read -r real_value; do
   reported_placeholders+="  • $placeholder"$'\n'
 done <<< "$matches"
 
+# ── Stash the sanitized prompt for auto-reload on the next message ───────
+mkdir -p "$STASH_DIR" 2>/dev/null || true
+chmod 700 "$STASH_DIR" 2>/dev/null || true
+stash_hint=""
+if printf '%s' "$sanitized" > "$stash_file" 2>/dev/null; then
+  chmod 600 "$stash_file" 2>/dev/null || true
+  stash_hint="Your original prompt was NOT sent to the model. The sanitized version
+below has been saved — just send any follow-up message (e.g. \"go\") and
+Prismor will load it automatically. Or paste it yourself:"
+else
+  stash_hint="Your original prompt was NOT sent to the model. Resubmit with the sanitized
+version below (the model will resolve each placeholder at tool-call time):"
+fi
+
 # ── Emit soft-block decision ──────────────────────────────────────────────
 reason="Prismor cloaking: detected secret(s) in your prompt.
 
 Stored under ${SECRETS_DIR} as:
 ${reported_placeholders%$'\n'}
 
-Your original prompt was NOT sent to the model. Resubmit with the sanitized
-version below (the model will resolve each placeholder at tool-call time):
+${stash_hint}
 
 ---
 ${sanitized}

--- a/tests/test_cloak_prompt_stash.py
+++ b/tests/test_cloak_prompt_stash.py
@@ -1,0 +1,140 @@
+"""Tests for the sanitized-prompt stash in userprompt-guard.sh.
+
+Claude Code cannot rewrite a prompt from a UserPromptSubmit hook, so when the
+guard detects a secret it blocks and stashes the sanitized prompt. The user's
+next clean message in the same session then reloads the stash as
+`additionalContext`, so nobody has to re-paste. These tests exercise the
+block -> stash -> reload lifecycle in isolation.
+
+Run:  python3 tests/test_cloak_prompt_stash.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+_HOME = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+_SECRETS = _HOME / "secrets"
+_SECRETS.mkdir(parents=True)
+_STASH = _HOME / "prompt_stash"
+os.environ["PRISMOR_HOME"] = str(_HOME)
+os.environ["PRISMOR_SECRETS_DIR"] = str(_SECRETS)
+os.environ["PRISMOR_PROMPT_STASH_DIR"] = str(_STASH)
+
+_GUARD = _REPO / "prismor" / "runtime" / "cloaking" / "hooks" / "userprompt-guard.sh"
+# Synthetic JWT-shaped canary, assembled at runtime so no literal token sits in
+# this file (the cloaking Write guard would otherwise vault it).
+_JWT = ".".join(["eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiJDQU5BUlkiLCJpYXQiOjB9",
+                 "CANARYsignatureCANARYsignature"])
+_PROMPT = f"curl https://example.test/api -b '__session={_JWT}' why does this 401?"
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if ok:
+        _passed += 1
+        print(f"  PASS  {name}")
+    else:
+        _failed += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def run(prompt: str, session: str = "sess-A") -> dict | None:
+    payload = {"prompt": prompt, "cwd": str(_HOME), "session_id": session}
+    proc = subprocess.run(["bash", str(_GUARD)], input=json.dumps(payload),
+                          capture_output=True, text=True, env=os.environ)
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+def blocked(res) -> bool:
+    return bool(res) and res.get("decision") == "block"
+
+
+def context_of(res) -> str:
+    return ((res or {}).get("hookSpecificOutput") or {}).get("additionalContext", "")
+
+
+def test_block_stashes_sanitized():
+    res = run(_PROMPT)
+    check("secret prompt is blocked", blocked(res), str(res))
+    reason = res.get("reason", "") if res else ""
+    check("raw value absent from block reason", _JWT not in reason)
+    check("reason mentions auto-load", "load it automatically" in reason, reason[:200])
+    stash = _STASH / "sess-A"
+    check("stash file written", stash.is_file())
+    body = stash.read_text() if stash.is_file() else ""
+    check("stash holds sanitized prompt", "@@SECRET:auto_" in body and _JWT not in body, body[:200])
+    check("stash is 0600", stash.is_file() and (stash.stat().st_mode & 0o777) == 0o600)
+
+
+def test_followup_reloads_and_clears():
+    res = run("go", session="sess-A")
+    ctx = context_of(res)
+    check("follow-up gets additionalContext", bool(ctx), str(res)[:200])
+    check("context carries sanitized prompt", "@@SECRET:auto_" in ctx and "why does this 401?" in ctx)
+    check("context never carries raw value", _JWT not in ctx)
+    check("stash consumed", not (_STASH / "sess-A").exists())
+    res2 = run("and then?", session="sess-A")
+    check("second follow-up injects nothing", res2 is None, str(res2))
+
+
+def test_stash_is_per_session():
+    run(_PROMPT, session="sess-B")
+    res = run("hello", session="sess-C")
+    check("other session sees no stash", res is None, str(res))
+    check("sess-B stash still present", (_STASH / "sess-B").is_file())
+    res = run("go", session="sess-B")
+    check("owning session reloads", "@@SECRET:auto_" in context_of(res))
+
+
+def test_reblock_overwrites_stash_without_reload():
+    run(_PROMPT, session="sess-D")
+    res = run(_PROMPT + " (again)", session="sess-D")
+    check("re-sent raw prompt is blocked again", blocked(res))
+    body = (_STASH / "sess-D").read_text()
+    check("stash updated to latest sanitized prompt", "(again)" in body and _JWT not in body)
+    res = run("ok", session="sess-D")
+    check("reload after re-block carries latest", "(again)" in context_of(res))
+
+
+def test_pasted_sanitized_prompt_not_duplicated():
+    res = run(_PROMPT, session="sess-E")
+    sanitized = res["reason"].split("---\n")[1].rstrip("\n-")
+    res = run(sanitized, session="sess-E")
+    check("pasting sanitized prompt passes clean", res is None, str(res)[:200])
+    check("stash cleared after paste", not (_STASH / "sess-E").exists())
+
+
+def test_expired_stash_is_dropped():
+    run(_PROMPT, session="sess-F")
+    old = time.time() - 7200
+    os.utime(_STASH / "sess-F", (old, old))
+    res = run("go", session="sess-F")
+    check("expired stash not injected", res is None, str(res))
+    check("expired stash removed", not (_STASH / "sess-F").exists())
+
+
+def test_allow_bypass_still_reloads():
+    run(_PROMPT, session="sess-G")
+    res = run("!!allow just checking", session="sess-G")
+    check("!!allow follow-up still reloads stash", "@@SECRET:auto_" in context_of(res))
+
+
+if __name__ == "__main__":
+    for fn in [v for k, v in sorted(globals().items()) if k.startswith("test_")]:
+        print(f"{fn.__name__}:")
+        fn()
+    print(f"\n{_passed} passed, {_failed} failed")
+    sys.exit(1 if _failed else 0)


### PR DESCRIPTION
## Why
When a pasted prompt contains a secret, `userprompt-guard.sh` blocks it and shows the sanitized version — but Claude Code cannot rewrite prompts from a hook, so the user had to copy/paste it back manually. In practice users re-send the original (which blocks again) or give up.

## What
- On block, the sanitized prompt is stashed at `$PRISMOR_HOME/prompt_stash/<session_id>` (0600).
- On the next clean prompt in that session (any message: `go`, a clarification, `!!allow ...`), the stash is emitted as `hookSpecificOutput.additionalContext` and deleted, so the model receives the sanitized request without a re-paste.
- Pasting the sanitized text yourself just clears the stash (no duplicate). Re-sending the raw prompt blocks again and refreshes the stash. Stashes older than 30 min (`PRISMOR_PROMPT_STASH_TTL`) are dropped, not injected.
- Block message updated to say "just send any follow-up (e.g. go)".
- Docs updated; new `tests/test_cloak_prompt_stash.py` (22 checks) covers block→stash→reload, per-session isolation, re-block, paste-dedupe, TTL expiry, `!!allow`.

## Not covered
- Image attachments on the blocked prompt cannot be carried over (Claude Code drops them with the block); the injected context tells the model so.