### PR TITLE
fix(mcp): make the gateway and the mirror survive being used together

### DIFF
--- a/prismor/runtime/mcp_gateway.py
+++ b/prismor/runtime/mcp_gateway.py
@@ -824,19 +824,26 @@ class Gateway:
             "tools/call", {"name": route.tool, "arguments": arguments},
             timeout=CALL_TIMEOUT)
 
-        # Mirrored built-ins execute inside Prismor, so their output can be
-        # *repaired* rather than only refused: strip credential material before
-        # the model sees it. This is the capability a PreToolUse hook cannot
-        # have — a hook sees the request, never the file contents — and it is
-        # why a secret hardcoded in ordinary source (not just .env) stops
-        # leaking. Redact before scanning so the scan sees what the model will.
-        if route.upstream.spec.local:
-            # Cloak masking runs even while paused: `prismor pause` suspends
-            # ENFORCEMENT, and the hook-layer scrubber does not consult pause
-            # either, so a paused mirror must not start pushing raw secret
-            # values into the model's context. Data-boundary redaction IS
-            # policy, so it goes with the rest of enforcement.
-            result = self._redact_result(result, data_boundary=not passthrough)
+        # The gateway holds the response, so its output can be *repaired*
+        # rather than only refused: strip credential material before the model
+        # sees it. This is the capability a PreToolUse hook cannot have — a hook
+        # sees the request, never the file contents — and it is why a secret
+        # hardcoded in ordinary source (not just .env) stops leaking. Redact
+        # before scanning so the scan sees what the model will.
+        #
+        # This applies to EVERY upstream, not only the mirrored built-ins. A
+        # filesystem MCP server reading .env is the same leak through a
+        # different door, and gating on `spec.local` meant putting a server
+        # behind the gateway left it leaking while the mirror's own Read of the
+        # same file came back masked. Redaction is best-effort by contract
+        # (see runtime/redaction.py) and never fails a call closed.
+        #
+        # Cloak masking runs even while paused: `prismor pause` suspends
+        # ENFORCEMENT, and the hook-layer scrubber does not consult pause
+        # either, so a paused gateway must not start pushing raw secret values
+        # into the model's context. Data-boundary redaction IS policy, so it
+        # goes with the rest of enforcement.
+        result = self._redact_result(result, data_boundary=not passthrough)
 
         # Post-call: the response is untrusted content — scan before the model
         # ever sees it (prompt injection, poisoned tool output, secrets).
@@ -941,7 +948,7 @@ class Gateway:
             result, workspace=self.workspace, data_boundary=data_boundary)
         if changed:
             sys.stderr.write(
-                "[prismor-gateway] redacted sensitive values from mirrored tool output\n")
+                "[prismor-gateway] redacted sensitive values from tool output\n")
         return out
 
     def _egress_guard(self, spec: UpstreamSpec) -> None:
@@ -1224,6 +1231,14 @@ def _gateway_entry(mode: str = "enforce") -> Dict[str, Any]:
                      "--mode", mode]}
 
 
+def _is_prismor_entry(name: str, spec: Any) -> bool:
+    """Is this .mcp.json entry Prismor itself (the gateway or the mirror)?"""
+    if name == "prismor":
+        return True
+    args = (spec.get("args") if isinstance(spec, dict) else None) or []
+    return "mcp-gateway" in [str(a) for a in args if isinstance(a, (str, int))]
+
+
 def _absorb(servers: Dict[str, Any]) -> int:
     """Merge servers into the gateway config. Returns how many moved."""
     DEFAULT_GATEWAY_CONFIG.parent.mkdir(parents=True, exist_ok=True)
@@ -1274,8 +1289,18 @@ def migrate_config(path: Path, mode: str = "enforce") -> MigrationResult:
             detail="no recognised MCP server block (mcpServers/servers)")
 
     servers = data[key]
