### PR TITLE
fix(cloak): add escape form for the literal @@SECRET:NAME@@ placeholder

### DIFF
--- a/prismor/runtime/cloaking/README.md
+++ b/prismor/runtime/cloaking/README.md
@@ -136,6 +136,23 @@ prismor cloak run -- curl https://api.example.com -H "Authorization: Bearer @@SE
 
 Secrets live under `$PRISMOR_HOME/secrets/` (default `~/.prismor/secrets/`) with the directory at `0700` and each file at `0600`. The directory should be **excluded from backups and sync** (Time Machine, iCloud, Dropbox). Override the location with `PRISMOR_SECRETS_DIR`.
 
+### Writing the literal placeholder syntax (escape form)
+
+`decloak.sh` runs over the whole Bash command string and fails closed on any
+`@@SECRET:name@@` it cannot resolve. That is correct for execution, but it also
+fires when you are merely *writing about* the syntax — a doc, a commit message,
+or a test fixture. To write the literal placeholder, escape the colon with a
+backslash:
+
+```bash
+git commit -m "docs: explain the @@SECRET\:name@@ placeholder form"
+```
+
+The placeholder regex skips `@@SECRET\:name@@` (a name may not contain a
+backslash) and no substitution touches it, so the escaped text is emitted
+verbatim and the guard does not fire. Fail-closed stays the default: a real,
+unresolved placeholder is still denied.
+
 ---
 
 ## The user-prompt boundary

--- a/prismor/runtime/cloaking/README.md
+++ b/prismor/runtime/cloaking/README.md
@@ -153,6 +153,14 @@ backslash) and no substitution touches it, so the escaped text is emitted
 verbatim and the guard does not fire. Fail-closed stays the default: a real,
 unresolved placeholder is still denied.
 
+**The backslash is part of what you write.** Nothing rewrites it on the way
+out, so the commit message above lands as `docs: explain the @@SECRET\:name@@
+placeholder form` — backslash included. The escape lets you write *about* the
+syntax through Bash; it does not produce the unescaped literal. When a file
+must contain the exact unescaped text (a fixture asserting on the real
+placeholder, say), build it in-process rather than through a Bash command
+string — in Python, `"@@" + "SECRET:" + name + "@@"` never reaches the hook.
+
 ---
 
 ## The user-prompt boundary

--- a/prismor/runtime/cloaking/hooks/decloak.sh
+++ b/prismor/runtime/cloaking/hooks/decloak.sh
@@ -54,8 +54,11 @@ if [[ -n "$placeholders" ]]; then
     secret_file="$SECRETS_DIR/$name"
     if [[ ! -f "$secret_file" ]]; then
       # Fail closed: deny rather than leaving a dangling placeholder that would
-      # confuse the downstream command.
-      jq -n --arg reason "Prismor cloaking: secret '$name' not registered. Run: prismor cloak add $name" \
+      # confuse the downstream command. The escaped form (backslash before the
+      # colon) is deliberately NOT matched by the grep above, so it reaches the
+      # shell verbatim and is how you write the literal syntax (docs, commit
+      # messages, tests) without triggering resolution.
+      jq -n --arg reason "Prismor cloaking: secret '$name' not registered. Run: prismor cloak add $name (list registered names: prismor cloak list). To write the literal placeholder syntax instead of resolving it, escape the colon: @@SECRET\:$name@@" \
         '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
       exit 0
     fi

--- a/prismor/runtime/cloaking/runtime.py
+++ b/prismor/runtime/cloaking/runtime.py
@@ -17,6 +17,10 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from prismor.runtime.cloaking.secrets_store import secrets_dir
 
+# Escape form: a backslash before the colon (``@@SECRET\:name@@``) is not a
+# valid placeholder — names may not contain a backslash — so the regex skips it
+# and no substitution touches it. This is how docs, commit messages, and test
+# fixtures write the literal placeholder syntax without tripping the guard.
 _PLACEHOLDER_RE = re.compile(r"@@SECRET:([a-zA-Z0-9_-]{1,64})@@")
 _ENV_ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 
