### PR TITLE
fix(audit): do not call an unverifiable feed tampered

### DIFF
--- a/prismor/runtime/audit.py
+++ b/prismor/runtime/audit.py
@@ -326,6 +326,31 @@ def _check_secret_permissions() -> List[AuditFinding]:
     return findings
 
 
+def _openssl_label() -> str:
+    """The openssl flavour and version, for a cannot-verify message."""
+    try:
+        out = subprocess.run(
+            ["openssl", "version"], capture_output=True, timeout=5, text=True
+        )
+        return (out.stdout or out.stderr).strip().splitlines()[0] or "openssl"
+    except Exception:
+        return "openssl"
+
+
+def _is_signature_mismatch(result: "subprocess.CompletedProcess") -> bool:
+    """Whether openssl actually rejected the signature.
+
+    A non-zero exit is not enough. macOS ships LibreSSL, which cannot load an
+    Ed25519 key and has no -rawin, so it exits non-zero for a feed that is
+    perfectly intact. Only OpenSSL's explicit rejection line means tampering;
+    anything else is a toolchain that could not answer the question.
+    """
+    output = b"".join(
+        part for part in (result.stdout, result.stderr) if isinstance(part, bytes)
+    ).decode("utf-8", "replace")
+    return "signature verification failure" in output.lower()
+
+
 def _check_feed_signature(repo_root: Path) -> List[AuditFinding]:
     """Verify the advisory feed Ed25519 signature."""
     findings: List[AuditFinding] = []
@@ -407,11 +432,21 @@ def _check_feed_signature(repo_root: Path) -> List[AuditFinding]:
                     category="feed",
                     message="Feed signature valid",
                 ))
-        else:
+        elif _is_signature_mismatch(result):
             findings.append(AuditFinding(
                 severity="CRITICAL",
                 category="feed",
                 message="Feed signature verification FAILED — feed may be tampered with",
+            ))
+        else:
+            findings.append(AuditFinding(
+                severity="MEDIUM",
+                category="feed",
+                message=(
+                    "Cannot verify feed signature — "
+                    f"{_openssl_label()} could not run the check "
+                    "(needs OpenSSL 3.x for Ed25519 with -rawin)"
+                ),
             ))
     except Exception as exc:
         findings.append(AuditFinding(

--- a/tests/test_audit_feed_signature.py
+++ b/tests/test_audit_feed_signature.py
@@ -1,0 +1,48 @@
+"""Regression tests for issue #288.
+
+A toolchain that cannot perform the check must not be reported as tampering.
+macOS ships LibreSSL, which cannot load Ed25519 and has no -rawin, so it exits
+non-zero on a perfectly intact feed.
+"""
+
+import subprocess
+
+from prismor.runtime.audit import _is_signature_mismatch
+
+
+def _completed(stdout: bytes = b"", stderr: bytes = b"", returncode: int = 1):
+    return subprocess.CompletedProcess(
+        args=["openssl"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestIsSignatureMismatch:
+    def test_openssl_rejection_is_a_mismatch(self):
+        # Exact stdout from `openssl pkeyutl -verify` on a modified payload.
+        assert _is_signature_mismatch(_completed(stdout=b"Signature Verification Failure\n"))
+
+    def test_rejection_on_stderr_is_also_a_mismatch(self):
+        assert _is_signature_mismatch(_completed(stderr=b"Signature Verification Failure\n"))
+
+    def test_match_is_case_insensitive(self):
+        assert _is_signature_mismatch(_completed(stdout=b"SIGNATURE VERIFICATION FAILURE"))
+
+    def test_libressl_unknown_option_is_not_a_mismatch(self):
+        # LibreSSL 3.3.6 has no -rawin; this is the shape of its complaint.
+        result = _completed(stderr=b"pkeyutl: Unknown option: -rawin\npkeyutl: Use -help for summary.\n")
+        assert not _is_signature_mismatch(result)
+
+    def test_unsupported_algorithm_is_not_a_mismatch(self):
+        result = _completed(stderr=b"Could not find private key from pub.pem\n")
+        assert not _is_signature_mismatch(result)
+
+    def test_empty_output_is_not_a_mismatch(self):
+        # Grey must not render as red: no evidence is not evidence of tampering.
+        assert not _is_signature_mismatch(_completed())
+
+    def test_none_streams_do_not_raise(self):
+        result = subprocess.CompletedProcess(args=["openssl"], returncode=1, stdout=None, stderr=None)
+        assert not _is_signature_mismatch(result)
+
+    def test_undecodable_bytes_do_not_raise(self):
+        assert not _is_signature_mismatch(_completed(stderr=b"\xff\xfe garbage"))


### PR DESCRIPTION
Closes #288.

`_check_feed_signature` treated **any** non-zero exit from `openssl pkeyutl -verify` as proof of tampering. LibreSSL cannot load Ed25519 and has no `-rawin`, so it exits non-zero on an intact feed — and every stock macOS saw `CRITICAL — feed may be tampered with`.

The function already separated *"openssl not found"* as MEDIUM cannot-verify. It just had no branch for **openssl present but unable to answer**.

## The distinguishing signal

The exit code cannot separate the two cases — both are `1`. I checked what actually differs, against OpenSSL 3.2.1:

| case | output | exit |
|---|---|---|
| modified payload | `Signature Verification Failure` | 1 |
| option it does not understand | `pkeyutl: Unknown option: -rawin` | 1 |

So only OpenSSL's explicit rejection line counts as tampering. Everything else non-zero becomes MEDIUM, with the openssl build named in the message so the user installs OpenSSL 3.x instead of hunting a compromise that did not happen.

```diff
-        else:
+        elif _is_signature_mismatch(result):
             findings.append(AuditFinding(severity="CRITICAL", ...))
+        else:
+            findings.append(AuditFinding(severity="MEDIUM", ... "Cannot verify feed signature"))
```

Two small helpers: `_is_signature_mismatch` (the check) and `_openssl_label` (the version string for the message). No new dependency, no change to the passing or genuinely-failing paths.

## Tests

`tests/test_audit_feed_signature.py` — 8 tests pinning **both** directions, so this cannot regress into either failure mode:

- rejection on stdout / on stderr / case-insensitively → **is** a mismatch
- LibreSSL `Unknown option: -rawin` → **not** a mismatch
- unsupported-algorithm complaint → **not** a mismatch
- empty output → **not** a mismatch (grey must not render as red)
- `None` streams and undecodable bytes → do not raise

Red-before-green verified: with `audit.py` stashed the tests cannot even import.

## Pre-existing failures, not from this PR

I checked both against a clean tree — identical with and without my change:

- `pytest tests/test_audit_trail.py tests/test_skills_audit.py` → **16 failed, 5 passed** both ways (missing optional modules in my environment)
- `ruff check prismor/runtime/audit.py` → **3 errors** both ways (including an unused `active_network`, which I have not touched)

`ruff check` on the new test file passes clean.