### PR TITLE
Fix cloaking transcript leak + scope-blind status/audit + scanner/sweep false positives

### DIFF
--- a/prismor/runtime/audit.py
+++ b/prismor/runtime/audit.py
@@ -102,37 +102,29 @@ def apply_fixes(findings: List[AuditFinding]) -> List[str]:
 # ── Individual checks ───────────────────────────────────────────────────────
 
 def _check_hooks(workspace: Path, repo_root: Path) -> List[AuditFinding]:
-    """Check hook installation across agents."""
+    """Check hook installation across agents, in both project and global scope."""
+    from prismor.runtime.hooks import coverage, _config_path
+
     findings: List[AuditFinding] = []
-    agents_config = {
-        "claude": workspace / ".claude" / "settings.json",
-        "cursor": workspace / ".cursor" / "hooks.json",
-        "windsurf": workspace / ".windsurf" / "hooks.json",
-        "openclaw": workspace / ".openclaw" / "plugins.json",
-        "hermes": workspace / ".hermes" / "plugins.json",
-        "codex": workspace / ".codex" / "hooks.json",
-    }
 
-    installed_agents: List[str] = []
+    installed: List[str] = []
     mode_found: Optional[str] = None
-
-    for agent, config_path in agents_config.items():
-        if not config_path.exists():
+    for agent, scopes in coverage(workspace).items():
+        hit = [sc for sc, ok in scopes.items() if ok]
+        if not hit:
             continue
-        try:
-            content = config_path.read_text(encoding="utf-8")
-        except OSError:
-            continue
+        installed.append(agent if "project" in hit else f"{agent} (global)")
+        if mode_found is None:
+            try:
+                content = _config_path(agent, hit[0], workspace).read_text(encoding="utf-8")
+            except (OSError, ValueError):
+                continue
+            if "--mode enforce" in content:
+                mode_found = "enforce"
+            elif "--mode observe" in content:
+                mode_found = "observe"
 
-        if "prismor" in content.lower() or "prismor" in content.lower():
-            installed_agents.append(agent)
-            if mode_found is None:
-                if "--mode enforce" in content:
-                    mode_found = "enforce"
-                elif "--mode observe" in content:
-                    mode_found = "observe"
-
-    if not installed_agents:
+    if not installed:
         def _fix_install_hooks() -> str:
             from prismor.runtime.hooks import install_hooks
             from prismor.runtime.store import register_workspace
@@ -157,7 +149,7 @@ def _check_hooks(workspace: Path, repo_root: Path) -> List[AuditFinding]:
         findings.append(AuditFinding(
             severity="PASS",
             category="hooks",
-            message=f"Hooks installed: {', '.join(installed_agents)}",
+            message=f"Hooks installed: {', '.join(installed)}",
         ))
 
         if mode_found == "observe":
@@ -235,7 +227,10 @@ def _check_cloaking(workspace: Path) -> List[AuditFinding]:
         ))
         return findings
 
-    result = cloak_status(workspace=workspace, scope="project")
+    for _scope in ("project", "user"):
+        result = cloak_status(workspace=workspace, scope=_scope)
+        if result["installed"]:
+            break
 
     if not result["installed"]:
         def _fix_install_cloak() -> str:

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -2256,9 +2256,18 @@ def main(argv: Optional[List[str]] = None) -> None:
             print()
             print(f"  {_color('CLOAKING', _BOLD)}")
             print(f"  {_color('─' * 50, _DIM)}")
-            # Claude Code cloaking status
-            result = cloak_status(workspace=workspace, scope=args.scope)
+            # Claude Code cloaking status. With no explicit --scope, report the
+            # scope the hooks actually live in: `prismor setup` with global scope
+            # writes them to ~/.claude, and a project-only lookup called that
+            # "not installed" while `prismor status` said the opposite.
+            scopes = [args.scope] if args.scope else ["project", "user"]
+            for _sc in scopes:
+                result = cloak_status(workspace=workspace, scope=_sc)
+                if result["installed"]:
+                    break
             state = "installed" if result["installed"] else "not installed"
