### PR TITLE
sec(deps): floor idna at >=3.15 (GHSA-65pc-fj4g-8rjx)

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.34.2
 jsonschema==4.21.1
+idna>=3.15  # sec: GHSA-65pc-fj4g-8rjx / PYSEC-2026-215 — idna.encode() bypass of the CVE-2024-3651 fix; pulled transitively by requests


### PR DESCRIPTION
### Summary

`osv-scanner` flags **idna 3.9.0** in the resolved dependency set (pulled transitively by `requests`): [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) / [PYSEC-2026-215](https://osv.dev/PYSEC-2026-215) — specially crafted input to `idna.encode()` bypasses the CVE-2024-3651 fix (CVSS 6.9). Fixed in **idna 3.15**.

idna is not pinned, so this adds an explicit floor `idna>=3.15` to `pipeline/requirements.txt`. It is compatible with the existing `requests==2.34.2` pin (its range is `idna<4,>=2.5`).

### Verification (Python 3.13)
- `pip install --dry-run` resolves cleanly: `requests==2.34.2`, `idna==3.19`, `jsonschema==4.21.1`.
- `osv-scanner` on the requirements: **1 Medium finding → 0** with the floor added.

Found by commitwork.