-    if list(servers.keys()) == ["prismor"]:
-        return MigrationResult(path, "skipped", detail="already behind the gateway")
+    # Prismor's own entries are not upstreams. The mirror (`prismor mirror on`)
+    # is a sibling surface, not a third-party server: absorbing it would nest a
+    # gateway inside a gateway and rename its tools to
+    # ``mcp__prismor__prismor-tools__Bash``, orphaning every permission and
+    # `enabledMcpjsonServers` entry `mirror on` just wrote. Whichever command
+    # runs second must leave the other alone.
+    keep = {name: spec for name, spec in servers.items() if _is_prismor_entry(name, spec)}
+    servers = {name: spec for name, spec in servers.items() if name not in keep}
+    if not servers:
+        return MigrationResult(path, "skipped",
+                               detail="already behind the gateway"
+                               if keep else "nothing to move")
 
     moved = _absorb(servers)
     if not moved:
@@ -1289,7 +1314,7 @@ def migrate_config(path: Path, mode: str = "enforce") -> MigrationResult:
         # trade for governing a server.
         return MigrationResult(path, "failed", detail=f"could not write backup: {exc}")
 
-    data[key] = {"prismor": _gateway_entry(mode)}
+    data[key] = {"prismor": _gateway_entry(mode), **keep}
     try:
         path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     except OSError as exc:
@@ -1332,9 +1357,23 @@ def install_gateway(workspace: Path, mode: str = "enforce") -> str:
         if "already behind the gateway" in result.detail:
             return "Gateway already installed (only the prismor entry remains)."
         return f"{mcp_json} has no mcpServers — nothing to install."
+    # A server declared in a project .mcp.json does not load until a human
+    # approves it, and the servers we just moved WERE approved under their own
+    # names — which no longer exist. Without carrying that approval over to the
+    # gateway, install silently downgrades a working set of MCP servers to none
+    # until the developer clicks through a dialog they were never told about.
+    # Same reasoning, same mechanism, as `prismor mirror on`.
+    note = ""
+    try:
+        from prismor.runtime.mirror_cli import _approve_project_server
+        ok, detail = _approve_project_server(workspace, "prismor")
+        if not ok:
+            note = f"\nApprove it in your agent to activate: {detail}"
+    except Exception:
+        note = "\nApprove the `prismor` server in your agent to activate it."
     return (f"Moved {result.moved} server(s) into {DEFAULT_GATEWAY_CONFIG}.\n"
             f"{mcp_json} now routes through the Prismor gateway "
-            f"(backup: {mcp_json.with_suffix('.json.bak')}).")
+            f"(backup: {mcp_json.with_suffix('.json.bak')}).{note}")
 
 
 def uninstall_gateway(workspace: Path) -> str:

--- a/prismor/runtime/redaction.py
+++ b/prismor/runtime/redaction.py
@@ -100,15 +100,24 @@ def redact_mcp_result(
 ) -> Tuple[Any, bool]:
     """Redact the text blocks of an MCP ``tools/call`` result.
 
-    Only ``content[].text`` is touched: other block kinds (images, resource
-    links) are returned untouched rather than guessed at, and a result that is
-    not shaped like an MCP result passes through unchanged.
+    Only ``content[].text`` and ``structuredContent`` are touched: other block
+    kinds (images, resource links) are returned untouched rather than guessed
+    at, and a result that is not shaped like an MCP result passes through
+    unchanged.
+
+    ``structuredContent`` matters as much as ``content``. Servers built on the
+    MCP SDK's output schemas return the same payload twice, and a client that
+    prefers the structured copy would be handed the very credential the text
+    copy just had masked out.
     """
     if not isinstance(result, dict):
         return result, False
     content = result.get("content")
+    structured = result.get("structuredContent")
     if not isinstance(content, list):
-        return result, False
+        if structured is None:
+            return result, False
+        content = []
 
     changed = False
     out: List[Any] = []
