### PR TITLE
semantic-check: fail fast on a tty instead of hanging on stdin

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -864,9 +864,20 @@ def main(argv: Optional[List[str]] = None) -> None:
     if args.command == "semantic-check":
         text = args.text
         if not text:
+            # Only fall back to stdin when something is actually piped in.
+            # On an interactive terminal `sys.stdin.read()` blocks forever, so
+            # a bare `prismor semantic-check` (or an empty-string argument)
+            # would hang with no prompt and no hint. Fail fast with usage.
+            if sys.stdin.isatty():
+                sys.stderr.write(
+                    "error: no text provided\n"
+                    "  pass it as an argument:  prismor semantic-check \"<text>\"\n"
+                    "  or pipe it via stdin:     echo \"<text>\" | prismor semantic-check\n"
+                )
+                raise SystemExit(1)
             text = sys.stdin.read()
         if not text or not text.strip():
-            sys.stderr.write("error: no text provided (pass as argument or pipe via stdin)\n")
+            sys.stderr.write("error: no text provided (pass as an argument or pipe via stdin)\n")
             raise SystemExit(1)
 
         mode = args.mode

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -534,5 +534,39 @@ class TestPolicyExport(unittest.TestCase):
         self.assertIn("export", r.stderr)
 
 
+
+def test_semantic_check_empty_piped_stdin_errors_fast():
+    """Empty piped input is a fast, clean error — never a hang."""
+    r = run_cli("semantic-check", stdin=subprocess.DEVNULL)
+    assert r.returncode == 1
+    assert "no text provided" in r.stderr
+
+
+def test_semantic_check_on_a_tty_does_not_hang():
+    """Regression: a bare `prismor semantic-check` on an interactive terminal
+    used to fall through to sys.stdin.read() and block forever. With a real tty
+    on stdin and nothing typed, it must fail fast with usage, not hang."""
+    import os, pty
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, CLI, "semantic-check"],
+            stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        os.close(slave)
+        try:
+            _, err = proc.communicate(timeout=15)  # old code hangs -> TimeoutExpired
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise AssertionError("semantic-check hung on a tty with no input")
+        assert proc.returncode == 1
+        assert "no text provided" in err
+    finally:
+        try:
+            os.close(master)
+        except OSError:
+            pass
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A bare `prismor semantic-check` on an interactive terminal **hangs**. Reported as "semantic-check shows an error."

`text = args.text; if not text: text = sys.stdin.read()` — with no argument (or an empty-string argument, which is falsy) it falls through to `sys.stdin.read()`, which blocks until EOF. On a real terminal with nobody piping input, the command just sits there with no prompt and no hint; the only way out is Ctrl-D, which then prints `error: no text provided`. Either way it reads as the tool being broken.

Proven with a real pty (no input sent):

```
OLD: HUNG — still waiting on stdin after 5.0s
NEW: errored fast in 0.3s
```

## Fix

Guard the stdin fallback with `sys.stdin.isatty()` — the same pattern `prismor unlock` already uses. When stdin is a terminal and no text was passed, print usage and exit 1 immediately:

```
$ prismor semantic-check
error: no text provided
  pass it as an argument:  prismor semantic-check "<text>"
  or pipe it via stdin:     echo "<text>" | prismor semantic-check
```

Piping (`echo … | prismor semantic-check`) and the positional-argument path are unchanged.

## Testing

- New pty regression test: a bare invocation on a tty errors fast, never hangs (would hit `subprocess.TimeoutExpired` against the old code).
- Fast-error path for empty piped stdin.
- Both in `tests/test_cli.py`; verified on st3ve that piped/arg invocations still analyze normally.
