### PR TITLE
remote_policy: fold allow_personal_workspaces into managedReposSig

### DIFF
--- a/prismor/runtime/enterprise/remote_policy.py
+++ b/prismor/runtime/enterprise/remote_policy.py
@@ -300,10 +300,13 @@ def _current_managed_repos_sig() -> str:
             f"{ex.get('id')}:{ex.get('expires') or ''}:{ex.get('overlay_sig') or ''}"
             for ex in exemptions if isinstance(ex, dict) and ex.get("id")
         )
-        if not pats and not ex_parts:
+        # allow_personal_workspaces=false is folded in only when set, mirroring
+        # the server, so default orgs keep their existing signature.
+        no_personal = settings.get("allow_personal_workspaces") is False
+        if not pats and not ex_parts and not no_personal:
             return ""
         import hashlib
-        sig_input = "\n".join([*pats, "|", *ex_parts])
+        sig_input = "\n".join([*pats, "|", *ex_parts, *(["|", "no_personal"] if no_personal else [])])
         return hashlib.sha256(sig_input.encode("utf-8")).hexdigest()[:16]
     except Exception:
         return ""

--- a/tests/test_workspace_scope.py
+++ b/tests/test_workspace_scope.py
@@ -157,3 +157,18 @@ def test_org_can_disable_personal_workspaces(tmp_path, monkeypatch):
     monkeypatch.setattr(ws, "_org_settings", lambda: {"managed_repo_patterns": ["github.com/acme/*"]})
     monkeypatch.delenv("PRISMOR_WORKSPACE_SCOPE")
     assert ws.resolve_scope(repo)["reason"] == "opt_out"
+
+
+def test_repull_sig_tracks_allow_personal_workspaces(monkeypatch):
+    """Flipping allow_personal_workspaces must change managedReposSig (else the
+    device never re-pulls); the default must leave the sig untouched."""
+    from prismor.runtime.enterprise import remote_policy as rp
+    pols = iter([
+        {"settings": {"managed_repo_patterns": ["github.com/acme/*"]}},
+        {"settings": {"managed_repo_patterns": ["github.com/acme/*"], "allow_personal_workspaces": True}},
+        {"settings": {"managed_repo_patterns": ["github.com/acme/*"], "allow_personal_workspaces": False}},
+        {"settings": {"allow_personal_workspaces": False}},
+    ])
+    monkeypatch.setattr(rp, "verify_and_load", lambda: next(pols))
+    base, explicit_true, off, off_no_patterns = (rp._current_managed_repos_sig() for _ in range(4))
+    assert base == explicit_true and base != off and off_no_patterns and off_no_patterns != off


### PR DESCRIPTION
Follow-up to #311. The re-pull signature must agree with prismor-web's `managedReposSig` (web PR incoming), otherwise a device whose org flips `allow_personal_workspaces: false` would re-pull on every debounce. Folded in only when false, so every org on the default keeps its current sig.

Test: `pytest tests/test_workspace_scope.py tests/test_pause_refresh_trigger.py` — 17 passed.