@@ -239,7 +243,9 @@ def run_decloaked_command(argv: Iterable[str]) -> int:
         name = str(exc).strip("'")
         raise ValueError(
             f"Prismor cloaking: secret '{name}' is not registered. "
-            f"Run: prismor cloak add {name}"
+            f"Run: prismor cloak add {name} (list registered names: prismor cloak list). "
+            f"To write the literal placeholder syntax instead of resolving it, "
+            f"escape the colon: @@SECRET\\:{name}@@"
         ) from exc
 
     env = os.environ.copy()

--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -193,6 +193,30 @@ def test_unregistered_placeholder_denied():
     check("unknown placeholder is denied (fail closed)", dec == "deny", str(res))
 
 
+def test_escaped_placeholder_not_substituted():
+    # The escaped form @@SECRET\:CANARY@@ must be skipped by the placeholder
+    # regex and pass through verbatim — never substituted with the real value,
+    # even though CANARY is registered. This is how docs/commit messages write
+    # the literal syntax without tripping the guard.
+    res = run_hook(_DECLOAK, bash_payload('echo "@@SECRET\\:CANARY@@"'))
+    dec = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+    wrapped = (res or {}).get("hookSpecificOutput", {}).get("updatedInput", {}).get("command", "")
+    check("escaped placeholder is not substituted",
+          dec != "deny" and "@@SECRET\\:CANARY@@" in wrapped and _CANARY not in wrapped,
+          str(res))
+
+
+def test_escaped_unregistered_placeholder_not_denied():
+    # An escaped name that is not registered must NOT be denied: the escape
+    # signals "literal text", not "resolve this secret".
+    res = run_hook(_DECLOAK, bash_payload('echo "@@SECRET\\:NOPE@@"'))
+    dec = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+    wrapped = (res or {}).get("hookSpecificOutput", {}).get("updatedInput", {}).get("command", "")
+    check("escaped unregistered placeholder is not denied",
+          dec != "deny" and "@@SECRET\\:NOPE@@" in wrapped,
+          str(res))
+
+
 # ── C. read-guard.sh ──────────────────────────────────────────────────────
 def read_payload(fp: str) -> dict:
     return {"hook_event_name": "PreToolUse", "tool_name": "Read",
@@ -224,6 +248,8 @@ def main() -> int:
         test_placeholder_substituted_and_output_scrubbed,
         test_leading_env_assignment_decloaked_and_scrubbed,
         test_unregistered_placeholder_denied,
+        test_escaped_placeholder_not_substituted,
+        test_escaped_unregistered_placeholder_not_denied,
         test_read_of_secret_file_denied, test_read_of_clean_file_allowed,
     ]:
         fn()

--- a/tests/test_codex_cloak_runtime.py
+++ b/tests/test_codex_cloak_runtime.py
@@ -11,6 +11,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from prismor.runtime.cloaking.runtime import codex_cloak_finding, run_decloaked_command
+from prismor.runtime.cloaking.runtime import decloak_text, placeholder_names
 from prismor.runtime.cloaking.secrets_store import add_secret
 from prismor.runtime.store import get_events_page
 
@@ -73,6 +74,28 @@ class TestCodexCloakRuntime(unittest.TestCase):
         combined = stdout.getvalue() + stderr.getvalue()
         self.assertIn("@@SECRET:OPENAI_API_KEY@@", combined)
         self.assertNotIn("sk-test-1234567890", combined)
+
+    def test_escaped_placeholder_skipped_by_regex_and_decloak(self):
+        # The escaped form @@SECRET\:NAME@@ is not a placeholder: the regex skips
+        # it and decloak_text leaves it verbatim, even when the name IS registered.
+        self.assertEqual(placeholder_names("doc: @@SECRET\\:OPENAI_API_KEY@@ literal"), [])
+        self.assertEqual(
+            decloak_text("@@SECRET\\:OPENAI_API_KEY@@"),
+            "@@SECRET\\:OPENAI_API_KEY@@",
+        )
+
+    def test_codex_escaped_placeholder_not_blocked(self):
+        # Codex's block-only cloak path must not deny a command that merely
+        # writes the literal placeholder syntax (escaped form).
+        finding = codex_cloak_finding(
+            {
+                "type": "shell",
+                "agent_event": "PreToolUse",
+                "command": "git commit -m 'docs: explain @@SECRET\\:OPENAI_API_KEY@@'",
+            },
+            "s1",
+        )
+        self.assertIsNone(finding)
 
     def test_cloak_run_decloaks_leading_env_assignments(self):
         stdout = StringIO()


