### PR TITLE
Redact tool results in the SDK adapters, not just screen the calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+### Fixed
+- **SDK adapters screen the call but never redacted the result.** A framework
+  agent whose tool returned a file with a hardcoded credential in it handed
+  that credential straight to the model. Every in-process adapter that holds
+  the tool's return value (LangChain/LangGraph, CrewAI, OpenAI Agents, Agno,
+  browser-use, Pydantic AI, Semantic Kernel, AutoGen Core's return leg) now
+  passes it through the shared `prismor.runtime.redaction` helper first, and
+  the Google ADK adapter gains `make_after_tool_callback()` for the same job.
+  Best-effort by contract: masking never raises and never fails a call closed.
+  BeeAI and the Claude Agent SDK hook only a pre-action event, so they see no
+  output to repair; each now says so where the others document the capability.
+  `contract.SURFACES` records `sdk-adapter` as `can_redact=True`.
+- The four adapter test modules errored at collection (`No module named
+  'prismor.langchain'`) from a source checkout, so none of the adapter tests
+  ran in CI. A `tests/conftest.py` extends `prismor.__path__` with each
+  bundled adapter shim, which is what the installed layout does anyway.
+
 ## [1.43.0] — 2026-08-20
 
 ### Added

--- a/adapters/agno/prismor_agno/__init__.py
+++ b/adapters/agno/prismor_agno/__init__.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from prismor.runtime.principal import Subject, resolve_subject
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.runtime import Decision, evaluate_tool_call
 
 __all__ = ["make_tool_hook", "prismor_tool_hook", "PrismorBlocked"]
@@ -98,7 +99,9 @@ def make_tool_hook(
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)
             raise RuntimeError(f"⛔ Prismor blocked this tool call: {reason}")
-        return function_call(**arguments)
+        # The hook chain hands back the tool's own return value: redact it
+        # here, the last point before Agno folds it into the model's context.
+        return redact_tool_result(function_call(**arguments), workspace=ws)
 
     return hook
 

--- a/adapters/agno/prismor_agno/__init__.py
+++ b/adapters/agno/prismor_agno/__init__.py
@@ -101,7 +101,8 @@ def make_tool_hook(
             raise RuntimeError(f"⛔ Prismor blocked this tool call: {reason}")
         # The hook chain hands back the tool's own return value: redact it
         # here, the last point before Agno folds it into the model's context.
-        return redact_tool_result(function_call(**arguments), workspace=ws)
+        return redact_tool_result(function_call(**arguments), workspace=ws,
+                                  engine=decision.engine)
 
     return hook
 

--- a/adapters/autogen-core/prismor_autogen_core/__init__.py
+++ b/adapters/autogen-core/prismor_autogen_core/__init__.py
@@ -32,9 +32,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from autogen_core import DefaultInterventionHandler, DropMessage, FunctionCall
+from autogen_core.models import FunctionExecutionResult
 from autogen_core.tool_agent import ToolException
 
 from prismor.runtime.principal import Subject, resolve_subject
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.runtime import Decision, evaluate_tool_call
 
 __all__ = ["PrismorInterventionHandler", "PrismorBlocked"]
@@ -130,4 +132,17 @@ class PrismorInterventionHandler(DefaultInterventionHandler):
                 content=f"⛔ Prismor blocked this tool call: {reason}",
                 name=message.name,
             )
+        return message
+
+    async def on_response(self, message: Any, *, sender: Any, recipient: Any) -> Any:
+        """Redact a tool's OUTPUT on the return leg.
+
+        ``on_send`` sees the request and can refuse it; the ToolAgent's reply
+        comes back through here as a ``FunctionExecutionResult`` whose
+        ``content`` is the raw tool output, on its way into the caller loop's
+        message list. That is where a credential in an allowed tool's result
+        would otherwise reach the model.
+        """
+        if isinstance(message, FunctionExecutionResult):
+            redact_tool_result(message, workspace=self._ws)
         return message

--- a/adapters/beeai/prismor_beeai/__init__.py
+++ b/adapters/beeai/prismor_beeai/__init__.py
@@ -16,6 +16,11 @@ checked carefully rather than assumed, after finding a *different*
 framework's documented "before execution" hook did NOT actually block in
 practice — see the Mastra adapter's notes.)
 
+RESULT REDACTION: not available here. The other adapters wrap the tool's
+entrypoint and so hold its return value; this one attaches a listener to a
+"start" event and never sees the output, so a credential in an allowed tool's
+result is out of reach on this surface (see contract.SURFACES["sdk-adapter"]).
+
 Easy path::
 
     from prismor.beeai import guard_tool

--- a/adapters/browser-use/prismor_browser_use/__init__.py
+++ b/adapters/browser-use/prismor_browser_use/__init__.py
@@ -206,7 +206,7 @@ def guard_controller(
                             params = _approvals.redact_approved_payload(params, workspace=ws)
                         return redact_tool_result(
                             await original_execute(action_name, params, **kwargs),
-                            workspace=ws)
+                            workspace=ws, engine=decision.engine)
                 except Exception:
                     pass
             reason = decision.reason or "policy violation"
@@ -218,7 +218,8 @@ def guard_controller(
         # An allowed action still returns a page's content — redact it before
         # browser-use hands the ActionResult back to the model.
         return redact_tool_result(
-            await original_execute(action_name, params, **kwargs), workspace=ws)
+            await original_execute(action_name, params, **kwargs), workspace=ws,
+            engine=decision.engine)
 
     registry.execute_action = _guarded_execute
     registry.__prismor_guarded__ = True

--- a/adapters/browser-use/prismor_browser_use/__init__.py
+++ b/adapters/browser-use/prismor_browser_use/__init__.py
@@ -38,6 +38,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.principal import Subject, resolve_subject, use_subject
 from prismor.runtime.runtime import Decision, evaluate_tool_call, log_observe_findings
 
