### PR TITLE
scoped-agent: see through the MCP gateway to its upstreams

### DIFF
--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -130,6 +130,58 @@ def _mcp_server_names_in(obj: Any) -> List[str]:
     return [str(k) for k in servers.keys() if isinstance(k, str) and k]
 
 
+def _gateway_upstreams(entry, home):
+    """If an MCP server entry is the Prismor mcp-gateway, return its upstream
+    server names (read from the gateway config); else None. The gateway
+    aggregates every upstream under ONE server name, so scoping must see
+    through it to the upstreams -- otherwise the only family is
+    ``mcp__<gateway>__*`` and no task prompt ever names it, so every gatewayed
+    MCP tool is denied by omission."""
+    if not isinstance(entry, dict):
+        return None
+    args = entry.get("args") or []
+    argv = " ".join(str(a) for a in args)
+    if "mcp-gateway" not in argv:
+        return None
+    cfg = None
+    for i, a in enumerate(args):
+        if str(a) == "--config" and i + 1 < len(args):
+            cfg = Path(str(args[i + 1])); break
+    if cfg is None:
+        cfg = home / ".prismor" / "mcp-gateway.json"
+    return _mcp_server_names_in(_read_json(cfg)) or []
+
+
+def _gateway_expansion(workspace, agent, home):
+    """Map each gateway family ``mcp__<gw>__*`` to its per-upstream families
+    ``mcp__<gw>__<upstream>__*``, so per-server token matching still works."""
+    out = {}
+    def scan(mcp):
+        if not isinstance(mcp, dict):
+            return
+        for name, entry in mcp.items():
+            ups = _gateway_upstreams(entry, home)
+            if ups:
+                out[mcp_family_for_server(name)] = [
+                    mcp_family_for_server(f"{name}__{u}") for u in ups
+                ]
+    try:
+        scan((_read_json(workspace / ".mcp.json") or {}).get("mcpServers"))
+        if agent in ("claude", "claude-code", "claude_code"):
+            cfg = _read_json(home / ".claude.json")
+            if isinstance(cfg, dict):
+                scan(cfg.get("mcpServers"))
+                projects = cfg.get("projects")
+                if isinstance(projects, dict):
+                    ws = str(workspace.resolve())
+                    for pth, proj in projects.items():
+                        if isinstance(proj, dict) and (pth == ws or ws.startswith(pth.rstrip("/") + "/")):
+                            scan(proj.get("mcpServers"))
+    except Exception:
+        pass
+    return out
+
+
 def discover_mcp_families(workspace: Path, agent: str = "claude") -> List[str]:
     """Best-effort inventory of the MCP servers this agent can reach, as
     ``mcp__<server>__*`` families. Cheap on purpose (a handful of JSON reads —
@@ -180,6 +232,13 @@ def discover_mcp_families(workspace: Path, agent: str = "claude") -> List[str]:
                             _add(f"plugin:{plugin}:{name}")
     except Exception:
         pass
+    expansion = _gateway_expansion(workspace, agent, Path.home())
+    if expansion:
+        expanded = []
+        for fam in families:
+            expanded.extend(expansion.get(fam, [fam]))
+        # de-dupe, preserve order
+        seen2 = set(); families = [f for f in expanded if not (f in seen2 or seen2.add(f))]
     return families
 
 
@@ -447,7 +506,7 @@ def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, A
     # MCP tool families: allow a family when the prompt names its server
     # ("query posthog for ..." → mcp__plugin_posthog_posthog__*).
     for fam in available_tools:
-        if is_mcp_family(fam) and any(tok in goal_lower for tok in _mcp_family_tokens(fam)):
+        if is_mcp_tool(fam) and any(tok in goal_lower for tok in _mcp_family_tokens(fam)):
             allowed.add(fam)
             deny_network = False
 

--- a/tests/test_scoped_gateway.py
+++ b/tests/test_scoped_gateway.py
@@ -1,0 +1,77 @@
+"""Scoped agent must see through the Prismor MCP gateway to its upstreams.
+
+The gateway aggregates every upstream MCP server under ONE server name, so the
+only family discovery produced was ``mcp__prismor__*`` — token "prismor", which
+no natural task prompt names. In static mode (no ANTHROPIC_API_KEY) that meant
+every gatewayed MCP tool was denied by omission, whatever the task asked for.
+
+The fix: ``discover_mcp_families`` expands a gateway server into per-upstream
+families (``mcp__prismor__notes__*``), and ``_static_fallback_rules`` matches
+individual MCP tools, not only ``__*`` families.
+"""
+from __future__ import annotations
+
+import json
+
+from prismor.runtime.scoped_agent import (
+    _static_fallback_rules,
+    _tool_matches,
+    discover_mcp_families,
+)
+
+
+def test_static_fallback_allows_upstream_named_in_goal():
+    fam = "mcp__prismor__notes__*"  # gateway-expanded family for the notes upstream
+    rules = _static_fallback_rules("get the release notes", [fam])
+    assert fam in rules["allowed_tools"]
+    # the concrete tool the gateway exposes is covered by the allowed family
+    assert _tool_matches("mcp__prismor__notes__fetch_notes", rules["allowed_tools"])
+    assert rules["deny_network"] is False
+
+
+def test_static_fallback_denies_unrelated_upstream():
+    notes, pay = "mcp__prismor__notes__*", "mcp__prismor__payments__*"
+    rules = _static_fallback_rules("get the release notes", [notes, pay])
+    assert notes in rules["allowed_tools"]
+    assert pay in rules["deny_tools"]  # payments never named → denied
+    assert not _tool_matches("mcp__prismor__payments__charge_card", rules["allowed_tools"])
+
+
+def test_static_fallback_matches_individual_mcp_tool():
+    # even without family expansion, an individual gatewayed tool is matched by
+    # its own name tokens (regression: the loop used to skip non-``__*`` tools).
+    tool = "mcp__prismor__notes__fetch_notes"
+    rules = _static_fallback_rules("fetch the notes", [tool])
+    assert tool in rules["allowed_tools"]
+
+
+def test_gateway_discovery_expands_to_upstream_families(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".prismor").mkdir(parents=True)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    cfg = home / ".prismor" / "mcp-gateway.json"
+    cfg.write_text(json.dumps({"mcpServers": {
+        "notes": {"command": "python3", "args": ["notes.py"]},
+        "payments": {"command": "python3", "args": ["pay.py"]},
+    }}))
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": {
+        "prismor": {"command": "prismor",
+                    "args": ["mcp-gateway", "--config", str(cfg)]},
+    }}))
+    # keep it hermetic: no real ~/.claude.json for the claude branch
+    import prismor.runtime.scoped_agent as sa
+    monkeypatch.setattr(sa.Path, "home", staticmethod(lambda: home))
+
+    fams = discover_mcp_families(ws)
+    assert "mcp__prismor__notes__*" in fams
+    assert "mcp__prismor__payments__*" in fams
+    # the broad gateway family is replaced by the per-upstream ones
+    assert "mcp__prismor__*" not in fams
+
+
+if __name__ == "__main__":  # pragma: no cover - quick self-check
+    test_static_fallback_allows_upstream_named_in_goal()
+    test_static_fallback_denies_unrelated_upstream()
+    test_static_fallback_matches_individual_mcp_tool()
+    print("ok")


### PR DESCRIPTION
## Problem

The MCP gateway (`prismor mcp-gateway`) aggregates every upstream server behind a single connector, so its tools all land under one server namespace — `mcp__prismor__*` (token `prismor`). The scoped-agent's per-session allowlist matches tool families by the tokens a task prompt actually names, and no natural prompt says "prismor."

In **static mode** (no `ANTHROPIC_API_KEY`, so no LLM synthesis) that meant every gatewayed MCP tool was denied by omission — a session that legitimately needed `fetch_notes` could never call it, and because the call was blocked before dispatch, it never even reached the gateway's own result-injection scanning. The gateway's whole value (scan upstream results, withhold poisoned ones) was unreachable behind the scoped agent.

## Fix

- `discover_mcp_families` now detects a Prismor gateway server (its args contain `mcp-gateway`), reads the gateway's `--config`, and expands the single aggregate family into **per-upstream families** (`mcp__prismor__notes__*`, …) so per-server token matching works again.
- `_static_fallback_rules` now matches individual MCP tools, not only `__*` families — the loop previously skipped any tool name that didn't end in `__*`.

## Tests

`tests/test_scoped_gateway.py` (new, 4 cases): static allow of an upstream named in the goal, static deny of an unrelated upstream, individual-MCP-tool match, and gateway discovery expanding to per-upstream families. The 40 existing scope tests still pass.

Surfaced while recording a gateway demo: the scoped agent was silently the thing blocking `fetch_notes`, not the gateway.
