### PR TITLE
Show which enforcement surfaces are actually governing this machine

### DIFF
--- a/docs/governance-surfaces.md
+++ b/docs/governance-surfaces.md
@@ -17,6 +17,9 @@ where they can intercept and what they can do there:
 | **eval-server** | non-Python callers and external proxies | yes | yes | yes |
 | **Inference hook** | a hosted transcript-turn channel | yes | no | no |
 
+Run `prismor surfaces` to see which of these are switched on for each agent
+detected on this machine, and which are possible but off.
+
 The rest of this page is about the two that govern a coding agent on a
 developer's machine, where the choice is a real decision. For the others:
 adapters ship with each framework (see `docs/frameworks-overview.md`), the

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1173,6 +1173,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         return
 
     # ── status: one-shot health check (mode, hooks, cloak, latest session) ──
+    if args.command == "surfaces":
+        _print_surfaces(workspace)
+        return
+
     if args.command == "status":
         if getattr(args, "all", False):
             _print_dashboard(days=getattr(args, "days", 7))
@@ -2867,6 +2871,12 @@ def build_parser() -> argparse.ArgumentParser:
     _ep.add_argument("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
     _ep.add_argument("--workspace", default=None, help="Workspace path for policy/IAM (default: cwd)")
     _ep.add_argument("--api-key", default=None, help="Require Authorization: Bearer <key> on /v1/evaluate (default: $PRISMOR_EVAL_KEY); needed when exposing beyond localhost")
+
+    # ── surfaces: which enforcement surfaces are governing this machine ──
+    subparsers.add_parser(
+        "surfaces",
+        help="Show which enforcement surfaces (hooks, MCP mirror, gateway) are active",
+    )
 
     # ── inference-hook: Claude Inference Hooks AI-security server ──────
     def _add_ih_serve_args(p: argparse.ArgumentParser) -> None:
@@ -5819,3 +5829,61 @@ def format_tokens(payload: Dict[str, Any]) -> str:
 
 if __name__ == "__main__":
     main()
+
+
+def _print_surfaces(workspace: Path) -> None:
+    """Which enforcement surfaces are governing this machine, and which could be.
+
+    Prismor can sit in front of an agent more than one way and the surfaces are
+    not interchangeable — so "off", "not possible here", and "governed a
+    different way" have to read differently. A single "not governed" for all
+    three is what makes an unsupported agent look like a misconfiguration.
+    """
+    from prismor.runtime import surfaces as _surfaces
+    from prismor.runtime.contract import surface as _surface
+
+    rows = _surfaces.resolve(workspace)
+    gw = _surfaces.gateway(workspace)
+
+    print(f"\n  {_color('PRISMOR', _BOLD)}  enforcement surfaces — {workspace}\n")
+
+    if not rows:
+        print(f"  {_color('No coding agents detected on this machine.', _DIM)}\n")
+    else:
+        print(f"  {_color('AGENT', _DIM)}{'':<10}{_color('HOOKS', _DIM)}      "
+              f"{_color('MIRROR', _DIM)}     {_color('GOVERNED BY', _DIM)}")
+        for agent in sorted(rows):
+            s = rows[agent]
+            def cell(sid: str) -> str:
+                if sid in s["active"]:
+                    return _color("on   ", _GREEN)
+                if sid in s["possible"]:
+                    return _color("off  ", _DIM)
+                return _color("n/a  ", _DIM)
+            if s["active"]:
+                by = _color(" + ".join(s["active"]), _GREEN)
+            elif s["possible"]:
+                by = _color("nothing — ungoverned", _YELLOW)
+            else:
+                by = _color("no interception surface exists", _DIM)
+            print(f"  {agent:<15}{cell('hook')}      {cell('mirror')}     {by}")
+
+    live = gw["live"]
+    if gw["configured"]:
+        state = (_color(f"{live} live", _GREEN) if live
+                 else _color("configured, starts with the next session", _DIM))
+        print(f"\n  {_color('MCP gateway', _DIM)}    {gw['configured']} upstream(s) · {state}")
+    else:
+        print(f"\n  {_color('MCP gateway', _DIM)}    not configured")
+
+    gaps = [a for a, s in rows.items() if s["possible"] and not s["active"]]
+    if gaps:
+        print(f"\n  {_color('Ungoverned:', _YELLOW)} {', '.join(sorted(gaps))}")
+        print(_color("  Prismor cannot constrain an agent it does not sit in front of.", _DIM))
+
+    print()
+    print(_color("  prismor setup                 install hooks (widest coverage)", _DIM))
+    print(_color("  prismor mirror on             serve built-ins over MCP (adds output redaction)", _DIM))
+    print(_color("  prismor mcp-gateway --help    front your MCP servers", _DIM))
+    print(_color("  docs/governance-surfaces.md   which surface to use per agent", _DIM))
+    print()

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -168,8 +168,22 @@ def coverage(workspace: Path) -> Dict[str, Dict[str, bool]]:
 
 
 def unguarded_agents(workspace: Path) -> List[str]:
-    """Detected agents with no Prismor hook at any scope — trivially bypassable."""
-    return [a for a, s in coverage(workspace).items() if not (s["project"] or s["global"])]
+    """Detected agents Prismor could govern but currently does not.
+
+    Hooks are not the only surface. An agent the MCP mirror governs is not
+    unguarded, and an agent with no interception surface at all (no hooks, and
+    built-ins that cannot be switched off) is not a coverage gap either — it is
+    unsupported, and listing it makes the gap count unactionable. Both used to
+    be reported here, which sent `ensure_global_coverage` off trying to install
+    hooks into agents that have no hook protocol.
+    """
+    try:
+        from prismor.runtime.surfaces import ungoverned  # lazy: import cycle
+        return ungoverned(workspace)
+    except Exception:
+        # Never let the richer answer break the caller: fall back to the
+        # hooks-only view rather than reporting no gaps at all.
+        return [a for a, s in coverage(workspace).items() if not (s["project"] or s["global"])]
 
 
 def ensure_global_coverage(*, repo_root: Path, workspace: Path, mode: str = "observe") -> List[str]:
@@ -186,6 +200,18 @@ def ensure_global_coverage(*, repo_root: Path, workspace: Path, mode: str = "obs
         gaps = unguarded_agents(workspace)
     except Exception:
         return repaired
+    # Heals by installing a HOOK, so it may only act on agents that have one.
+    # A mirror-only agent with nothing on is a real gap, but not one this
+    # function can close — asking install_hooks for it could only ever fail.
+    # Asked per agent rather than via surfaces.resolve() so this keeps using
+    # unguarded_agents() as its one source of gaps (callers stub that), and so
+    # it does not repeat resolve()'s filesystem scan on the refresh path; the
+    # registry lookup behind governance() is cached.
+    try:
+        from prismor.runtime.integrations.registry import governance
+        gaps = [a for a in gaps if governance(a).get("hooks")]
+    except Exception:
+        pass  # capability unknown: fall back to attempting every gap
     for agent in gaps:
         try:
             install_hooks(repo_root=repo_root, workspace=workspace, agent=agent, scope="global", mode=mode)

--- a/prismor/runtime/immunity_cli.py
+++ b/prismor/runtime/immunity_cli.py
@@ -169,7 +169,7 @@ _HELP_GROUPS = [
     ("Quick start",          ["setup", "discover", "status", "dashboard", "audit", "update", "pause", "pause-hard", "resume"]),
     ("Runtime protection",   ["check", "semantic-check", "scan", "deps", "sandbox", "policy"]),
     ("Sessions & forensics", ["analyze", "ingest", "sessions", "session"]),
-    ("Hooks",                ["install-hooks", "uninstall-hooks", "mcp-gateway", "mirror"]),
+    ("Hooks",                ["install-hooks", "uninstall-hooks", "mcp-gateway", "mirror", "surfaces"]),
     ("Secret prevention",    ["cloak", "sweep", "canary"]),
     ("Identity & scoping",   ["iam", "scope", "learn"]),
     ("Enterprise / org",     ["enroll", "enroll-status", "workspace", "exempt", "logout"]),

--- a/prismor/runtime/integrations/registry.py
+++ b/prismor/runtime/integrations/registry.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import yaml
@@ -75,12 +76,19 @@ def registry_path() -> Path:
     return _REGISTRY_PATH
 
 
+@lru_cache(maxsize=4)
+def _parsed(src: Path) -> Tuple[Integration, ...]:
+    """Parse+cache one registry file. `get`/`by_surface`/`governance` each
+    reparsed the whole YAML per call, so asking about N agents cost N parses of
+    a file that ships inside the package and cannot change under a running
+    process. Returns a tuple: a cached mutable list would alias across callers."""
+    raw = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    return tuple(Integration.from_dict(e) for e in (raw.get("agents") or []))
+
+
 def load_registry(path: Optional[Path] = None) -> List[Integration]:
     """Parse the registry into ``Integration`` objects (declaration order)."""
-    src = path or _REGISTRY_PATH
-    raw = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
-    entries = raw.get("agents") or []
-    return [Integration.from_dict(e) for e in entries]
+    return list(_parsed(path or _REGISTRY_PATH))
 
 
 def get(agent_id: str, path: Optional[Path] = None) -> Optional[Integration]:

--- a/prismor/runtime/surfaces.py
+++ b/prismor/runtime/surfaces.py
@@ -1,0 +1,107 @@
+"""Which enforcement surfaces are actually governing this machine.
+
+`contract.SURFACES` says what each surface IS and what it can do.
+`integrations.registry.governance()` says which ones CAN reach a given agent.
+This module answers the third question — which are switched on right now — by
+reading the state the installers already write. It adds no state of its own.
+
+The distinction that makes it worth having: "not governed" and "cannot be
+governed" are different answers, and so is "governed by the mirror instead of
+hooks". Collapsing them is how an agent Prismor deliberately does not support
+gets reported as a coverage gap, and how an agent the mirror governs perfectly
+well gets reported as unguarded.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+#: Surfaces that govern one named agent. The gateway is machine-level (it
+#: fronts MCP servers, not an agent's own tools) so it is reported separately.
+AGENT_SURFACES = ("hook", "mirror")
+
+
+def _mirror_agents(workspace: Path) -> set:
+    """Agents `prismor mirror on` currently governs, per its install records."""
+    out = set()
+    try:
+        from prismor.runtime import mirror_cli
+    except Exception:
+        return out
+    try:
+        rec = mirror_cli._read_record(workspace)  # noqa: SLF001 — same package
+        if rec and rec.get("agent"):
+            out.add(str(rec["agent"]))
+    except Exception:
+        pass
+    try:
+        # Codex is wired machine-wide, so its record lives outside the workspace.
+        codex = mirror_cli._load_json(mirror_cli._codex_record_path())  # noqa: SLF001
+        if codex.get("agent"):
+            out.add(str(codex["agent"]))
+    except Exception:
+        pass
+    return out
+
+
+def resolve(workspace: Path) -> Dict[str, Dict[str, Any]]:
+    """Per detected agent: which surfaces are possible, and which are on.
+
+    ``{agent: {"possible": [...], "active": [...], "recommended": str}}``
+    """
+    from prismor.runtime.hooks import coverage
+    from prismor.runtime.integrations.registry import governance
+
+    mirrored = _mirror_agents(workspace)
+    out: Dict[str, Dict[str, Any]] = {}
+    for agent, scopes in coverage(workspace).items():
+        try:
+            gov = governance(agent)
+        except Exception:
+            gov = {"hooks": False, "mirror": "unknown", "recommended": "none"}
+        possible: List[str] = []
+        if gov.get("hooks"):
+            possible.append("hook")
+        if str(gov.get("mirror")) in ("verified", "possible"):
+            possible.append("mirror")
+        active: List[str] = []
+        if scopes.get("project") or scopes.get("global"):
+            active.append("hook")
+        if agent in mirrored:
+            active.append("mirror")
+        out[agent] = {
+            "possible": possible,
+            "active": active,
+            "recommended": gov.get("recommended", "none"),
+            "scopes": scopes,
+        }
+    return out
+
+
+def gateway(workspace: Path) -> Dict[str, Any]:
+    """Machine-level MCP gateway state: configured upstreams and live processes."""
+    from prismor.runtime.mcp_gateway import DEFAULT_GATEWAY_CONFIG, load_gateway_config
+
+    info: Dict[str, Any] = {"configured": 0, "live": 0, "config": str(DEFAULT_GATEWAY_CONFIG)}
+    try:
+        if DEFAULT_GATEWAY_CONFIG.exists():
+            info["configured"] = len(load_gateway_config(DEFAULT_GATEWAY_CONFIG))
+    except Exception:
+        pass
+    try:
+        from prismor.runtime import mirror_cli
+        info["live"] = len(mirror_cli._live_gateways(workspace))  # noqa: SLF001
+    except Exception:
+        pass
+    return info
+
+
+def ungoverned(workspace: Path) -> List[str]:
+    """Detected agents Prismor COULD govern but currently does not.
+
+    Excludes agents with no interception surface at all — naming those is a
+    support question, not a coverage gap, and listing them makes the gap count
+    unactionable.
+    """
+    return sorted(a for a, s in resolve(workspace).items()
+                  if s["possible"] and not s["active"])

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -1,0 +1,71 @@
+"""Which surfaces govern which agent.
+
+The logic worth testing is the three-way distinction: governed, ungoverned,
+and no-surface-exists. Collapsing the last two is the bug this module fixed.
+"""
+from pathlib import Path
+
+from prismor.runtime import surfaces
+
+
+def _fake(monkeypatch, cov, gov, mirrored=()):
+    monkeypatch.setattr("prismor.runtime.hooks.coverage", lambda ws: cov)
+    monkeypatch.setattr(
+        "prismor.runtime.integrations.registry.governance",
+        lambda a, path=None: gov[a])
+    monkeypatch.setattr(surfaces, "_mirror_agents", lambda ws: set(mirrored))
+
+
+OFF = {"project": False, "global": False}
+ON = {"project": False, "global": True}
+HOOKABLE = {"hooks": True, "mirror": "verified", "recommended": "hooks"}
+MIRROR_ONLY = {"hooks": False, "mirror": "verified", "recommended": "mirror"}
+NEITHER = {"hooks": False, "mirror": "unsupported", "recommended": "none"}
+
+
+def test_hooked_agent_is_governed(monkeypatch, tmp_path):
+    _fake(monkeypatch, {"claude": ON}, {"claude": HOOKABLE})
+    assert surfaces.resolve(tmp_path)["claude"]["active"] == ["hook"]
+    assert surfaces.ungoverned(tmp_path) == []
+
+
+def test_mirror_governed_agent_is_not_ungoverned(monkeypatch, tmp_path):
+    """The bug: an agent with no hook protocol, governed by the mirror, used to
+    report as a coverage gap because 'governed' meant 'hooked'."""
+    _fake(monkeypatch, {"opencode": OFF}, {"opencode": MIRROR_ONLY},
+          mirrored=["opencode"])
+    assert surfaces.resolve(tmp_path)["opencode"]["active"] == ["mirror"]
+    assert surfaces.ungoverned(tmp_path) == []
+
+
+def test_agent_with_no_surface_is_not_a_coverage_gap(monkeypatch, tmp_path):
+    """Warp/Trae have no interception point at all. Listing them as gaps makes
+    the count unactionable — there is nothing to install."""
+    _fake(monkeypatch, {"warp": OFF}, {"warp": NEITHER})
+    s = surfaces.resolve(tmp_path)["warp"]
+    assert s["possible"] == [] and s["active"] == []
+    assert surfaces.ungoverned(tmp_path) == []
+
+
+def test_real_gap_is_still_reported(monkeypatch, tmp_path):
+    _fake(monkeypatch, {"claude": OFF}, {"claude": HOOKABLE})
+    assert surfaces.ungoverned(tmp_path) == ["claude"]
+
+
+def test_both_surfaces_on(monkeypatch, tmp_path):
+    _fake(monkeypatch, {"claude": ON}, {"claude": HOOKABLE}, mirrored=["claude"])
+    assert surfaces.resolve(tmp_path)["claude"]["active"] == ["hook", "mirror"]
+
+
+def test_self_heal_only_targets_hookable_agents(monkeypatch, tmp_path):
+    """ensure_global_coverage installs a HOOK, so a mirror-only gap must not
+    reach it — that call could only ever fail."""
+    from prismor.runtime import hooks
+
+    _fake(monkeypatch, {"opencode": OFF}, {"opencode": MIRROR_ONLY})
+    assert surfaces.ungoverned(tmp_path) == ["opencode"]   # a real gap...
+    tried = []
+    monkeypatch.setattr(hooks, "install_hooks",
+                        lambda **kw: tried.append(kw["agent"]))
+    hooks.ensure_global_coverage(repo_root=tmp_path, workspace=tmp_path)
+    assert tried == []                                      # ...but not a hookable one


### PR DESCRIPTION
Choosing hooks vs the MCP mirror vs the gateway was already possible — `setup`, `mirror on|off`, `mcp-gateway`. What was missing is seeing the result, and that gap was hiding a bug.

## The bug

`unguarded_agents()` meant "not hooked". So it reported two things that are not coverage gaps:

- **An agent the mirror governs.** OpenCode has no hook protocol at all — MCP is the only interposition point that exists for it. Governed perfectly well, reported as unguarded.
- **An agent with no interception surface at all.** Warp, Trae: no hooks, and built-ins that cannot be switched off. Nothing to install, so listing it makes the gap count unactionable.

Worse, `ensure_global_coverage` feeds that list straight into `install_hooks`. The enrolled-device self-heal was repeatedly trying to install hooks into agents that have none, failing silently inside a `try/except`.

## The fix

`runtime/surfaces.py` answers the three-way question — governed / ungoverned / no surface exists — by composing state the installers already write:

| source | answers |
|---|---|
| `hooks.coverage()` | is a hook installed, at either scope |
| mirror install records | is the mirror on, and for which agent |
| gateway config + live markers | upstreams configured, processes live |
| `registry.governance()` | which surfaces *can* reach this agent |

It adds no state of its own — no new config file, no declared-intent file. "Ungoverned" is derivable from detected × possible × active, so nothing new has to be kept in sync.

`unguarded_agents()` now delegates to it, which fixes the bug for **every** caller rather than at the display layer, and falls back to the old hooks-only computation if anything goes wrong — a richer answer must not be able to turn into no answer. `coverage()` is untouched, so nothing that reads it changes shape.

## The view

```
  AGENT          HOOKS      MIRROR     GOVERNED BY
  claude         on         off        hook
  openclaw       off        n/a        nothing — ungoverned
  openhands      on         n/a        hook

  MCP gateway    2 upstream(s) · configured, starts with the next session

  Ungoverned: openclaw
```

`on` / `off` / `n/a` are three different answers. Collapsing them is what made an unsupported agent look like a misconfiguration. On my own machine it immediately found a real gap.

## Also: the registry now parses once

`governance()` called `load_registry()`, which reparses the whole YAML **per call** — and `resolve()` asks about every detected agent, on the refresh path. Now `lru_cache`d, returned as a tuple so a cached list cannot alias across callers. 50 `governance()` calls: ~0ms, was 50 full parses. Every existing caller (`get`, `by_surface`, `by_status`) gets that too.

## Compatibility

- `coverage()` signature and shape unchanged.
- `unguarded_agents()` / `ensure_global_coverage()` signatures unchanged.
- `ensure_global_coverage` still gets its gaps from `unguarded_agents()` — that seam is stubbed by `test_hook_config_error`, and an earlier single-pass version of this patch broke it. The hook-capability filter asks `governance()` per agent instead, which needs no second filesystem scan now that the registry is cached.
- New read-only command; it shows under Hooks in `--help`.

**Test evidence.** This suite is not green on `main` and its count drifts between runs with no code change (I measured 28 → 29), so the meaningful check is the failure *set*, not the count: **zero new failures** — 28 on this branch is a strict subset of a 29-failure same-session baseline, 2260 passed. Six new tests cover the three-way distinction and the self-heal filter.

Related: #308 (the suite's pre-existing PolicyEngine leak, which is why baselines are compared as sets here).