@@ -123,6 +132,48 @@ def redact_mcp_result(
             block = {**block, "text": text}
         out.append(block)
 
+    structured_out = structured
+    if structured is not None:
+        structured_out, hit = _redact_tree(
+            structured, workspace=workspace, data_boundary=data_boundary)
+        changed = changed or hit
+
     if not changed:
         return result, False
-    return {**result, "content": out}, True
+    new = {**result}
+    if result.get("content") is not None:
+        new["content"] = out
+    if structured is not None:
+        new["structuredContent"] = structured_out
+    return new, True
+
+
+def _redact_tree(
+    node: Any,
+    *,
+    workspace: Optional[Path] = None,
+    data_boundary: bool = True,
+) -> Tuple[Any, bool]:
+    """Redact every string in a JSON tree. Keys are left alone — a credential
+    lives in a value, and rewriting keys would break the schema the client is
+    parsing against."""
+    if isinstance(node, str):
+        return redact_text(node, workspace=workspace, data_boundary=data_boundary)
+    if isinstance(node, dict):
+        out: Dict[str, Any] = {}
+        changed = False
+        for key, value in node.items():
+            out[key], hit = _redact_tree(
+                value, workspace=workspace, data_boundary=data_boundary)
+            changed = changed or hit
+        return (out, True) if changed else (node, False)
+    if isinstance(node, list):
+        items = []
+        changed = False
+        for value in node:
+            item, hit = _redact_tree(
+                value, workspace=workspace, data_boundary=data_boundary)
+            items.append(item)
+            changed = changed or hit
+        return (items, True) if changed else (node, False)
+    return node, False

--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -130,6 +130,31 @@ def _mcp_server_names_in(obj: Any) -> List[str]:
     return [str(k) for k in servers.keys() if isinstance(k, str) and k]
 
 
+def _gateway_inner_servers(spec: Any) -> List[str]:
+    """Servers a ``prismor mcp-gateway`` entry fronts, or [].
+
+    Once `prismor mcp-gateway install` runs, ``.mcp.json`` lists one server —
+    ``prismor`` — and the real ones move into the gateway config. The gateway
+    namespaces their tools as ``<server>__<tool>``, so the family a scope needs
+    is ``mcp__prismor__filesystem__*``, not ``mcp__prismor__*``. Without this
+    the only word a scope could match on is "prismor", so no ordinary prompt
+    ("read it with the filesystem tool") ever widens the scope to reach them.
+    """
+    if not isinstance(spec, dict):
+        return []
+    args = [str(a) for a in spec.get("args", []) if isinstance(a, (str, int))]
+    if "mcp-gateway" not in args or "--mirror" in args:
+        return []
+    cfg = None
+    if "--config" in args:
+        idx = args.index("--config")
+        if idx + 1 < len(args):
+            cfg = Path(args[idx + 1])
+    if cfg is None:
+        cfg = Path.home() / ".prismor" / "mcp-gateway.json"
+    return _mcp_server_names_in(_read_json(cfg))
+
+
 def discover_mcp_families(workspace: Path, agent: str = "claude") -> List[str]:
     """Best-effort inventory of the MCP servers this agent can reach, as
     ``mcp__<server>__*`` families. Cheap on purpose (a handful of JSON reads —
@@ -147,8 +172,18 @@ def discover_mcp_families(workspace: Path, agent: str = "claude") -> List[str]:
     try:
         home = Path.home()
         # Workspace-level .mcp.json (Claude Code, Codex, Cursor share the shape).
-        for name in _mcp_server_names_in(_read_json(workspace / ".mcp.json")):
-            _add(name)
+        ws_cfg = _read_json(workspace / ".mcp.json")
+        ws_servers = ws_cfg.get("mcpServers", ws_cfg) if isinstance(ws_cfg, dict) else {}
+        for name in _mcp_server_names_in(ws_cfg):
+            inner = _gateway_inner_servers(
+                ws_servers.get(name) if isinstance(ws_servers, dict) else None)
+            # The gateway serves no tools of its own. Registering the bare
+            # family alongside the expanded ones would deny every fronted tool
+            # by glob even when the specific family is allowed.
+            for sub in inner:
+                _add(f"{name}__{sub}")
+            if not inner:
+                _add(name)
         if agent in ("claude", "claude-code", "claude_code"):
             cfg = _read_json(home / ".claude.json")
             if isinstance(cfg, dict):
@@ -594,6 +629,15 @@ def check_scoped_rules(
         # it (e.g. allowed_tools:[Read,Edit] + deny_tools:[Write] blocks Write).
         # Entries may be globs — ``mcp__posthog__*`` covers every tool of that
         # MCP server.
+        # ...except by a blanket family glob. A scope is synthesised from the
+        # user's goal, which never names the mirror's server, so both the LLM
+        # and the static fallback (which denies everything not allowed) put
+        # ``mcp__prismor-tools__*`` in deny_tools — denying the very built-ins
+        # the same scope allows by native name, leaving the agent with no tools
+        # at all. A mirrored built-in is therefore judged by its native tag
+        # unless the operator denied that exact MCP tag.
+        if alias and _tool_matches(alias, allowed):
+            denied = [e for e in denied if "*" not in str(e)]
         if any(_tool_matches(t, denied) for t in tags):
             return _scoped_finding(
                 session_id,

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -668,3 +668,78 @@ def test_install_mode_observe_is_honoured(tmp_path, monkeypatch):
     install_gateway(ws, mode="observe")
     args = json.loads((ws / ".mcp.json").read_text())["mcpServers"]["prismor"]["args"]
     assert args[args.index("--mode") + 1] == "observe"
+
+
+def test_install_leaves_the_mirror_alone(tmp_path, monkeypatch):
+    """`mirror on` then `mcp-gateway install` must not absorb the mirror.
+
+    Nesting it renames its tools to ``mcp__prismor__prismor-tools__Bash``,
+    orphaning the permissions and `enabledMcpjsonServers` entry `mirror on`
+    wrote — the agent is left with no built-ins at all.
+    """
+    monkeypatch.setattr(gw_mod, "DEFAULT_GATEWAY_CONFIG", tmp_path / "gw.json")
+    ws = tmp_path / "ws"; ws.mkdir()
+    mirror_entry = {"command": "python3",
+                    "args": ["-m", "prismor.runtime.immunity_cli", "mcp-gateway",
+                             "--mirror", "--mode", "enforce"]}
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": {
+        "notes": {"command": "python3", "args": ["notes.py"]},
+        "prismor-tools": mirror_entry,
+    }}))
+    install_gateway(ws)
+    servers = json.loads((ws / ".mcp.json").read_text())["mcpServers"]
+    assert servers["prismor-tools"] == mirror_entry      # untouched, still top-level
+    assert "prismor" in servers                           # gateway added alongside
+    downstream = json.loads((tmp_path / "gw.json").read_text())["mcpServers"]
+    assert set(downstream) == {"notes"}
+
+
+def test_install_is_idempotent_with_the_mirror_present(tmp_path, monkeypatch):
+    """A second run has only Prismor's own entries left and must not re-migrate."""
+    monkeypatch.setattr(gw_mod, "DEFAULT_GATEWAY_CONFIG", tmp_path / "gw.json")
+    ws = tmp_path / "ws"; ws.mkdir()
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": {
+        "notes": {"command": "python3", "args": ["notes.py"]},
+        "prismor-tools": {"command": "python3", "args": ["mcp-gateway", "--mirror"]},
+    }}))
+    install_gateway(ws)
+    before = (ws / ".mcp.json").read_text()
+    install_gateway(ws)
+    assert (ws / ".mcp.json").read_text() == before
+
+
+def test_install_carries_the_mcp_approval_over_to_the_gateway(tmp_path, monkeypatch):
+    """The migrated servers were approved under names that no longer exist; the
+    gateway must inherit that approval or the agent loads no MCP servers at all."""
+    monkeypatch.setattr(gw_mod, "DEFAULT_GATEWAY_CONFIG", tmp_path / "gw.json")
+    ws = tmp_path / "ws"; ws.mkdir()
+    (ws / ".mcp.json").write_text(json.dumps({"mcpServers": {
+        "notes": {"command": "python3", "args": ["notes.py"]}}}))
+    install_gateway(ws)
+    local = json.loads((ws / ".claude" / "settings.local.json").read_text())
+    assert "prismor" in local["enabledMcpjsonServers"]
+
+
+def test_downstream_results_are_redacted_too(tmp_path, monkeypatch):
+    """A filesystem MCP server reading .env is the same leak as a mirrored Read.
+
+    Gating redaction on `spec.local` meant putting a server behind the gateway
+    left it leaking raw credentials while the mirror's own Read of the same
+    file came back masked — one file, two verdicts, and the "guarded" door was
+    the leaky one.
+    """
+    secret = "sk_live_" + "0123456789abcdefXYZ"
+    fs = FakeUpstream(
+        UpstreamSpec(name="filesystem", command=["true"], transport="stdio"),
+        tools=[{"name": "read_text_file", "inputSchema": {"type": "object"}}],
+        results={"read_text_file": {
+            "content": [{"type": "text", "text": f"STRIPE_SECRET_KEY={secret}\n"}]}})
+    gateway, sent = make_gateway(tmp_path, monkeypatch, [fs])
+    allow_all(monkeypatch)
+    monkeypatch.setattr(gateway, "_redact_result",
+                        lambda result, **kw: {"content": [{"type": "text",
+                                                           "text": "[REDACTED:secret]"}]})
+    gateway._handle_tools_call_safe(
+        "R1", {"name": "filesystem__read_text_file", "arguments": {"path": ".env"}})
+    body = json.dumps(sent[-1])
+    assert secret not in body

