### PR TITLE
workspace scope: org can disable personal workspaces

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -304,7 +304,7 @@ Deep dive: [Learning](learning.md).
 |---|---|---|
 | `prismor enroll <token>` | `--label`, `--api-base` | Exchange a single-use org token (minted in the dashboard) for this machine's device identity; pulls the signed org policy. |
 | `prismor enroll-status` | — | Show enrollment state, device label, and the applied policy version. |
-| `prismor workspace [managed\|personal\|auto]` | — | With no argument, shows whether this workspace is org-managed (org policy + telemetry) or personal (local-only). Pass `managed`/`personal`/`auto` to set it. Org-claimed repos can't be downgraded. |
+| `prismor workspace [managed\|personal\|auto]` | — | With no argument, shows whether this workspace is org-managed (org policy + telemetry) or personal (local-only). Pass `managed`/`personal`/`auto` to set it. Org-claimed repos can't be downgraded, and `personal` is ignored entirely when the org policy sets `allow_personal_workspaces: false`. |
 | `prismor exempt request` | `--reason` | Ask an org admin to relax specific non-floor rules for this repo; served back in the signed policy. |
 | `prismor logout` | — | Un-enroll: removes the device identity and cached remote policy. Local protection stays on. |
 

--- a/docs/connecting-to-the-platform.md
+++ b/docs/connecting-to-the-platform.md
@@ -121,7 +121,18 @@ On the hot path, `remote_policy.check_and_refresh()` (debounced, clamped to
 ## 3. Redacted telemetry (what leaves the box)
 
 Telemetry flows only for **org-managed** workspaces (`workspace_scope.py`).
-Personal repos emit nothing. The `prismor` sink (`prismor/runtime/sinks.py`) builds
+Personal repos emit nothing — but the local security floor still applies to them;
+"personal" removes org visibility and the org overlay, never protection.
+
+Scope is decided by the git remote matching an org-claimed pattern
+(`settings.managed_repo_patterns`). That is a developer-privacy convenience,
+not a security boundary: a developer can rewrite or drop `origin` so a repo no
+longer matches, then mark it personal. Orgs that need every workspace on an
+enrolled device governed set `settings.allow_personal_workspaces: false` in the
+signed policy — `prismor workspace personal`, `PRISMOR_WORKSPACE_SCOPE=personal`
+and the non-claimed-repo default are then all ignored.
+
+The `prismor` sink (`prismor/runtime/sinks.py`) builds
 records via `telemetry.build_record()` and runs `assert_redacted()` before upload
 — a fail-closed guard.
 

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -733,6 +733,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         if scope == "managed":
             why = {"org_claimed": "matches an org-claimed repo pattern (cannot be downgraded)",
                    "opt_in": "you opted this repo in",
+                   "org_no_personal": "your org has disabled personal workspaces on enrolled devices (cannot be downgraded)",
                    "default_all": "your org governs all enrolled machines (no per-repo scoping set)"}.get(reason, reason)
             print(f"  scope:      ORG-MANAGED — {why}")
             print(f"  org:        {ident.get('org_name') or ident.get('org_id')}")

--- a/prismor/runtime/enterprise/workspace_scope.py
+++ b/prismor/runtime/enterprise/workspace_scope.py
@@ -102,20 +102,35 @@ def set_override(workspace: Path, scope: Optional[str]) -> None:
         pass
 
 
-def org_managed_patterns() -> List[str]:
-    """The org's claimed-repo glob patterns, read from the *verified* signed
-    remote policy (settings.managed_repo_patterns). Empty if not enrolled / no
-    policy — which means nothing is auto-managed."""
+def _org_settings() -> Dict[str, Any]:
+    """``settings`` block of the *verified* signed remote policy, or {}."""
     try:
         from prismor.runtime.enterprise import remote_policy as _remote
         pol = _remote.verify_and_load()
         if pol:
-            pats = (pol.get("settings") or {}).get("managed_repo_patterns")
-            if isinstance(pats, list):
-                return [str(p) for p in pats if p]
+            return pol.get("settings") or {}
     except Exception:
         pass
+    return {}
+
+
+def org_managed_patterns() -> List[str]:
+    """The org's claimed-repo glob patterns (settings.managed_repo_patterns).
+    Empty if not enrolled / no policy — which means nothing is auto-managed."""
+    pats = _org_settings().get("managed_repo_patterns")
+    if isinstance(pats, list):
+        return [str(p) for p in pats if p]
     return []
+
+
+def org_allows_personal() -> bool:
+    """``settings.allow_personal_workspaces`` (default True). When the org sets
+    it False, every workspace on an enrolled device is managed: the personal
+    override, PRISMOR_WORKSPACE_SCOPE=personal, and the non-claimed-repo default
+    are all ignored. This is the only way to close the scope-is-the-git-remote
+    hole — a developer can always rewrite or drop ``origin`` to dodge a claimed
+    pattern, so orgs that need full coverage must disable personal space."""
+    return _org_settings().get("allow_personal_workspaces", True) is not False
 
 
 def _matches(remote: str, pattern: str) -> bool:
@@ -150,11 +165,14 @@ def resolve_scope(workspace: Path) -> Dict[str, Any]:
       1. not enrolled → local (nothing to report to).
       2. remote matches an org-claimed pattern → managed, FORCED (a developer
          cannot downgrade a company/client repo).
-      3. PRISMOR_WORKSPACE_SCOPE env override for a non-claimed workspace →
+      3. org set settings.allow_personal_workspaces=false → managed, FORCED
+         (no personal space on this device at all; closes the rewrite-the-
+         remote bypass for orgs that need it).
+      4. PRISMOR_WORKSPACE_SCOPE env override for a non-claimed workspace →
          honored (the deployed-workload path: no git remote, no writable home).
-      4. developer override (opt-in 'managed' / opt-out 'personal') for a
+      5. developer override (opt-in 'managed' / opt-out 'personal') for a
          non-claimed repo → honored.
-      5. default: if the org has claimed NO patterns, manage everything
+      6. default: if the org has claimed NO patterns, manage everything
          (backward-compatible "cover all dev machines"); if the org HAS claimed
          patterns, a non-matching repo is the developer's personal space.
     """
@@ -172,6 +190,9 @@ def resolve_scope(workspace: Path) -> Dict[str, Any]:
         for pat in patterns:
             if _matches(remote, pat):
                 return {"scope": "managed", "reason": "org_claimed", "remote": remote, "org_id": org_id, "pattern": pat}
+
+    if not org_allows_personal():
+        return {"scope": "managed", "reason": "org_no_personal", "remote": remote, "org_id": org_id}
 
     env_scope = _env_scope()
     if env_scope == "managed":

--- a/tests/test_workspace_scope.py
+++ b/tests/test_workspace_scope.py
@@ -135,3 +135,25 @@ def test_policy_engine_skips_remote_for_personal(tmp_path, monkeypatch):
     assert engine.workspace_managed is False
     # No prismor telemetry sink should be present for a personal workspace.
     assert not any(str(o.get("type", "")).lower() == "prismor" for o in (engine.outputs or []))
+
+
+def test_org_can_disable_personal_workspaces(tmp_path, monkeypatch):
+    """allow_personal_workspaces=false → every workspace is managed: the
+    personal override, the env opt-out, and the non-claimed default all lose.
+    (Scope is keyed on the git remote, which a dev can rewrite — this is the
+    org's only way to close that.)"""
+    from prismor.runtime.enterprise import workspace_scope as ws
+    _enroll()
+    monkeypatch.setattr(ws, "_org_settings", lambda: {
+        "managed_repo_patterns": ["github.com/acme/*"], "allow_personal_workspaces": False})
+    repo = _git_repo(tmp_path, "https://github.com/me/remote-rewritten-to-dodge-acme")
+    ws.set_override(repo, "personal")
+    monkeypatch.setenv("PRISMOR_WORKSPACE_SCOPE", "personal")
+    info = ws.resolve_scope(repo)
+    assert info["scope"] == "managed" and info["reason"] == "org_no_personal"
+    # An org-claimed repo still reports the more specific reason.
+    assert ws.resolve_scope(_git_repo(tmp_path, "https://github.com/acme/x"))["reason"] == "org_claimed"
+    # Default stays permissive when the key is absent.
+    monkeypatch.setattr(ws, "_org_settings", lambda: {"managed_repo_patterns": ["github.com/acme/*"]})
+    monkeypatch.delenv("PRISMOR_WORKSPACE_SCOPE")
+    assert ws.resolve_scope(repo)["reason"] == "opt_out"


### PR DESCRIPTION
## Problem
`workspace_scope.py` decides managed-vs-personal from the git remote. A developer can `git remote set-url origin` (or drop it) so a company repo no longer matches `managed_repo_patterns`, then `prismor workspace personal` — org telemetry and the org overlay stop applying. The local security floor still holds, but anything the org layered above it is gone and the org can't see it.

## Fix
- New signed-policy setting `settings.allow_personal_workspaces` (default `true`, no behavior change). When `false`, every workspace on an enrolled device is managed (`reason: org_no_personal`); the personal override, `PRISMOR_WORKSPACE_SCOPE=personal` and the non-claimed default are ignored. Org-claimed repos still report `org_claimed`.
- `prismor workspace` explains the new reason.
- Docs: state plainly that pattern scoping is a privacy convenience, not a security boundary, and how to close it.

Not changed: opt-out with zero patterns configured is tested as intentional (`test_dev_can_opt_out_personal_when_no_patterns`), so left alone — the new setting covers that case too.

## Test
`pytest tests/test_workspace_scope.py tests/test_workspace_scope_env.py tests/test_scope_ux.py` — 32 passed.