### PR TITLE
docs: point the attestation bundle at a Cloak page that exists

### DIFF
--- a/docs/attestation-bundle.md
+++ b/docs/attestation-bundle.md
@@ -71,7 +71,7 @@ actually applies to it:
 |---|---|
 | Coding agents | Prismor's hook dispatcher is wired into the agent's config |
 | MCP servers | the server is routed through `prismor mcp-gateway` |
-| Provider keys | the credential is registered with [Cloak](cloaking.md) |
+| Provider keys | the credential is registered with [Cloak](sweep-and-cloak.md) |
 
 ```
   PRISMOR  discover   ~/src/acme


### PR DESCRIPTION
`docs/attestation-bundle.md` line 74 links `[Cloak](cloaking.md)`. This repo has never had a `cloaking.md` — the page is `sweep-and-cloak.md`, so the link 404s when the doc is read on GitHub.

Found while wiring the docs site to render this repo's markdown directly: it was the only unresolvable relative `.md` link across all 48 docs (checked by resolving every `](*.md)` target against the tree). The site currently special-cases the `cloaking` slug to keep the rendered link from dead-ending; with this merged that workaround is only there for old copies.