### PR TITLE
deps: match dependencies against the bundled IOC database, not just the (empty) feed

### DIFF
--- a/prismor/runtime/deps.py
+++ b/prismor/runtime/deps.py
@@ -781,6 +781,58 @@ def check_lockfile_integrity(workspace: Path) -> List[Dict[str, Any]]:
     return findings
 
 
+def check_against_ioc(deps: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+    """Match dependencies against the bundled supply-chain IOC database
+    (``supplychain.ioc``).
+
+    This is independent of the signed advisory feed. The feed currently ships
+    zero ``dependency_vulnerability`` advisories, so without this `prismor deps`
+    could never flag a known-malicious package (e.g. ``mistralai==2.4.6``,
+    ``@mistralai/mistralai`` in the mini-Shai-Hulud range) even though Prismor
+    curates exactly those IOCs. Results are shaped like ``check_against_feed``
+    matches so all existing rendering and exit-code logic applies unchanged.
+    """
+    try:
+        from supplychain.ioc import check_package
+    except Exception:
+        return []
+
+    def _exact_version(raw: str) -> Optional[str]:
+        # A concrete pinned version enables the CRITICAL exact-range check.
+        # pip keeps its operator ("==2.4.6"); npm stores a bare version.
+        # Anything floating/range (>=, ~=, ^, *, a git url) -> None -> the
+        # name-only (HIGH) IOC verdict rather than a bogus range comparison.
+        v = (raw or "").strip()
+        m = re.match(r"^==\s*([0-9][\w.\-+]*)$", v)
+        if m:
+            return m.group(1)
+        if re.match(r"^[0-9][\w.\-+]*$", v):
+            return v
+        return None
+
+    matches: List[Dict[str, Any]] = []
+    for dep in deps:
+        name = dep.get("name", "")
+        if not name:
+            continue
+        raw_version = str(dep.get("version", ""))
+        exact = _exact_version(raw_version)
+        hit = check_package(name, exact)
+        if not hit:
+            continue
+        shown = exact or raw_version
+        matches.append({
+            "advisory_id": hit.ioc_id,
+            "severity": str(hit.severity).lower(),
+            "title": hit.description,
+            "affected": f"{name}@{shown}" if shown else name,
+            "action": "Remove this package or pin to a known-safe version.",
+            "matched_deps": [dep],
+            "source": "ioc",
+        })
+    return matches
+
+
 def scan_workspace(
     workspace: Path,
     feed: Dict[str, Any],
@@ -799,6 +851,16 @@ def scan_workspace(
         all_deps.extend(deps)
 
     feed_matches = check_against_feed(all_deps, feed)
+    # The signed feed carries no dependency_vulnerability advisories today, so
+    # also consult the bundled IOC database directly. Dedup by (id, dep name)
+    # in case a future feed and the IOC list name the same compromise.
+    _seen = {(m.get("advisory_id"), d.get("name"))
+             for m in feed_matches for d in m.get("matched_deps", [])}
+    for m in check_against_ioc(all_deps):
+        key = (m.get("advisory_id"), m["matched_deps"][0].get("name"))
+        if key not in _seen:
+            feed_matches.append(m)
+            _seen.add(key)
     lockfile_issues = check_lockfile_presence(workspace)
     integrity_issues = check_lockfile_integrity(workspace)
     floating_ranges = check_floating_ranges(workspace, lockfile_map)

--- a/tests/test_deps_semver.py
+++ b/tests/test_deps_semver.py
@@ -105,3 +105,38 @@ def test_parse_package_json_uses_lockfile_pin(tmp_path: Path) -> None:
         "range": "^4.17.0",
         "pinned_via_lock": True,
     }]
+
+
+# ── IOC database wiring (independent of the signed advisory feed) ────────────
+# Regression: the shipped feed carries 0 dependency_vulnerability advisories,
+# so `prismor deps` matched nothing. It now also consults supplychain.ioc, so a
+# known-malicious pinned package is flagged even with an empty feed.
+
+def test_deps_flags_known_ioc_with_empty_feed(tmp_path):
+    (tmp_path / "requirements.txt").write_text(
+        "requests==2.31.0\nmistralai==2.4.6\nguardrails-ai==0.10.1\n"
+    )
+    result = scan_workspace(tmp_path, feed={"advisories": []})
+    matched = {m["matched_deps"][0]["name"]: m for m in result["feed_matches"]}
+    assert "mistralai" in matched, result["feed_matches"]
+    assert "guardrails-ai" in matched
+    # exact pip pin -> CRITICAL exact-version match, not a name-only HIGH
+    assert matched["mistralai"]["severity"] == "critical"
+    assert "2.4.6" in matched["mistralai"]["affected"]
+
+
+def test_deps_ioc_no_false_positive_on_safe_version(tmp_path):
+    # 2.4.5 is the legitimate release; only 2.4.6 is compromised.
+    (tmp_path / "requirements.txt").write_text("requests==2.31.0\nmistralai==2.4.5\n")
+    result = scan_workspace(tmp_path, feed={"advisories": []})
+    assert result["feed_matches"] == [], result["feed_matches"]
+
+
+def test_deps_flags_ioc_npm_range(tmp_path):
+    (tmp_path / "package.json").write_text(json.dumps({
+        "name": "fixture", "version": "0.0.0",
+        "dependencies": {"@mistralai/mistralai": "2.2.4"},
+    }))
+    result = scan_workspace(tmp_path, feed={"advisories": []})
+    names = {m["matched_deps"][0]["name"] for m in result["feed_matches"]}
+    assert "@mistralai/mistralai" in names, result["feed_matches"]


### PR DESCRIPTION
## Summary

`prismor deps` — whose entire job is "check workspace dependencies against the threat feed" — **never matched anything**, because the shipped signed feed (`advisories/immunity-feed.json`) contains **217 advisories but 0 of type `dependency_vulnerability`**. Meanwhile Prismor curates a rich IOC database in `supplychain/ioc.py` (the TanStack / mini-Shai-Hulud / AntV supply-chain attacks). The two were never connected.

So a manifest pinning a **known-malicious** package Prismor itself documents was reported clean:

**Before** — `requirements.txt` with `mistralai==2.4.6` + `guardrails-ai==0.10.1` (both curated IOCs), `package.json` with `@mistralai/mistralai@2.2.4` → only a missing-lockfile nag:

![deps before](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/deps-before.png)

**After** — the same manifests, all three flagged **CRITICAL** with attack attribution:

![deps after](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/cloak-fix/img/deps-after.png)

## Fix

`scan_workspace()` now also consults the bundled `supplychain.ioc` via a new `check_against_ioc()`, independent of the signed feed (no signing key needed, always present). Matches are shaped exactly like feed matches, so all rendering, JSON output, and the exit-code=1 behavior are unchanged; deduped by `(advisory_id, dep name)`.

An exact pip pin (`==2.4.6`) is normalized to its concrete version so it hits the **CRITICAL exact-range** verdict instead of degrading to a name-only HIGH. Floating specifiers (`>=`, `~=`, `^`) still fall back to name-only.

## Testing

- **0 → 3 CRITICAL** findings on the repro manifests.
- Negative control: the legitimate adjacent release `mistralai==2.4.5` stays **clean** (no false positive).
- 3 regression tests added to `tests/test_deps_semver.py` (empty-feed IOC match; no-FP on safe version; npm range). Full file: **11 passed**.

> Screenshots are real captures on the throwaway `pr-assets/cloak-fix` branch (not part of this diff).