--- a/tests/test_redaction_structured_content.py
+++ b/tests/test_redaction_structured_content.py
@@ -1,0 +1,47 @@
+"""An MCP result carries its payload twice; masking one copy is not masking.
+
+Servers built on the MCP SDK's output schemas return the same data as
+``content[].text`` AND as ``structuredContent``. Redacting only the text copy
+hands a client that prefers the structured one the raw credential.
+"""
+from prismor.runtime.redaction import redact_mcp_result
+
+SECRET = "sk_live_" + "0123456789abcdefXYZ"
+
+
+def test_structured_content_is_redacted_alongside_text():
+    result = {
+        "content": [{"type": "text", "text": f"STRIPE_SECRET_KEY={SECRET}"}],
+        "structuredContent": {"content": f"STRIPE_SECRET_KEY={SECRET}"},
+    }
+    out, changed = redact_mcp_result(result, data_boundary=True)
+    assert changed
+    assert SECRET not in str(out)
+
+
+def test_structured_content_alone_is_still_redacted():
+    """No text blocks at all — the structured copy is the only leak path."""
+    out, changed = redact_mcp_result(
+        {"structuredContent": {"rows": [{"key": SECRET}]}}, data_boundary=True)
+    assert changed
+    assert SECRET not in str(out)
+
+
+def test_structured_keys_survive_redaction():
+    """Values are masked; the schema the client parses against is not."""
+    out, _ = redact_mcp_result(
+        {"structuredContent": {"STRIPE_SECRET_KEY": SECRET}}, data_boundary=True)
+    assert list(out["structuredContent"]) == ["STRIPE_SECRET_KEY"]
+
+
+def test_clean_result_passes_through_untouched():
+    result = {"content": [{"type": "text", "text": "no secrets here"}],
+              "structuredContent": {"ok": True, "n": 3}}
+    out, changed = redact_mcp_result(result, data_boundary=True)
+    assert not changed and out is result
+
+
+def test_non_mcp_shapes_are_unchanged():
+    for value in ({}, {"foo": "bar"}, "text", None, 7):
+        out, changed = redact_mcp_result(value)
+        assert not changed and out == value

