### PR TITLE
fix(deps): follow nested node_modules edges when checking reachability

### DIFF
--- a/prismor/runtime/deps.py
+++ b/prismor/runtime/deps.py
@@ -545,6 +545,11 @@ def _reachable_lockfile_names(declared: set, packages: Dict[str, Any]) -> Option
     the manifest's declared dependency names, returning every package
     name reachable through the real dependency graph.
 
+    Both flat and nested `node_modules/.../node_modules/<name>` records
+    contribute edges. A nested record is often the *only* thing requiring
+    a hoisted package, so ignoring those edges makes ordinary transitives
+    look unreachable and reports them as injection.
+
     npm hoists resolvable transitive dependencies to flat top-level
     `node_modules/<name>` entries whenever there's no version conflict —
     so a package that is NOT a direct dependency commonly still has a
@@ -561,15 +566,20 @@ def _reachable_lockfile_names(declared: set, packages: Dict[str, Any]) -> Option
     """
     if not declared:
         return None
-    own_deps: Dict[str, List[str]] = {}
+    own_deps: Dict[str, set] = {}
     for path, meta in packages.items():
         if not path.startswith("node_modules/") or not isinstance(meta, dict):
             continue
-        if "/node_modules/" in path[len("node_modules/"):]:
-            continue  # nested entry — BFS only needs the flat frontier
         deps = meta.get("dependencies")
-        if isinstance(deps, dict):
-            own_deps[path[len("node_modules/"):]] = list(deps.keys())
+        if not isinstance(deps, dict):
+            continue
+        # A nested record node_modules/a/node_modules/b describes package b,
+        # and its edges are the only route to anything b alone requires. The
+        # name is the segment after the last node_modules/; a name appearing
+        # at several depths contributes the union of its edges, since any one
+        # of them is a real way to reach a package.
+        name = path.rsplit("node_modules/", 1)[1]
+        own_deps.setdefault(name, set()).update(deps.keys())
     if not own_deps:
         return None
 

--- a/tests/test_lockfile_integrity.py
+++ b/tests/test_lockfile_integrity.py
@@ -152,3 +152,60 @@ def test_audit_pass_message_does_not_imply_cve_freedom(tmp_path: Path) -> None:
     assert len(passes) == 1
     assert "does not mean" in passes[0].message
     assert "checked live" in passes[0].message
+
+
+def test_reachable_names_follows_nested_node_modules_edges() -> None:
+    """Regression for #289.
+
+    Reproduces the reported shape: jackspeak is required only by a nested
+    copy of glob, which is itself required only by a nested copy under
+    rimraf. Ignoring nested edges leaves jackspeak unreachable, and an
+    ordinary hoisted transitive gets reported as lockfile injection.
+    """
+    packages = {
+        "node_modules/rimraf": {"dependencies": {"glob": "^10.0.0"}},
+        "node_modules/rimraf/node_modules/glob": {"dependencies": {"jackspeak": "^2.0.0"}},
+        "node_modules/jackspeak": {"dependencies": {}},
+    }
+    reachable = _reachable_lockfile_names({"rimraf"}, packages)
+    assert reachable is not None
+    assert "jackspeak" in reachable, "hoisted transitive reached only via a nested edge"
+    assert reachable == {"rimraf", "glob", "jackspeak"}
+
+
+def test_reachable_names_unions_edges_across_nesting_depths() -> None:
+    """The same package at two depths may pin different dependency sets;
+    either is a real route, so the union is what reachability means."""
+    packages = {
+        "node_modules/glob": {"dependencies": {"minimatch": "1"}},
+        "node_modules/rimraf": {"dependencies": {"glob": "1"}},
+        "node_modules/rimraf/node_modules/glob": {"dependencies": {"jackspeak": "1"}},
+        "node_modules/minimatch": {"dependencies": {}},
+        "node_modules/jackspeak": {"dependencies": {}},
+    }
+    reachable = _reachable_lockfile_names({"rimraf"}, packages)
+    assert reachable == {"rimraf", "glob", "minimatch", "jackspeak"}
+
+
+def test_reachable_names_still_excludes_a_genuine_orphan() -> None:
+    """The nested fix must not make everything reachable — a package no
+    edge points at is still injection."""
+    packages = {
+        "node_modules/a": {"dependencies": {"b": "1"}},
+        "node_modules/a/node_modules/b": {"dependencies": {}},
+        "node_modules/injected": {"dependencies": {}},
+    }
+    reachable = _reachable_lockfile_names({"a"}, packages)
+    assert reachable == {"a", "b"}
+    assert "injected" not in reachable
+
+
+def test_reachable_names_handles_scoped_packages_when_nested() -> None:
+    packages = {
+        "node_modules/pkg": {"dependencies": {"@scope/child": "1"}},
+        "node_modules/pkg/node_modules/@scope/child": {"dependencies": {"leaf": "1"}},
+        "node_modules/leaf": {"dependencies": {}},
+    }
+    reachable = _reachable_lockfile_names({"pkg"}, packages)
+    assert "@scope/child" in reachable
+    assert "leaf" in reachable


### PR DESCRIPTION
Addresses the false-positive half of #289.

`_reachable_lockfile_names` built its edge map from flat entries only:

```python
if "/node_modules/" in path[len("node_modules/"):]:
    continue  # nested entry — BFS only needs the flat frontier
```

That comment is the bug. A nested record describes a real package and carries real edges, and it is often the **only** route to a hoisted transitive. Your reported case exactly: `jackspeak` is required solely by the nested copy of `glob` under `rimraf`, so it came out unreachable and got reported as injection.

## The change

Take the package name from the segment after the **last** `node_modules/`, and union the edge sets when a name appears at more than one depth — any one of them is a genuine route.

**This can only remove findings, never add them.** It strictly widens reachability; a package no edge points at is still unreachable and still reported.

## Tests — 4 added, 13 total passing

- the reported `rimraf` → nested `glob` → `jackspeak` shape
- union of edges across nesting depths
- scoped packages (`@scope/child`) when nested
- **a genuine orphan that must stay flagged** — the guard against "fixing" this by making everything reachable

The first three fail before the change; the orphan test passes both ways, which is the point of including it.

`ruff check` on `deps.py` and the test file: clean, and identical to baseline.

## Deliberately not addressed — and #289 stays open

Your report contains three distinct problems. This PR fixes one, so the commit says **`Refs #289`, not `Closes`** — merging it will not auto-close the issue, because these remain:

1. **Duplicate counting** — `265 = 53 × 5`, from globbing `**/package.json` and counting four `.claude/worktrees/` copies while `manifests[]` in the same output says `1`.
2. **Scope bleed** — `prismor scan` reading the host `~/.claude/**` alongside the repo's, so a finding filed against a repo may belong to the machine.

Happy to take either as a follow-up.