+            if result["installed"] and not args.scope:
+                state += " (project)" if _sc == "project" else " (global)"
             installed_color = _GREEN if result["installed"] else _YELLOW
             print(f"  {_color('Claude Code:', _GREEN)} {_color(state, installed_color)}")
             if result.get("configPath"):
@@ -2266,7 +2275,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             if result.get("events"):
                 print(f"  {_color('Events:', _GREEN)}    {', '.join(result['events'])}")
             # Hermes Agent cloaking status
-            h_result = hermes_status(workspace=workspace, scope=args.scope)
+            h_result = hermes_status(workspace=workspace, scope=args.scope or "project")
             h_state = "installed" if h_result["installed"] else "not installed"
             h_color = _GREEN if h_result["installed"] else _YELLOW
             print(f"  {_color('Hermes Agent:', _GREEN)} {_color(h_state, h_color)}")
@@ -3563,8 +3572,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     t_status = cloak_sub.add_parser("status", help="Show whether cloaking hooks are installed")
     t_status.add_argument("--workspace", help="Workspace path")
-    t_status.add_argument("--scope", choices=["project", "user", "global"], default="project",
-                          help="Hook scope (default: project)")
+    t_status.add_argument("--scope", choices=["project", "user", "global"], default=None,
+                          help="Hook scope (default: whichever scope the hooks are installed in)")
 
     t_run = cloak_sub.add_parser(
         "run",

--- a/prismor/runtime/cloaking/hooks/decloak-exec.sh
+++ b/prismor/runtime/cloaking/hooks/decloak-exec.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Prismor — decloak resolver, run as the CHILD of a wrapped Bash tool call.
+#
+# Why this exists: the PreToolUse hook has to hand Claude Code a runnable
+# command, and Claude Code records the command it is handed verbatim in the
+# session transcript on disk. Substituting the real secret into that string
+# therefore wrote the raw value into ~/.claude/projects/*.jsonl — the exact
+# leak the cloaking layer exists to prevent (the value never reached the
+# model, but it did reach the disk).
+#
+# So the hook now hands over the command with its placeholders INTACT, and
+# this script does the substitution here, inside the child process, where
+# nothing is recorded.
+#
+# In:  $PRISMOR_CLOAK_CMD   the command text, placeholders unresolved
+#      $PRISMOR_SECRETS_DIR the vault
+# Out: the command's own stdout/stderr and exit status.
+set -uo pipefail
+
+SECRETS_DIR="${PRISMOR_SECRETS_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/secrets}"
+cmd="${PRISMOR_CLOAK_CMD:-}"
+[[ -n "$cmd" ]] || exit 0
+
+# Same placeholder grammar as decloak.sh. An escaped colon is deliberately not
+# matched, so the literal syntax can still be written.
+while IFS= read -r placeholder; do
+  [[ -z "$placeholder" ]] && continue
+  name="${placeholder#@@SECRET:}"
+  name="${name%@@}"
+  secret_file="$SECRETS_DIR/$name"
+  # decloak.sh already denied on a missing secret; if it vanished between the
+  # hook and here, leave the placeholder alone rather than running a command
+  # with an empty credential silently substituted in.
+  [[ -f "$secret_file" ]] || continue
+  real="$(cat "$secret_file")"
+  cmd="${cmd//"$placeholder"/$real}"
+done < <(printf '%s' "$cmd" | grep -oE '@@SECRET:[a-zA-Z0-9_-]+@@' | sort -u || true)
+
+eval "$cmd"

--- a/prismor/runtime/cloaking/hooks/decloak.sh
+++ b/prismor/runtime/cloaking/hooks/decloak.sh
@@ -29,6 +29,7 @@ set -uo pipefail
 _HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SECRETS_DIR="${PRISMOR_SECRETS_DIR:-${PRISMOR_HOME:-$HOME/.prismor}/secrets}"
 SCRUBBER="$_HOOK_DIR/scrub-stream.sh"
+RESOLVER="$_HOOK_DIR/decloak-exec.sh"
 
 # Require jq — hook scripts are shell-only for speed. Fail closed if missing.
 if ! command -v jq >/dev/null 2>&1; then
@@ -43,8 +44,10 @@ tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
 [[ -n "$cmd" ]] || exit 0
 
-# ── 1. Decloak: substitute any @@SECRET:name@@ placeholders ────────────────
-new_cmd="$cmd"
+# ── 1. Decloak: validate every placeholder in the command ────────────────
+# Resolution itself happens in decloak-exec.sh, in the child process. Doing it
+# here would put the real value into the command string that Claude Code
+# records verbatim in ~/.claude/projects/*.jsonl.
 placeholders="$(printf '%s' "$cmd" | grep -oE '@@SECRET:[a-zA-Z0-9_-]+@@' | sort -u || true)"
 if [[ -n "$placeholders" ]]; then
   while IFS= read -r placeholder; do
@@ -62,8 +65,6 @@ if [[ -n "$placeholders" ]]; then
         '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
       exit 0
     fi
-    real="$(cat "$secret_file")"
-    new_cmd="${new_cmd//"$placeholder"/$real}"
   done <<< "$placeholders"
 fi
 
@@ -78,15 +79,23 @@ for _f in "$SECRETS_DIR"/*; do
   [[ -f "$_f" ]] && { have_secrets=1; break; }
 done
 
-if [[ "$have_secrets" -eq 0 && "$new_cmd" == "$cmd" ]]; then
+if [[ "$have_secrets" -eq 0 && -z "$placeholders" ]]; then
   exit 0
 fi
 
 # Wrap: run the command in a brace group, merge stderr into stdout, pipe
 # through the scrubber, and re-raise the command's own exit status (not sed's)
 # so callers that branch on exit codes still behave correctly. Only the
-# scrubber path and the secrets-dir path are embedded — never a secret value.
-wrapped="{ $new_cmd ; } 2>&1 | PRISMOR_SECRETS_DIR=$(printf '%q' "$SECRETS_DIR") $(printf '%q' "$SCRUBBER"); exit \${PIPESTATUS[0]}"
+# scrubber path, the resolver path and the secrets-dir path are embedded —
+# never a secret value, in either branch.
+if [[ -n "$placeholders" ]]; then
+  # Placeholders present: hand the command over unresolved and let the child
+  # resolve it, so the recorded string holds placeholders and not secrets.
+  runner="PRISMOR_SECRETS_DIR=$(printf '%q' "$SECRETS_DIR") PRISMOR_CLOAK_CMD=$(printf '%q' "$cmd") bash $(printf '%q' "$RESOLVER")"
+else
+  runner="{ $cmd ; }"
+fi
+wrapped="$runner 2>&1 | PRISMOR_SECRETS_DIR=$(printf '%q' "$SECRETS_DIR") $(printf '%q' "$SCRUBBER"); exit \${PIPESTATUS[0]}"
 
 new_input="$(printf '%s' "$input" | jq --arg c "$wrapped" '.tool_input | .command = $c')"
 jq -n --argjson ni "$new_input" \

--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -132,6 +132,22 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
     return results
 
 
+# Agents whose hook is registered as a plugin path rather than an inline
+# command. _strip_openclaw / _strip_hermes / _strip_opencode use the same
+# "is this one of ours" test when uninstalling.
+_PLUGIN_REGISTERED_AGENTS = ("openclaw", "hermes", "opencode")
+
+
+def _prismor_plugin_registered(config_text: str) -> bool:
+    try:
+        plugins = json.loads(config_text).get("plugins", [])
+    except (json.JSONDecodeError, AttributeError):
+        return False
+    if not isinstance(plugins, list):
+        return False
+    return any(m in str(entry).lower() for entry in plugins for m in ("prismor", "warden"))
+
+
 def hook_installed(agent: str, scope: str, workspace: Path) -> bool:
     """True if a Prismor PreToolUse hook is present in this agent's config at
     ``scope`` ("project" | "global"). Text-based — the dispatcher command embeds
@@ -146,7 +162,20 @@ def hook_installed(agent: str, scope: str, workspace: Path) -> bool:
         return False
     try:
         path = _config_path(agent, scope, workspace)
-        return path.exists() and "hook-dispatch" in path.read_text(encoding="utf-8")
+        if not path.exists():
+            return False
+        text = path.read_text(encoding="utf-8")
+        if "hook-dispatch" in text:
+            return True
+        # openclaw / hermes / opencode do not take an inline command: install
+        # registers a *plugin path* in config["plugins"] and writes the
+        # dispatcher into the scaffolded plugin. The marker is therefore never
+        # in the config file, so the text search above reported these agents as
+        # unhooked forever — which made coverage() under-report them and sent
+        # ensure_global_coverage re-installing them on every run.
+        if agent in _PLUGIN_REGISTERED_AGENTS:
+            return _prismor_plugin_registered(text)
+        return False
     except Exception:
         return False
 

--- a/prismor/runtime/scanner.py
+++ b/prismor/runtime/scanner.py
@@ -17,6 +17,7 @@ import json
 import re
 import shlex
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -221,7 +222,27 @@ def _claude_skill_files(workspace: Path) -> List[Path]:
     for root in (home / ".claude" / "skills", workspace / ".claude" / "skills"):
         if root.is_dir():
             found.extend(sorted(root.glob("*/SKILL.md")))
+    # `prismor setup` installs Prismor's own skill; scanning it made a fresh
+    # install report itself as a CRITICAL "skill injects shell commands"
+    # finding, because the skill documents the very commands and credential
+    # paths the rules look for. Skip it while it is byte-identical to the
+    # bundled copy — an edited one is a third-party skill again and is scanned.
+    ours = _bundled_skill_digest()
+    if ours:
+        found = [p for p in found if _digest(p) != ours]
     return found
+
+
+def _digest(path: Path) -> Optional[str]:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _bundled_skill_digest() -> Optional[str]:
+    return _digest(Path(__file__).parent / "data" / "SKILL.md")
 
 
 def _cursor_configs(workspace: Path) -> List[Path]:

--- a/prismor/runtime/sweep-gitleaks.toml
+++ b/prismor/runtime/sweep-gitleaks.toml
@@ -46,14 +46,14 @@ tags        = ["cohere", "llm", "ai"]
 [[rules]]
 id          = "mistral-api-key"
 description = "Mistral AI API key"
-regex       = '''[A-Za-z0-9]{32}'''
+regex       = '''(?i)mistral[_\-]?(?:ai)?[_\-]?(?:api[_\-]?)?key["'\s:=]{1,10}([A-Za-z0-9]{32})'''
 keywords    = ["mistral"]
 tags        = ["mistral", "llm", "ai"]
 
 [[rules]]
 id          = "together-api-key"
 description = "Together AI API key"
-regex       = '''[A-Za-z0-9]{40}'''
+regex       = '''(?i)together[_\-]?(?:ai)?[_\-]?(?:api[_\-]?)?key["'\s:=]{1,10}([A-Za-z0-9]{40})'''
 keywords    = ["together_ai", "TOGETHER_API_KEY"]
 tags        = ["together", "llm", "ai"]
 

--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -238,6 +238,19 @@ def test_read_of_clean_file_allowed():
     check("Read of a clean file is allowed (no-op)", res is None, str(res))
 
 
+def test_no_secret_in_wrapped_command_when_placeholder_used():
+    # Regression (transcript leak): when a command references a placeholder,
+    # decloak.sh used to substitute the REAL value into the command string it
+    # handed back — and Claude Code records that string verbatim in
+    # ~/.claude/projects/*.jsonl. The value never reached the model but did
+    # reach disk. The wrapped command must now carry the placeholder, with
+    # resolution deferred to the child (decloak-exec.sh).
+    res = run_hook(_DECLOAK, bash_payload(f"echo using {_PLACEHOLDER}"))
+    wrapped = res["hookSpecificOutput"]["updatedInput"]["command"]
+    check("placeholder command: wrapped string holds no raw secret",
+          _CANARY not in wrapped and _PLACEHOLDER in wrapped, wrapped)
+
+
 def main() -> int:
     for fn in [
         test_scrub_masks_secret, test_scrub_passthrough_no_secret,
@@ -246,6 +259,7 @@ def main() -> int:
         test_grep_output_scrubbed, test_source_echo_scrubbed,
         test_no_secret_in_wrapped_command, test_exit_code_preserved,
         test_placeholder_substituted_and_output_scrubbed,
+        test_no_secret_in_wrapped_command_when_placeholder_used,
         test_leading_env_assignment_decloaked_and_scrubbed,
         test_unregistered_placeholder_denied,
         test_escaped_placeholder_not_substituted,


### PR DESCRIPTION
## Summary

Five issues surfaced while exercising a fresh `enforce` + global-scope install with a real Claude Code agent in the loop, on an isolated host. All are runtime/CLI fixes; no behavior change for anyone not hitting the specific paths.

| # | Area | Severity | One-liner |
|---|------|----------|-----------|
| 1 | `cloaking/hooks/decloak.sh` | **High** | Resolved secret was inlined into the command Claude Code records verbatim → raw value hit `~/.claude/projects/*.jsonl` |
| 2 | `cli.py`, `audit.py` | Medium | `cloak status` / `audit` were project-scope-only → a global install reported "not installed" while `prismor status` said the opposite |
| 3 | `hooks.py` | Medium | `hook_installed()` missed plugin-path agents (openclaw/hermes/opencode) → coverage under-reported, `ensure_global_coverage` re-ran every time |
| 4 | `scanner.py` | Medium | `prismor scan` flagged Prismor's **own** installed skill as CRITICAL shell-injection |
| 5 | `sweep-gitleaks.toml` | Low | mistral/together rules used bare length classes → 88 phantom "secrets" in one transcript |

---

### 1. Cloaking transcript leak (the important one)

`decloak.sh` has to hand Claude Code a runnable command, and Claude Code records that command **verbatim** in its on-disk transcript. Substituting the real secret into that string therefore wrote the raw value to disk — the exact leak the cloaking layer exists to prevent (it never reached the model, but it did reach `~/.claude/projects/*.jsonl`).

Fix: resolution moves into the child process (`decloak-exec.sh`); the recorded command keeps its `@@SECRET:name@@` placeholders.

**Before** — the wrapped command handed back contains the raw key (highlighted):

![before](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/leak-before.png)

**After** — placeholders preserved, resolution deferred to `decloak-exec.sh`:

![after](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/leak-after.png)

End-to-end check with a real agent: after asking Claude to *use* the key, a value-grep of every transcript file returns **0** raw-secret occurrences.

![claude under cloaking](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/claude.gif)

A regression test is added that **fails against the old hook and passes now** (`tests/test_cloak_output_scrub.py`).

---

### 2 + 3. Scope-blind status/audit & plugin-path coverage

`prismor setup --scope global` writes hooks to `~/.claude`, but `audit`/`cloak status` only looked at project scope, and `hook_installed()` only recognised the inline-command form (openclaw/hermes/opencode register a plugin *path* instead). Net effect on a correctly-installed global machine:

**Before** — CRITICAL "no hooks" + HIGH "cloaking not installed", both false:

![audit before](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/audit-before.png)

**After** — hooks detected in both scopes and across plugin-path agents:

![audit after](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/audit-after.png)

---

### 4. Scanner flagged Prismor's own skill

`prismor setup` installs Prismor's own skill, which documents the very commands and credential paths the skill rules look for — so a clean install scanned itself as CRITICAL. Now skipped while byte-identical to the bundled copy; an edited copy is scanned again, and a malicious-skill positive control still fires.

**Before** (own skill flagged) → **After** (clean):

![scan before](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/scan-before.png)
![scan after](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/scan-after.png)

---

### 5. Sweep false positives

`mistral-api-key` / `together-api-key` used bare length classes (`[A-Za-z0-9]{32}`) gated only by a file-level keyword, so one mention of "mistral" anywhere in a file matched every 32-char run in it (88 phantom hits in a single Claude transcript). Both are now bound to an assignment context; a positive control on a real `MISTRAL_API_KEY=…` still detects.

---

## Cloaking, end to end

![cloak flow](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/cloak.gif)

## Testing

- New regression test for the transcript leak (fails on old hook, passes now).
- `453 passed, 2 skipped` across the cloak/audit/sweep/scanner/hooks/surface subset (the one remaining failure, `test_cloak_add_env_file_imports_each_entry`, is **pre-existing on `main`** — unrelated).
- `python -m build` confirms the new `decloak-exec.sh` ships in the wheel.

> Screenshots/GIFs are real captures from a clean host; they live on the throwaway `pr-assets/cloak-fix` branch (not part of this diff, safe to delete after merge).