@@ -203,7 +204,9 @@ def guard_controller(
                         if getattr(outcome, "redacted", False):
                             # "Approve redacted": strip flagged values on-device first.
                             params = _approvals.redact_approved_payload(params, workspace=ws)
-                        return await original_execute(action_name, params, **kwargs)
+                        return redact_tool_result(
+                            await original_execute(action_name, params, **kwargs),
+                            workspace=ws)
                 except Exception:
                     pass
             reason = decision.reason or "policy violation"
@@ -212,7 +215,10 @@ def guard_controller(
             # Return a string error — browser-use surfaces this back to the LLM
             return f"⛔ Prismor blocked action '{action_name}': {reason}"
 
-        return await original_execute(action_name, params, **kwargs)
+        # An allowed action still returns a page's content — redact it before
+        # browser-use hands the ActionResult back to the model.
+        return redact_tool_result(
+            await original_execute(action_name, params, **kwargs), workspace=ws)
 
     registry.execute_action = _guarded_execute
     registry.__prismor_guarded__ = True

--- a/adapters/claude-agent-sdk/prismor_claude_agent_sdk/__init__.py
+++ b/adapters/claude-agent-sdk/prismor_claude_agent_sdk/__init__.py
@@ -33,6 +33,11 @@ once installed. That test also caught a real bug: an earlier default
 anything but Claude's own built-in tools — ``matcher`` now defaults to
 ``None`` (every tool call) for exactly this reason.
 
+RESULT REDACTION: not available here, and not for want of trying — this is
+a PreToolUse hook, which is handed the request and answers with a permission
+decision. It never carries the tool's output, so unlike the wrapper-style
+adapters it cannot repair one (see contract.SURFACES["sdk-adapter"]).
+
 Use::
 
     from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient

--- a/adapters/crewai/prismor_crewai/__init__.py
+++ b/adapters/crewai/prismor_crewai/__init__.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List, Optional, Sequence, Union
 
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.principal import Subject, resolve_subject, use_subject
 from prismor.runtime.runtime import Decision, evaluate_tool_call, log_observe_findings
 
@@ -138,6 +139,16 @@ def prismor_guard_tool(
             return f"⛔ Prismor blocked this tool call: {reason}"
         return None
 
+    def _redact(result: Any) -> Any:
+        """Mask the tool's OUTPUT before CrewAI feeds it back to the model.
+
+        The pre-call check can only refuse; a tool that reads a file with a
+        hardcoded credential in it is allowed, and the credential is in the
+        return value. This wrapper holds that value, so it is the one place
+        that leak can still be repaired.
+        """
+        return redact_tool_result(result, workspace=ws)
+
     wrapped_any = False
     for attr in _IMPL_ATTRS:
         impl = getattr(tool, attr, None)
@@ -149,8 +160,10 @@ def prismor_guard_tool(
         def guarded(*args: Any, __impl=impl, **kwargs: Any) -> Any:
             denial = _decide(args, kwargs)
             if isinstance(denial, _RunWith):
-                return __impl(*denial.args, **denial.kwargs)
-            return denial if denial is not None else __impl(*args, **kwargs)
+                return _redact(__impl(*denial.args, **denial.kwargs))
+            if denial is not None:
+                return denial
+            return _redact(__impl(*args, **kwargs))
 
         try:
             setattr(tool, attr, guarded)

--- a/adapters/crewai/prismor_crewai/__init__.py
+++ b/adapters/crewai/prismor_crewai/__init__.py
@@ -115,6 +115,7 @@ def prismor_guard_tool(
             agent=agent, agent_name=_agent_name, mode=mode, sid=sid, event_type=event_type,
         )
         log_observe_findings(decision, mode=mode, tool_name=tool_name)
+        _engine[0] = decision.engine
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             # Headless STEP_UP → post an approval request and block until an admin
             # decides. Approve → proceed; deny/timeout/not-enrolled → fail closed.
@@ -139,6 +140,12 @@ def prismor_guard_tool(
             return f"⛔ Prismor blocked this tool call: {reason}"
         return None
 
+    # The Decision's own PolicyEngine, parked by _decide for _redact to reuse
+    # rather than rebuild. A list because the guarded callables are re-entrant
+    # (and async, in LangChain's case): index 0 is only ever a fresher engine
+    # for the same workspace, so a racing overwrite costs nothing.
+    _engine: List[Any] = [None]
+
     def _redact(result: Any) -> Any:
         """Mask the tool's OUTPUT before CrewAI feeds it back to the model.
 
@@ -147,7 +154,7 @@ def prismor_guard_tool(
         return value. This wrapper holds that value, so it is the one place
         that leak can still be repaired.
         """
-        return redact_tool_result(result, workspace=ws)
+        return redact_tool_result(result, workspace=ws, engine=_engine[0])
 
     wrapped_any = False
     for attr in _IMPL_ATTRS:

--- a/adapters/google-adk/prismor_google_adk/__init__.py
+++ b/adapters/google-adk/prismor_google_adk/__init__.py
@@ -18,7 +18,12 @@ Easy path::
     agent = LlmAgent(
         model="gemini-2.0-flash", name="ops", tools=[run_shell],
         before_tool_callback=make_before_tool_callback(subject="user:alice", mode="enforce"),
+        after_tool_callback=make_after_tool_callback(),
     )
+
+The after-callback is the result side of the same gate: ADK hands it
+``tool_response`` and a dict return REPLACES it, so a credential sitting in
+an otherwise-allowed tool's output is masked before the model reads it.
 """
 from __future__ import annotations
 
@@ -28,9 +33,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from prismor.runtime.principal import Subject, resolve_subject
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.runtime import Decision, evaluate_tool_call
 
-__all__ = ["make_before_tool_callback", "PrismorBlocked"]
+__all__ = ["make_before_tool_callback", "make_after_tool_callback", "PrismorBlocked"]
 
 _TYPE_FIELD = {
     "shell": "command",
@@ -98,5 +104,29 @@ def make_before_tool_callback(
             # not an exception.
             return {"error": f"⛔ Prismor blocked this tool call: {reason}"}
         return None  # None -> proceed with the real tool call
+
+    return callback
+
+
+def make_after_tool_callback(
+    *,
+    workspace: Optional[Union[str, Path]] = None,
+) -> Callable[[Any, Dict[str, Any], Any, Any], Optional[Any]]:
+    """Build a Prismor after_tool_callback that redacts the tool's OUTPUT.
+
+    ``before_tool_callback`` sees only the request. This one is handed the
+    tool's response, and a non-``None`` return REPLACES it — ADK's own
+    substitution mechanism, the same one the before-callback denies through.
+    Best-effort by contract: it never raises, so a masking failure can never
+    turn into a failed tool call.
+    """
+    ws = Path(workspace) if workspace else Path.cwd()
+
+    def callback(tool: Any, args: Dict[str, Any], tool_context: Any,
+                 tool_response: Any) -> Optional[Any]:
+        redacted = redact_tool_result(tool_response, workspace=ws)
+        # None -> ADK keeps the original response (which, for a result object
+        # redacted in place, is already the masked one).
+        return redacted if redacted != tool_response else None
 
     return callback

--- a/adapters/langchain/prismor_langchain/__init__.py
+++ b/adapters/langchain/prismor_langchain/__init__.py
@@ -30,6 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Sequence, Union
 
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.principal import Subject, resolve_subject, use_subject
 from prismor.runtime.runtime import Decision, evaluate_tool_call, log_observe_findings
 
@@ -176,14 +177,26 @@ def prismor_guard_tool(
             return f"⛔ Prismor blocked this tool call: {reason}"
         return None  # allowed
 
+    def _redact(result: Any) -> Any:
+        """Mask the tool's OUTPUT before LangChain feeds it back to the model.
+
+        The pre-call check can only refuse; a tool that reads a file with a
+        hardcoded credential in it is allowed, and the credential is in the
+        return value. This wrapper holds that value, so it is the one place
+        that leak can still be repaired.
+        """
+        return redact_tool_result(result, workspace=ws)
+
     original_func = getattr(tool, "func", None)
     if callable(original_func):
         @functools.wraps(original_func)
         def guarded_func(*args: Any, **kwargs: Any) -> Any:
             denial = _decide(args, kwargs)
             if isinstance(denial, _RunWith):
-                return original_func(*denial.args, **denial.kwargs)
-            return denial if denial is not None else original_func(*args, **kwargs)
+                return _redact(original_func(*denial.args, **denial.kwargs))
+            if denial is not None:
+                return denial
+            return _redact(original_func(*args, **kwargs))
         tool.func = guarded_func
 
     original_coro = getattr(tool, "coroutine", None)
@@ -197,8 +210,10 @@ def prismor_guard_tool(
 
             denial = await asyncio.to_thread(_decide, args, kwargs)
             if isinstance(denial, _RunWith):
-                return await original_coro(*denial.args, **denial.kwargs)
-            return denial if denial is not None else await original_coro(*args, **kwargs)
+                return _redact(await original_coro(*denial.args, **denial.kwargs))
+            if denial is not None:
+                return denial
+            return _redact(await original_coro(*args, **kwargs))
         tool.coroutine = guarded_coro
 
     tool.__prismor_guarded__ = True

--- a/adapters/langchain/prismor_langchain/__init__.py
+++ b/adapters/langchain/prismor_langchain/__init__.py
@@ -151,6 +151,7 @@ def prismor_guard_tool(
             agent=agent, agent_name=_agent_name, mode=mode, sid=sid, event_type=event_type,
         )
         log_observe_findings(decision, mode=mode, tool_name=tool_name)
+        _engine[0] = decision.engine
         if not decision.allow:  # honor the runtime decision (incl. org kill-switch / forced-enforce), not the app-passed mode
             # Headless STEP_UP → post an approval request and block until an admin
             # decides. Approve → proceed; deny/timeout/not-enrolled → fail closed.
@@ -177,6 +178,12 @@ def prismor_guard_tool(
             return f"⛔ Prismor blocked this tool call: {reason}"
         return None  # allowed
 
+    # The Decision's own PolicyEngine, parked by _decide for _redact to reuse
+    # rather than rebuild. A list because the guarded callables are re-entrant
+    # (and async, in LangChain's case): index 0 is only ever a fresher engine
+    # for the same workspace, so a racing overwrite costs nothing.
+    _engine: List[Any] = [None]
+
     def _redact(result: Any) -> Any:
         """Mask the tool's OUTPUT before LangChain feeds it back to the model.
 
@@ -185,7 +192,7 @@ def prismor_guard_tool(
         return value. This wrapper holds that value, so it is the one place
         that leak can still be repaired.
         """
-        return redact_tool_result(result, workspace=ws)
+        return redact_tool_result(result, workspace=ws, engine=_engine[0])
 
     original_func = getattr(tool, "func", None)
     if callable(original_func):

--- a/adapters/openai-agents/prismor_openai/__init__.py
+++ b/adapters/openai-agents/prismor_openai/__init__.py
@@ -204,7 +204,8 @@ def prismor_guard(
             return decision
         # Allowed: the tool ran, and its OUTPUT is the half a pre-call check
         # never sees. Redact before the SDK folds it into the model's context.
-        return redact_tool_result(tool(*args, **kwargs), workspace=ws)
+        return redact_tool_result(tool(*args, **kwargs), workspace=ws,
+                                  engine=decision.engine)
 
     wrapper.__prismor_guarded__ = True  # type: ignore[attr-defined]
     return wrapper
@@ -312,14 +313,16 @@ def _guard_function_tool(
                             # "Approve redacted": strip flagged values on-device first.
                             input_str = _approvals.redact_approved_payload(input_str, workspace=ws)
                         return redact_tool_result(
-                            await original(ctx, input_str), workspace=ws)
+                            await original(ctx, input_str), workspace=ws,
+                            engine=decision.engine)
                 except Exception:
                     pass  # any approval-path error fails closed
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)
             return f"⛔ Prismor blocked this tool call: {reason}"
-        return redact_tool_result(await original(ctx, input_str), workspace=ws)
+        return redact_tool_result(await original(ctx, input_str), workspace=ws,
+                                  engine=decision.engine)
 
     tool.on_invoke_tool = guarded
     tool.__prismor_guarded__ = True

--- a/adapters/openai-agents/prismor_openai/__init__.py
+++ b/adapters/openai-agents/prismor_openai/__init__.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
 
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.principal import Subject, resolve_subject, use_subject
 from prismor.runtime.runtime import Decision, evaluate_tool_call, log_observe_findings
 
@@ -201,7 +202,9 @@ def prismor_guard(
             if raise_on_block:
                 raise PrismorBlocked(decision.reason or "blocked", decision)
             return decision
-        return tool(*args, **kwargs)
+        # Allowed: the tool ran, and its OUTPUT is the half a pre-call check
+        # never sees. Redact before the SDK folds it into the model's context.
+        return redact_tool_result(tool(*args, **kwargs), workspace=ws)
 
     wrapper.__prismor_guarded__ = True  # type: ignore[attr-defined]
     return wrapper
@@ -308,14 +311,15 @@ def _guard_function_tool(
                         if getattr(outcome, "redacted", False):
                             # "Approve redacted": strip flagged values on-device first.
                             input_str = _approvals.redact_approved_payload(input_str, workspace=ws)
-                        return await original(ctx, input_str)
+                        return redact_tool_result(
+                            await original(ctx, input_str), workspace=ws)
                 except Exception:
                     pass  # any approval-path error fails closed
             reason = decision.reason or "policy violation"
             if raise_on_block:
                 raise PrismorBlocked(reason, decision)
             return f"⛔ Prismor blocked this tool call: {reason}"
-        return await original(ctx, input_str)
+        return redact_tool_result(await original(ctx, input_str), workspace=ws)
 
     tool.on_invoke_tool = guarded
     tool.__prismor_guarded__ = True

--- a/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
+++ b/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
@@ -31,6 +31,7 @@ from pydantic_ai.exceptions import ToolFailed
 from pydantic_ai.toolsets import WrapperToolset
 
 from prismor.runtime.principal import Subject, resolve_subject
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.runtime import Decision, evaluate_tool_call
 
 __all__ = ["guard_toolsets", "PrismorToolset", "PrismorBlocked"]
@@ -115,7 +116,12 @@ class PrismorToolset(WrapperToolset):
             # without the retry-budget consumption ModelRetry implies (this
             # is a policy denial, not a transient/correctable error).
             raise ToolFailed(f"⛔ Prismor blocked this tool call: {reason}")
-        return await super().call_tool(name, tool_args, ctx, tool)
+        # call_tool is also the single choke point the RESULT comes back
+        # through, so the same wrapper that refuses a call can repair one.
+        return redact_tool_result(
+            await super().call_tool(name, tool_args, ctx, tool),
+            workspace=self._prismor_ws,  # type: ignore[attr-defined]
+        )
 
 
 def guard_toolsets(toolsets: Sequence[Any], **kwargs: Any) -> List[PrismorToolset]:

--- a/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
+++ b/adapters/pydantic-ai/prismor_pydantic_ai/__init__.py
@@ -121,6 +121,7 @@ class PrismorToolset(WrapperToolset):
         return redact_tool_result(
             await super().call_tool(name, tool_args, ctx, tool),
             workspace=self._prismor_ws,  # type: ignore[attr-defined]
+            engine=decision.engine,
         )
 
 

--- a/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
+++ b/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
@@ -33,6 +33,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional, Union
 from semantic_kernel.functions.function_result import FunctionResult
 
 from prismor.runtime.principal import Subject, resolve_subject
+from prismor.runtime.redaction import redact_tool_result
 from prismor.runtime.runtime import Decision, evaluate_tool_call
 
 __all__ = ["make_filter", "PrismorBlocked"]
@@ -114,5 +115,12 @@ def make_filter(
             )
             return
         await next(context)
+        # The chain leaves the function's OUTPUT on context.function_result;
+        # redact it before Semantic Kernel folds it into the chat history.
+        result = getattr(context, "function_result", None)
+        if result is not None:
+            redacted = redact_tool_result(result, workspace=ws)
+            if redacted is not result:
+                context.function_result = redacted
 
     return prismor_filter

--- a/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
+++ b/adapters/semantic-kernel/prismor_semantic_kernel/__init__.py
@@ -119,7 +119,8 @@ def make_filter(
         # redact it before Semantic Kernel folds it into the chat history.
         result = getattr(context, "function_result", None)
         if result is not None:
-            redacted = redact_tool_result(result, workspace=ws)
+            redacted = redact_tool_result(result, workspace=ws,
+                                          engine=decision.engine)
             if redacted is not result:
                 context.function_result = redacted
 

--- a/prismor/runtime/contract.py
+++ b/prismor/runtime/contract.py
@@ -259,9 +259,13 @@ SURFACES: Tuple[Surface, ...] = (
         kind="adapter",
         module="adapters/*",
         normalizer="per-adapter (in-process tool wrapper)",
-        can_refuse=True, can_rewrite=False, can_redact=False,
+        can_refuse=True, can_rewrite=False, can_redact=True,
         notes="In-process interception for LangChain, CrewAI, OpenAI Agents and "
-              "the rest. Refuses by raising; no host surface to rewrite through.",
+              "the rest. Refuses by raising; no host surface to rewrite through. "
+              "Holds the tool's return value before the framework hands it to "
+              "the model, so it redacts the result too — except where the "
+              "framework's only hook is pre-action (the Claude Agent SDK "
+              "PreToolUse hook, BeeAI's tool 'start' event).",
     ),
     Surface(
         id="eval-server",

--- a/prismor/runtime/redaction.py
+++ b/prismor/runtime/redaction.py
@@ -36,6 +36,7 @@ def redact_text(
     *,
     workspace: Optional[Path] = None,
     data_boundary: bool = True,
+    engine: Any = None,
 ) -> Tuple[str, bool]:
     """Mask cloak secrets and classified data-boundary values in ``text``.
 
@@ -43,6 +44,13 @@ def redact_text(
     only — the split matters because ``prismor pause`` suspends *policy*
     (data boundary) while cloak masking keeps running: a paused agent must
     still not have raw secret values pushed into its context.
+
+    ``engine`` is the ``PolicyEngine`` the caller already built for this call
+    (every ``Decision`` carries one). Without it the classifier builds a fresh
+    engine per string — 6.6 ms of rule construction on a 2-core box, which on
+    a result-side path is paid once per tool call for nothing. Reusing the
+    decision's engine took a 96-byte result from 9.5 ms to 0.17 ms, and is
+    exactly as fresh as the decision that allowed the call.
     """
     if not isinstance(text, str) or not text:
         return text, False
@@ -57,7 +65,9 @@ def redact_text(
     if data_boundary:
         try:
             from prismor.runtime.data_boundary import redact_payload
-            redacted = redact_payload(text, workspace=workspace)
+            redacted = redact_payload(
+                text, workspace=workspace,
+                policy=getattr(engine, "data_boundary", None))
             if isinstance(redacted, str):
                 text = redacted
         except Exception:
@@ -78,6 +88,7 @@ def redact_payload_values(
     *,
     workspace: Optional[Path] = None,
     data_boundary: bool = True,
+    engine: Any = None,
 ) -> Tuple[Any, bool]:
     """``redact_text`` over every string leaf of a dict/list/str payload.
 
@@ -94,7 +105,8 @@ def redact_payload_values(
     def _walk(x: Any, depth: int) -> Any:
         nonlocal changed
         if isinstance(x, str):
-            out, hit = redact_text(x, workspace=workspace, data_boundary=data_boundary)
+            out, hit = redact_text(x, workspace=workspace,
+                                   data_boundary=data_boundary, engine=engine)
             changed = changed or hit
             return out
         if depth >= _MAX_DEPTH:
@@ -127,6 +139,7 @@ def redact_tool_result(
     *,
     workspace: Optional[Path] = None,
     data_boundary: bool = True,
+    engine: Any = None,
 ) -> Any:
     """Result-side redaction for an in-process SDK adapter. Never raises.
 
@@ -138,7 +151,8 @@ def redact_tool_result(
     """
     try:
         redacted, _ = redact_payload_values(
-            result, workspace=workspace, data_boundary=data_boundary)
+            result, workspace=workspace, data_boundary=data_boundary,
+            engine=engine)
         return redacted
     except Exception:
         return result

--- a/prismor/runtime/redaction.py
+++ b/prismor/runtime/redaction.py
@@ -66,30 +66,82 @@ def redact_text(
     return text, text != original
 
 
+#: How far ``redact_payload_values`` descends. Framework result objects nest a
+#: few levels (a result wrapper holding a list of models holding strings); past
+#: that a payload is more likely a graph than a document, and a bounded walk is
+#: what keeps a self-referencing result object from hanging the tool call.
+_MAX_DEPTH = 8
+
+
 def redact_payload_values(
     payload: Any,
     *,
     workspace: Optional[Path] = None,
     data_boundary: bool = True,
 ) -> Tuple[Any, bool]:
-    """``redact_text`` over every string leaf of a dict/list/str payload."""
+    """``redact_text`` over every string leaf of a dict/list/str payload.
+
+    Objects carrying a ``__dict__`` (pydantic models, framework result
+    wrappers) are redacted **in place** on their string attributes: once a
+    framework has wrapped a tool result it is rarely a bare string any more,
+    and rebuilding an arbitrary class from its fields is a guess this cannot
+    afford to get wrong. An attribute that refuses assignment (frozen model,
+    ``__slots__``, computed property) is left as it was rather than failing
+    the call.
+    """
     changed = False
 
-    def _walk(x: Any) -> Any:
+    def _walk(x: Any, depth: int) -> Any:
         nonlocal changed
         if isinstance(x, str):
             out, hit = redact_text(x, workspace=workspace, data_boundary=data_boundary)
             changed = changed or hit
             return out
+        if depth >= _MAX_DEPTH:
+            return x
         if isinstance(x, dict):
-            return {k: _walk(v) for k, v in x.items()}
+            return {k: _walk(v, depth + 1) for k, v in x.items()}
         if isinstance(x, list):
-            return [_walk(v) for v in x]
+            return [_walk(v, depth + 1) for v in x]
         if isinstance(x, tuple):
-            return tuple(_walk(v) for v in x)
+            return tuple(_walk(v, depth + 1) for v in x)
+        attrs = getattr(x, "__dict__", None)
+        if isinstance(attrs, dict) and not isinstance(x, type):
+            for key, value in list(attrs.items()):
+                if key.startswith("__"):
+                    continue
+                walked = _walk(value, depth + 1)
+                if walked is value:
+                    continue
+                try:
+                    setattr(x, key, walked)
+                except Exception:
+                    pass
         return x
 
-    return _walk(payload), changed
+    return _walk(payload, 0), changed
+
+
+def redact_tool_result(
+    result: Any,
+    *,
+    workspace: Optional[Path] = None,
+    data_boundary: bool = True,
+) -> Any:
+    """Result-side redaction for an in-process SDK adapter. Never raises.
+
+    An adapter holds the tool's return value before the framework hands it to
+    the model — the one point in a framework agent where a credential sitting
+    in ordinary source can still be masked. Adapters call this rather than
+    :func:`redact_payload_values` directly so "best effort, never fail the call
+    closed" is written once instead of once per adapter.
+    """
+    try:
+        redacted, _ = redact_payload_values(
+            result, workspace=workspace, data_boundary=data_boundary)
+        return redacted
+    except Exception:
+        return result
 
 
 def redact_mcp_result(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Make the bundled framework adapters importable from a source checkout.
+
+Installed, ``prismor.langchain`` and friends land inside the same ``prismor/``
+package the runtime ships, so they are ordinary subpackages. In the repo they
+live under ``adapters/<framework>/prismor/<framework>/`` instead — and since
+``prismor/__init__.py`` exists (deliberately: it stops an unrelated installed
+``prismor`` distribution from shadowing the repo-local runtime, see
+PrismorSec/prismor#173), ``prismor`` is a regular package whose ``__path__``
+does not grow when a new sys.path entry appears. Four adapter test modules
+therefore failed at *collection* with ``No module named 'prismor.langchain'``
+unless the extras happened to be pip-installed.
+
+Extending ``__path__`` here fixes all of them in one place, before any test
+module is imported. Each adapter directory also goes on ``sys.path`` so the
+flat ``prismor_<framework>`` implementation modules the shims re-export from
+resolve too.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ADAPTERS = Path(__file__).resolve().parent.parent / "adapters"
+
+
+def _wire_adapters() -> None:
+    import prismor
+
+    for adapter in sorted(_ADAPTERS.iterdir()):
+        shim_root = adapter / "prismor"
+        if not shim_root.is_dir():
+            continue  # non-Python adapter (vercel-ai, mastra)
+        if str(adapter) not in sys.path:
+            sys.path.insert(0, str(adapter))
+        if str(shim_root) not in prismor.__path__:
+            prismor.__path__.append(str(shim_root))
+
+
+_wire_adapters()

--- a/tests/test_adapter_result_redaction.py
+++ b/tests/test_adapter_result_redaction.py
@@ -1,0 +1,217 @@
+"""SDK adapters must redact the tool RESULT, not only screen the call.
+
+PrismorSec/prismor#309: every adapter wrapped the call and none of them
+touched the return value, so a tool that read a file with a hardcoded
+credential in it handed that credential straight to the model — the exact
+leak the mirror exists to stop, on the surface with no developer watching the
+transcript.
+
+Only the adapters whose framework is not needed at import time are driven
+here (fake tool objects, real policy pipeline, no live LLM), which is enough
+to prove the shared helper is wired at each return site. The two adapters that
+structurally cannot redact — BeeAI's "start" listener, the Claude Agent SDK
+PreToolUse hook — are asserted to have said so.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# conftest.py puts every adapters/<fw> dir on the path and extends
+# prismor.__path__ with its shim, so these import from a bare checkout.
+from prismor.runtime.redaction import redact_text, redact_tool_result
+
+#: A token the data-boundary classifier recognises on its own, so the test
+#: does not depend on a cloak store being registered in this workspace.
+SECRET = "ghp_" + "A" * 36
+LEAKY_OUTPUT = f"config.yaml:\n  github_token: {SECRET}\n"
+
+
+def _is_masked(text: str) -> bool:
+    return SECRET not in str(text)
+
+
+def test_the_specimen_is_actually_redactable():
+    """Guard the guard: if the classifier stops matching, every case below
+    would pass vacuously by never having had anything to mask."""
+    masked, changed = redact_text(LEAKY_OUTPUT)
+    assert changed and _is_masked(masked)
+
+
+# ── the shared helper ───────────────────────────────────────────────────────
+
+def test_helper_walks_containers_and_objects():
+    class Result:  # a framework result wrapper (browser-use ActionResult &c.)
+        def __init__(self):
+            self.extracted_content = LEAKY_OUTPUT
+            self.error = None
+
+    out = redact_tool_result({"content": [LEAKY_OUTPUT], "n": 1})
+    assert _is_masked(out["content"][0]) and out["n"] == 1
+
+    obj = Result()
+    redact_tool_result(obj)  # objects are repaired in place
+    assert _is_masked(obj.extracted_content) and obj.error is None
+
+
+def test_helper_never_raises_and_never_fails_closed():
+    """Best-effort by contract: a masking failure must not become an outage."""
+    class Hostile:
+        @property
+        def __dict__(self):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    sentinel = Hostile()
+    assert redact_tool_result(sentinel) is sentinel
+    assert redact_tool_result(None) is None
+
+
+def test_helper_terminates_on_a_self_referencing_result():
+    class Node:
+        def __init__(self):
+            self.text = LEAKY_OUTPUT
+            self.parent = None
+
+    node = Node()
+    node.parent = node  # a result that points back at its own container
+    redact_tool_result(node)
+    assert _is_masked(node.text)
+
+
+# ── wrapper-style adapters ──────────────────────────────────────────────────
+
+class _Tool:
+    """A structured tool with .name + .func — the shape LangChain and CrewAI
+    both wrap (and the shape their own test doubles already use)."""
+
+    def __init__(self, fn):
+        self.name = "read_config"
+        self.func = fn
+
+
+def _leaky(**kwargs):
+    return LEAKY_OUTPUT
+
+
+def test_langchain_redacts_the_result(tmp_path):
+    from prismor.langchain import prismor_guard_tool
+
+    tool = _Tool(_leaky)
+    prismor_guard_tool(tool, workspace=tmp_path, mode="enforce")
+    assert _is_masked(tool.func(path="config.yaml"))
+
+
+def test_langchain_redacts_an_async_result(tmp_path):
+    from prismor.langchain import prismor_guard_tool
+
+    async def leaky(**kwargs):
+        return LEAKY_OUTPUT
+
+    tool = _Tool(None)
+    tool.func = None
+    tool.coroutine = leaky
+    prismor_guard_tool(tool, workspace=tmp_path, mode="enforce")
+    assert _is_masked(asyncio.run(tool.coroutine(path="config.yaml")))
+
+
+def test_crewai_redacts_the_result(tmp_path):
+    from prismor.crewai import prismor_guard_tool
+
+    tool = _Tool(_leaky)
+    prismor_guard_tool(tool, workspace=tmp_path, mode="enforce")
+    assert _is_masked(tool.func(path="config.yaml"))
+
+
+def test_openai_agents_redacts_a_plain_callable(tmp_path):
+    from prismor.openai import prismor_guard
+
+    def read_config(path: str) -> str:
+        return LEAKY_OUTPUT
+
+    guarded = prismor_guard(read_config, workspace=tmp_path, mode="enforce")
+    assert _is_masked(guarded(path="config.yaml"))
+
+
+def test_openai_agents_redacts_a_function_tool(tmp_path):
+    from prismor.openai import prismor_guard
+
+    async def on_invoke_tool(ctx, input_str):
+        return LEAKY_OUTPUT
+
+    tool = MagicMock()
+    tool.name = "read_config"
+    tool.on_invoke_tool = on_invoke_tool
+    tool.__prismor_guarded__ = False
+
+    prismor_guard(tool, workspace=tmp_path, mode="enforce")
+    assert _is_masked(asyncio.run(tool.on_invoke_tool(None, '{"path": "config.yaml"}')))
+
+
+def test_agno_redacts_the_result(tmp_path):
+    from prismor.agno import make_tool_hook
+
+    hook = make_tool_hook(workspace=tmp_path, mode="enforce")
+    out = hook("read_config", lambda **kw: LEAKY_OUTPUT, {"path": "config.yaml"})
+    assert _is_masked(out)
+
+
+def test_browser_use_redacts_the_action_result(tmp_path):
+    from prismor.browser_use import guard_controller
+
+    ctrl = MagicMock()
+    ctrl.registry = MagicMock()
+    ctrl.registry.__prismor_guarded__ = False
+    ctrl.registry.execute_action = AsyncMock(return_value=LEAKY_OUTPUT)
+
+    guard_controller(ctrl, workspace=tmp_path, mode="enforce")
+    out = asyncio.run(ctrl.registry.execute_action("extract_content", {"goal": "read it"}))
+    assert _is_masked(out)
+
+
+def test_google_adk_after_callback_substitutes_a_masked_response(tmp_path):
+    from prismor.google_adk import make_after_tool_callback
+
+    cb = make_after_tool_callback(workspace=tmp_path)
+    replaced = cb(MagicMock(), {"path": "config.yaml"}, None, {"result": LEAKY_OUTPUT})
+    # A dict return REPLACES the response; None would leave the leak in place.
+    assert replaced is not None and _is_masked(replaced["result"])
+
+    clean = {"result": "nothing to see"}
+    assert cb(MagicMock(), {}, None, clean) is None
+
+
+def test_redaction_does_not_disturb_a_clean_result(tmp_path):
+    from prismor.langchain import prismor_guard_tool
+
+    tool = _Tool(lambda **kw: "ran: ls -la")
+    prismor_guard_tool(tool, workspace=tmp_path, mode="enforce")
+    assert tool.func(path="x") == "ran: ls -la"
+
+
+def test_a_denied_call_still_returns_the_denial_not_a_result(tmp_path):
+    """Redaction sits on the allow path only — it must not swallow a block."""
+    from prismor.langchain import prismor_guard_tool
+
+    ran = []
+    tool = _Tool(lambda **kw: ran.append(1) or LEAKY_OUTPUT)
+    tool.name = "run_shell"
+    prismor_guard_tool(tool, workspace=tmp_path, mode="enforce", approvals=False)
+    out = tool.func(command="rm -rf /")
+    assert "Prismor blocked" in str(out) and ran == []
+
+
+# ── the surfaces that cannot ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("rel", [
+    "adapters/beeai/prismor_beeai/__init__.py",
+    "adapters/claude-agent-sdk/prismor_claude_agent_sdk/__init__.py",
+])
+def test_pre_action_only_adapters_say_so(rel):
+    """These two hook a pre-action event and never see the output. Silently
+    shipping them under a can_redact=True surface is how a capability ends up
+    in the docs but not in the code."""
+    text = (Path(__file__).resolve().parent.parent / rel).read_text()
+    assert "RESULT REDACTION: not available here" in text

--- a/tests/test_surface_conformance.py
+++ b/tests/test_surface_conformance.py
@@ -296,6 +296,10 @@ def test_surface_registry_is_wellformed():
     # capability in the docs that does not exist.
     assert contract.surface("hook").can_redact is False
     assert contract.surface("mirror").can_redact is True
+    # An in-process adapter holds the tool's return value, so it can repair one
+    # (PrismorSec/prismor#309). The registry only gets to say so while the
+    # adapters actually do it — test_adapter_result_redaction is the check.
+    assert contract.surface("sdk-adapter").can_redact is True
 
 
 # ── shared redaction ─────────────────────────────────────────────────────────
@@ -310,3 +314,27 @@ def test_redaction_is_shared_and_best_effort():
     # Non-text blocks survive untouched rather than being guessed at.
     res = {"content": [{"type": "image", "data": "xyz"}]}
     assert redact_mcp_result(res)[0] == res
+
+
+def test_every_result_carrying_surface_masks_the_same_secret():
+    """The result side of the conformance claim.
+
+    A credential in a tool's OUTPUT must be masked whichever surface carried
+    it back, in the payload shape that surface actually deals in: an MCP
+    content block for the gateway and the mirror, a plain return value for an
+    in-process SDK adapter. They share one helper precisely so a fix to the
+    classifier lands on all of them at once — this asserts they still do.
+    """
+    from prismor.runtime.redaction import redact_mcp_result, redact_tool_result
+
+    secret = "ghp_" + "A" * 36
+    text = f"token: {secret}"
+
+    gateway, changed = redact_mcp_result({"content": [{"type": "text", "text": text}]})
+    assert changed and secret not in gateway["content"][0]["text"]
+
+    adapter = redact_tool_result(text)
+    assert secret not in adapter
+
+    for etype in contract.TEXT_TYPES:
+        assert etype in contract.TYPE_FIELD  # a result event has somewhere to go


### PR DESCRIPTION
Closes #309.

## What changed

Every in-process adapter that holds the tool's return value now passes it
through the shared `prismor.runtime.redaction` helper before the framework
hands it to the model:

| adapter | return site |
| --- | --- |
| LangChain / LangGraph | `func` + `coroutine` wrappers |
| CrewAI | `func` / `_run` / `run` wrapper |
| OpenAI Agents | plain-callable wrapper + `FunctionTool.on_invoke_tool` |
| Agno | `tool_hook`'s `function_call(...)` |
| browser-use | `Registry.execute_action` |
| Pydantic AI | `WrapperToolset.call_tool` |
| Semantic Kernel | `context.function_result`, after `next(context)` |
| AutoGen Core | new `on_response` — the send leg can only refuse |
| Google ADK | new `make_after_tool_callback()` — `before_tool_callback` never sees the output |

BeeAI (a listener on the tool's `start` event) and the Claude Agent SDK (a
`PreToolUse` hook) hook a pre-action event and carry no output to repair. Each
now says so in its module docstring, where the others document the capability.

`contract.SURFACES` records `sdk-adapter` as `can_redact=True`.

`redact_payload_values` learns to walk objects, redacting their string
attributes in place. Once a framework has wrapped a result it is rarely a bare
string, and rebuilding an arbitrary class from its fields is a guess this
cannot afford to get wrong. Bounded depth, so a self-referencing result object
cannot hang the call. Best-effort by contract throughout: masking never raises
and never fails a call closed.

### Two things found on the way

**No adapter test has been running in CI.** The four modules the issue names
error at *collection* from a bare checkout; with the framework extras actually
installed it is six, and a collection error aborts the whole run. Cause:
`prismor/__init__.py` (deliberate — it stops an installed distribution from
shadowing the repo-local runtime, #173) makes `prismor` a regular package, so
`adapters/*/prismor/<fw>/` can never be found by adding a sys.path entry. A
`tests/conftest.py` extends `prismor.__path__` with each bundled shim, which is
what the installed wheel layout does anyway. That is +63 tests now running.

**Result redaction built a whole PolicyEngine per string.** The data-boundary
classifier instantiates one when it isn't handed a policy — 6.6 ms of rule
construction, per tool call, for an engine the caller had just built and parked
on `Decision.engine` for exactly this purpose. The adapters now hand it over.
Not a cache, so there is no staleness question: the engine reused is the one
that allowed the call. Measured on st3ve (2-core, 200 samples, median):
**8.11 ms → 0.27 ms** per result.

## Verified on st3ve

A fresh clone, real framework SDKs installed (langchain-core 1.6, crewai
1.15.17, openai-agents 0.22, agno 3.0.1, pydantic-ai-slim 2.35.1,
semantic-kernel 1.44.1, google-adk 2.8, autogen-core 0.7.5), tested against the
built **wheel** rather than the editable install, because the editable layout
is the one that cannot resolve the shims.

**Live leak test** — each adapter driven with its real framework objects and a
tool that reads a config file with two planted credentials (one registered in
the cloak store, one a `ghp_` token the classifier catches). Every case is run
twice, so "masked" only counts because the same tool leaked first:

```
langchain        leaked_unguarded=true  leaked_guarded=false
crewai           leaked_unguarded=true  leaked_guarded=false
openai-agents    leaked_unguarded=true  leaked_guarded=false
agno             leaked_unguarded=true  leaked_guarded=false
pydantic-ai      leaked_unguarded=true  leaked_guarded=false
semantic-kernel  leaked_unguarded=true  leaked_guarded=false
google-adk       leaked_unguarded=true  leaked_guarded=false
autogen-core     leaked_unguarded=true  leaked_guarded=false
browser-use      leaked_unguarded=true  leaked_guarded=false

  github_token: [REDACTED:secret]
  db_password:  @@SECRET:E2E_DB_PASSWORD@@
```

Both passes fire: the classifier masks the token shape, and the cloak store
re-cloaks the registered value back to its placeholder.

**Full suite**, same box, same venv:

| | failed | passed | collection errors |
| --- | --- | --- | --- |
| `origin/main` | 21 | 2290 | 6 |
| this branch | 21 | 2353 | 0 |

Identical failure set — zero regressions, and the 21 are the suite's
pre-existing red.

## Not in scope

Vercel AI SDK and Mastra reach the runtime over `eval-server` and need the
redacted text returned in the HTTP response, which the issue calls out as
separate work.
