### PR TITLE
Move the __main__ guard to the end of cli.py

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -5853,10 +5853,6 @@ def format_tokens(payload: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-if __name__ == "__main__":
-    main()
-
-
 def _print_surfaces(workspace: Path) -> None:
     """Which enforcement surfaces are governing this machine, and which could be.
 
@@ -5913,3 +5909,12 @@ def _print_surfaces(workspace: Path) -> None:
     print(_color("  prismor mcp-gateway --help    front your MCP servers", _DIM))
     print(_color("  docs/governance-surfaces.md   which surface to use per agent", _DIM))
     print()
+
+
+# Must stay the LAST statement in this module. `python -m prismor.runtime.cli`
+# executes the file top to bottom, so anything defined below this line does not
+# exist yet when main() dispatches to it — which is how `prismor surfaces`
+# came to work through the console script and die with a NameError under
+# `python -m`. test_cli_main_guard_is_last keeps it here.
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_main_guard.py
+++ b/tests/test_cli_main_guard.py
@@ -1,0 +1,47 @@
+"""The ``if __name__ == "__main__"`` guard must be the last statement in a CLI.
+
+``python -m prismor.runtime.cli`` executes the module top to bottom, so a
+function defined *below* the guard does not exist yet when ``main()`` dispatches
+to it. That is not a hypothetical: ``_print_surfaces`` was appended after the
+guard, which left ``prismor surfaces`` working through the console script entry
+point (which imports the module fully, then calls ``main()``) and dying with
+``NameError: name '_print_surfaces' is not defined`` under ``python -m`` — the
+form the docs and several examples use.
+
+An AST check rather than a subprocess run, because the failure is structural and
+every ``main()`` dispatch that would exercise it reads real machine state
+(enrolment, installed hooks) that a test has no business depending on.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_RUNTIME = Path(__file__).resolve().parent.parent / "prismor" / "runtime"
+CLI_MODULES = ["cli.py", "immunity_cli.py"]
+
+
+def _guard_index(tree: ast.Module) -> int:
+    for i, node in enumerate(tree.body):
+        if (isinstance(node, ast.If) and isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Name)
+                and node.test.left.id == "__name__"):
+            return i
+    return -1
+
+
+@pytest.mark.parametrize("module", CLI_MODULES)
+def test_cli_main_guard_is_last(module):
+    path = _RUNTIME / module
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    idx = _guard_index(tree)
+    assert idx != -1, f"{module}: no `if __name__ == '__main__'` guard"
+
+    after = [n for n in tree.body[idx + 1:]
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))]
+    assert not after, (
+        f"{module}: {', '.join(n.name for n in after)} defined after the "
+        "__main__ guard — unreachable under `python -m`. Move the guard to the "
+        "end of the file.")


### PR DESCRIPTION
`prismor surfaces` dies under `python -m prismor.runtime.cli`:

```
NameError: name '_print_surfaces' is not defined. Did you mean: '_print_status'?
```

`_print_surfaces` sits below `if __name__ == "__main__": main()` at cli.py:5856, and `python -m` runs the file top to bottom — so `main()` dispatches to a function that does not exist yet. The console-script entry point imports the module first and then calls `main()`, which is why `prismor surfaces` looked fine and `python -m` did not. The `python -m` form is what `docs/live-telemetry.md` and the examples use.

Moving the guard to the end of the file fixes it for every function rather than this one, and `tests/test_cli_main_guard.py` asserts no function or class is defined below the guard in either CLI module (`cli.py`, `immunity_cli.py`) so the next thing appended to a 5900-line file cannot land in the same trap. The test fails on the bug and passes on the fix.

Verified on st3ve from a fresh clone: `python3 -m prismor.runtime.cli surfaces` now renders the full table; `tests/test_cli_main_guard.py` + `tests/test_cli.py` 54 passed.