--- a/tests/test_scope_mirrored_builtins.py
+++ b/tests/test_scope_mirrored_builtins.py
@@ -88,3 +88,66 @@ def test_static_fallback_allows_read_only_discovery():
     for tool in ("Read", "Bash", "Glob", "Grep"):
         assert tool in rules["allowed_tools"], tool
     assert "Write" in rules["deny_tools"]
+
+
+# ── the family-glob regression ───────────────────────────────────────────────
+
+def test_family_glob_does_not_swallow_an_allowed_mirrored_builtin():
+    """The synthesiser never names the mirror's server, so every scope denies
+    ``mcp__prismor-tools__*`` — the static fallback denies everything it did
+    not allow, and the LLM lists the unknown family too. That blanket entry
+    must not cancel the built-ins the same scope allows by native name, or the
+    agent is left with no tools at all (verified live: Claude Code with
+    `prismor mirror on` could not read a file)."""
+    rules = {"allowed_tools": ["Bash", "Read", "Glob", "Grep"],
+             "deny_tools": ["Write", "Edit", "mcp__prismor-tools__*",
+                            "mcp__prismor__*"],
+             "allowed_paths": ["**"]}
+    assert check_scoped_rules(rules, _ev("mcp__prismor-tools__Bash")) is None
+    assert check_scoped_rules(rules, _ev("mcp__prismor-tools__Read", "file_read",
+                                         path="/x/y.py")) is None
+    # A built-in the scope did NOT allow stays denied.
+    assert check_scoped_rules(rules, _ev("mcp__prismor-tools__Write",
+                                         "file_write", path="/x/y.py")) is not None
+    # An ordinary MCP tool behind a denied family stays denied.
+    assert check_scoped_rules(rules, _ev("mcp__prismor__filesystem__read_text_file",
+                                         "file_read", path="/x/y.py")) is not None
+
+
+def test_exact_mcp_deny_still_beats_the_native_allow():
+    """Narrowing the fix must not disarm a deliberate per-server deny."""
+    rules = {"allowed_tools": ["Bash"],
+             "deny_tools": ["mcp__prismor-tools__Bash", "mcp__prismor-tools__*"],
+             "allowed_paths": ["**"]}
+    assert check_scoped_rules(rules, _ev("mcp__prismor-tools__Bash")) is not None
+
+
+# ── gateway-fronted servers stay reachable ───────────────────────────────────
+
+def test_gateway_fronted_servers_get_their_own_families(tmp_path):
+    """After `prismor mcp-gateway install` the workspace lists one server named
+    `prismor`, so the only token a scope could match was "prismor" — no natural
+    prompt widens to the servers behind it. Expand the gateway config instead."""
+    import json as _json
+    from prismor.runtime.scoped_agent import discover_mcp_families
+
+    gw = tmp_path / "gw.json"
+    gw.write_text(_json.dumps({"mcpServers": {"filesystem": {}, "memory": {}}}))
+    (tmp_path / ".mcp.json").write_text(_json.dumps({"mcpServers": {
+        "prismor": {"command": "prismor",
+                    "args": ["mcp-gateway", "--config", str(gw), "--mode", "enforce"]},
+        "prismor-tools": {"command": "python3",
+                          "args": ["-m", "x", "mcp-gateway", "--mirror"]},
+    }}))
+    fams = discover_mcp_families(tmp_path)
+    assert "mcp__prismor__filesystem__*" in fams
+    assert "mcp__prismor__memory__*" in fams
+    # The bare gateway family must not ride along: it would glob-deny the ones above.
+    assert "mcp__prismor__*" not in fams
+    # The mirror is not a fan-out point; it keeps its own family.
+    assert "mcp__prismor-tools__*" in fams
+
+
+def test_gateway_family_token_matches_the_fronted_server_name(tmp_path):
+    from prismor.runtime.scoped_agent import _mcp_family_tokens
+    assert "filesystem" in _mcp_family_tokens("mcp__prismor__filesystem__*")