### PR DESCRIPTION
## Problem

Cloak's `decloak.sh` hook scans the whole Bash command string and denies any `@@SECRET:NAME@@` it cannot resolve. That fail-closed behavior is correct for execution, but it also fires on text that merely *mentions* the syntax — writing docs, a commit message, or a test fixture about Cloak itself is blocked:

```bash
git commit -m "docs: explain the @@SECRET:NAME@@ placeholder form"
# Prismor cloaking: secret 'NAME' not registered. Run: prismor cloak add NAME
```

The only workaround today is string concatenation (`"@@" + "SECRET:" + name + "@@"`), which is not discoverable from the error.

Closes #301

## Prior art — what already exists

- [x] **An existing mechanism was close but not sufficient.** The `_PLACEHOLDER_RE` regex in `cloaking/runtime.py` and the `grep -oE` in `decloak.sh` already skip `@@SECRET\:NAME@@` (a name cannot contain a backslash), so the escape form *already* passes through untouched — it just was never documented, surfaced in the deny message, or covered by a test. This PR makes that existing behavior explicit rather than adding a new abstraction.

**Tangential updates:** none.

## Solution — high level

- Document `@@SECRET\:NAME@@` (backslash before the colon) as the escape form for writing the literal placeholder syntax.
- Extend the `decloak.sh` deny message (and the matching `prismor cloak run` error) to mention `prismor cloak list` and how to write the literal.
- Add tests proving the escaped form is neither substituted nor denied, and that Codex's block-only path lets it through.

## Deep dive — how it works

The escape is entirely structural: a valid placeholder name is `[a-zA-Z0-9_-]{1,64}`, so `@@SECRET\:NAME@@` can never match `_PLACEHOLDER_RE` (Python) or `@@SECRET:[a-zA-Z0-9_-]+@@` (`grep -oE` in `decloak.sh`). No substitution touches the escaped form, so it reaches the shell verbatim.

Fail-closed is unchanged: a real, unresolved `@@SECRET:NAME@@` is still denied with the same guard, and a registered placeholder is still resolved. The change is documentation + a clearer deny message + tests; no detection logic was altered.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/cloaking/hooks/decloak.sh` | Deny message now tells users how to write the literal (`@@SECRET\:NAME@@`) and to run `prismor cloak list` for registered names. |
| `prismor/runtime/cloaking/runtime.py` | Documents the escape form on `_PLACEHOLDER_RE`; mirrors the new deny message in `run_decloaked_command`. |
| `prismor/runtime/cloaking/README.md` | Documents the escape form for docs/commit-message/test authors. |
| `tests/test_cloak_output_scrub.py` | New tests: escaped placeholder is not substituted (even when registered) and escaped unregistered placeholder is not denied. |
| `tests/test_codex_cloak_runtime.py` | New tests: `placeholder_names`/`decloak_text` skip the escaped form; Codex block-only path allows it. |

## Testing

```
python3 tests/test_cloak_output_scrub.py   # 15 passed
python3 -m pytest tests/test_codex_cloak_runtime.py -q   # 6 passed
bash scripts/run_security_tests.sh         # All security regression checks passed
```

- [x] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [ ] If a policy rule changed: `prismor policy validate prismor/runtime/default_policy.yaml`
- [ ] If an integration changed: `bash scripts/verify_registry.sh`

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No real secret values printed, logged, or serialized (used `@@SECRET:<name>@@`)
- [x] No guardrail weakened; if one was, it is called out and justified above
- [x] Docs that describe this behavior (`SKILL.md`, `docs/`, `AGENTS.md`) are still accurate

## Diff size

Lines changed: +78 / -3 · Justification if large: mostly tests and docs; the code delta is the deny message and a comment.