### PR DESCRIPTION
Found by walking the documented setup end to end on a real box — `pip install`
→ `prismor setup` → `prismor mcp-gateway install` → `prismor mirror on` → a
live Claude Code session — rather than by reading the code.

Every one of these surfaces works **on its own**. Using the gateway and the
mirror **together**, which is what setup now offers in one wizard, silently
removed protection the install had just claimed to put in place. Four of the
five leave no error behind; the fifth leaks credentials.

### 1. Session scope denied the mirror — the agent got no tools at all

A scope is synthesised from the user's goal, which never names the mirror's
server, so both the LLM path and `_static_fallback_rules` (which denies
everything it did not allow) put `mcp__prismor-tools__*` in `deny_tools`.
Deny-first then cancelled the built-ins the same scope allowed by native name,
defeating the `native_alias` reconciliation already in `scoped_agent.py`.

A mirrored built-in is now judged by its native tag unless the operator denied
that **exact** MCP tag; a blanket family glob no longer swallows it. A
deliberate per-server deny still wins.

### 2. Session scope denied every gateway-fronted server

After `mcp-gateway install` the workspace lists one server, `prismor`, so the
only word `_mcp_family_tokens` could match on was "prismor" — no ordinary
prompt ("read it with the filesystem tool") ever widened the scope to the
servers behind it.

`discover_mcp_families` now expands the gateway config into per-server
families (`mcp__prismor__filesystem__*`). The bare gateway family is
deliberately **not** registered alongside them: it would glob-deny the very
servers it fronts.

### 3. `mcp-gateway install` absorbed the mirror

Running it after `mirror on` moved `prismor-tools` into the gateway's own
downstream config — a gateway nested inside a gateway, its tools renamed to
`mcp__prismor__prismor-tools__Bash`, orphaning every permission and
`enabledMcpjsonServers` entry `mirror on` had just written. Order of the two
commands mattered and neither warned.

Prismor's own entries are now left alone, whichever command runs second.

### 4. `mcp-gateway install` did not carry the MCP approval over

A project `.mcp.json` server does not load until a human approves it, and the
servers it had just migrated were approved under names that no longer existed.
So install silently downgraded a working set of MCP servers to none until the
developer clicked through a dialog they were never told about — the exact trap
`_approve_project_server`'s docstring describes for `mirror on`. It now uses
the same mechanism.

### 5. The gateway redacted only mirrored results

`spec.local` gated the credential masking, so a filesystem MCP server reading
`.env` handed the model raw secrets while the mirror's `Read` of the same file
came back masked — one file, two verdicts, and the "guarded" door was the leaky
one. `runtime/redaction.py`'s own docstring already names the gateway as a
surface that carries the response and should repair it.

Redaction (best-effort by contract, never fails a call closed) now runs for
every upstream, and covers `structuredContent` as well as `content[].text` —
servers built on the MCP SDK's output schemas return the payload twice, and
masking one copy is not masking.

## Verification

Reproduced and re-verified live on st3ve in an isolated `PRISMOR_HOME` against
a real Claude Code session with two real downstream MCP servers
(`server-filesystem`, `server-memory`):

- a hidden HTML-comment injection in a vendor doc is **withheld** by the
  gateway before the model sees it;
- `.env` read through the *downstream filesystem server* now comes back
  `[REDACTED:secret]` in both `content` and `structuredContent` (before this
  PR: raw);
- `curl … | bash` is blocked by the `remote-execution` floor rule through the
  mirrored `Bash`.

11 new regression tests. Baseline reds are unchanged — `test_mcp_gateway.py`
had 5 pre-existing failures, `test_mcp_guardrails.py` 1 and
`test_mcp_security.py` 1, before and after; the FAILED sets were diffed rather
than assumed.

## Note

`_gateway_entry` pinning `--mode enforce` is already on `main` but is not in
PyPI 1.43.0, so a gateway installed from the released package is observe-only
and forwards injections it has flagged. Worth a release alongside this.
