### PR TITLE
fix(tests): prevent policy engine and module-state leaks across test suite (#308)

### DIFF
--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1406,7 +1406,15 @@ class PolicyEngine:
         # are reported with `contextInert` semantics and an `execTarget` origin,
         # but never block, until the real false-positive rate is known from
         # fleet telemetry. Enable blocking per-category once warmed up.
-        if event_type == "shell" and self.inspect_execution_targets:
+        # Never on a synthetic script line: the block below already walks the
+        # invocation tree, and it does so with a depth budget and with the
+        # nested file recorded as the finding's origin. Running this here too
+        # opens one more file per line — past _MAX_SCRIPT_DEPTH, and reporting
+        # a nested match with no `viaScript`, which then gets stamped with the
+        # OUTERMOST script's name on the way up. Same reason the other
+        # per-command side checks below are `_script_line`-gated.
+        if (event_type == "shell" and self.inspect_execution_targets
+                and not event.get("_script_line")):
             _cmd = field_values.get("command", "")
             if _cmd:
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,56 @@
-"""Make the bundled framework adapters importable from a source checkout.
+"""Suite-wide isolation so a leak in one test cannot rewrite another's verdict.
 
-Installed, ``prismor.langchain`` and friends land inside the same ``prismor/``
-package the runtime ships, so they are ordinary subpackages. In the repo they
-live under ``adapters/<framework>/prismor/<framework>/`` instead — and since
-``prismor/__init__.py`` exists (deliberately: it stops an unrelated installed
-``prismor`` distribution from shadowing the repo-local runtime, see
-PrismorSec/prismor#173), ``prismor`` is a regular package whose ``__path__``
-does not grow when a new sys.path entry appears. Four adapter test modules
-therefore failed at *collection* with ``No module named 'prismor.langchain'``
-unless the extras happened to be pip-installed.
+Also wires the bundled framework adapters so they are importable from a
+source checkout without separate package installation.
 
-Extending ``__path__`` here fixes all of them in one place, before any test
-module is imported. Each adapter directory also goes on ``sys.path`` so the
-flat ``prismor_<framework>`` implementation modules the shims re-export from
-resolve too.
+Two classes of cross-test state used to make ``pytest tests/`` red in ways that
+depended on which files ran before which — so the same test passed alone and
+failed in the suite, and CI signal degraded to "count the failures and hope".
+
+**1. Module-attribute leaks.** Several tests replaced a module function by plain
+assignment (``approvals._identity.load_identity = lambda: ...``) instead of
+``monkeypatch.setattr``, so the stub outlived the test for the rest of the
+process. Two of those compounded into the headline symptom: one left the device
+looking permanently enrolled to a fake org, another left a signed org policy
+that denied ``Bash`` — after which every shell event evaluated as ``block``,
+``ls -la`` included. ``_no_module_state_leaks`` snapshots every function and
+method reachable from the imported ``prismor`` package, restores anything a test
+replaced, and fails that test — so a leak is loud at its source instead of
+silent three files later.
+
+The snapshot walks module *objects*, not ``sys.modules`` names, because several
+tests drop a module from ``sys.modules`` to force a fresh import (to reset a
+module-level cache). Every module already holding ``from ... import identity as
+_identity`` keeps the *old* object, so two live copies of one module exist and a
+name-keyed guard would watch the wrong one.
+
+**2. Ambient $HOME / $PRISMOR_HOME.** The enrollment, identity, signing and
+ledger tests assume a not-enrolled machine with an empty event store. They
+passed on CI and failed on any enrolled developer laptop, and inside a run they
+leaked homes into each other — the shared sqlite ledger lives in $PRISMOR_HOME
+(``store.get_data_dir`` ignores its workspace argument), so a file's tests
+accumulated each other's rows. ``_isolated_prismor_home`` gives every test a
+fresh $HOME and $PRISMOR_HOME and restores the whole environment afterwards.
+
+Modules that deliberately provision their own vault at import time (the cloaking
+tests build a $PRISMOR_HOME with registered secrets and hand ``os.environ``
+straight to hook subprocesses) must keep it. Their import-time writes are
+recorded per module by ``pytest_make_collect_report`` and replayed for that
+module's tests, so declaring a home still works — it just no longer escapes into
+the modules collected after it.
 """
 from __future__ import annotations
 
+import inspect
+import os
 import sys
+import types
 from pathlib import Path
+from typing import Any, Dict, List, Tuple
 
+import pytest
+
+# Framework adapter imports
 _ADAPTERS = Path(__file__).resolve().parent.parent / "adapters"
 
 
@@ -37,3 +68,251 @@ def _wire_adapters() -> None:
 
 
 _wire_adapters()
+
+
+# Environment keys this file owns: the agent's home plus every Prismor knob.
+# Restored around every test, so nothing a test sets can reach the next one.
+_ENV_PREFIX = "PRISMOR_"
+_ENV_EXTRA = ("HOME",)
+
+
+def _tracked_env(env: Dict[str, str]) -> Dict[str, str]:
+    return {k: v for k, v in env.items() if k.startswith(_ENV_PREFIX) or k in _ENV_EXTRA}
+
+
+# Environment as pytest started, captured before any test module is imported.
+_PRISTINE_ENV: Dict[str, str] = {}
+# nodeid -> {env key: value or None} written while that module was imported.
+_MODULE_ENV: Dict[str, Dict[str, Any]] = {}
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    _PRISTINE_ENV.update(_tracked_env(os.environ))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_make_collect_report(collector: pytest.Collector):
+    """Record the env a test module writes while being imported.
+
+    Wraps ``collector.collect()``, which is where a Module is imported, so the
+    before/after diff is exactly that module's import-time declaration.
+    """
+    if not isinstance(collector, pytest.Module):
+        yield
+        return
+    before = _tracked_env(os.environ)
+    yield
+    after = _tracked_env(os.environ)
+    declared = {k: v for k, v in after.items() if before.get(k) != v}
+    declared.update({k: None for k in before if k not in after})
+    if declared:
+        _MODULE_ENV[collector.nodeid] = declared
+
+
+@pytest.fixture(scope="session")
+def _sandbox_home(tmp_path_factory) -> Any:
+    """One throwaway $HOME for the whole run, standing in for the developer's.
+
+    Session-scoped on purpose. A per-test $HOME would be more thorough, but
+    some modules freeze the home directory into a module-level constant at
+    import time (``corpus._HOME_RE`` compiles ``expanduser("~")`` once), and a
+    $HOME that moves underneath them makes their behaviour depend on which test
+    happened to import them first. $PRISMOR_HOME — which is what the runtime
+    actually reads, and where the shared sqlite ledger lives — is per test.
+    """
+    return tmp_path_factory.mktemp("home")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_prismor_home(request: pytest.FixtureRequest, tmp_path_factory,
+                           _sandbox_home) -> Any:
+    """Run every test against a fresh, not-enrolled $PRISMOR_HOME.
+
+    The full environment is restored afterwards, so a test that sets a variable
+    without cleaning up (a bare ``os.environ[...] = ...`` in ``setUp``) cannot
+    change what the next test sees.
+    """
+    saved = dict(os.environ)
+
+    for key in _tracked_env(os.environ):
+        if key not in _PRISTINE_ENV:
+            del os.environ[key]
+    os.environ.update(_PRISTINE_ENV)
+
+    os.environ["HOME"] = str(_sandbox_home)
+    os.environ["PRISMOR_HOME"] = str(tmp_path_factory.mktemp("prismor-home"))
+
+    # A module that provisioned its own home at import time keeps it.
+    module = getattr(request.node, "parent", None)
+    while module is not None and not isinstance(module, pytest.Module):
+        module = getattr(module, "parent", None)
+    if module is not None:
+        for key, value in _MODULE_ENV.get(module.nodeid, {}).items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+# module-attribute leak guard
+
+def _live_prismor_modules() -> List[types.ModuleType]:
+    """Every live ``prismor`` module object, including copies orphaned from
+    ``sys.modules`` by a test that popped the name to force a re-import but
+    that other modules still hold a reference to."""
+    import sys
+
+    seen: set = set()
+    found: List[types.ModuleType] = []
+    stack = [
+        m for name, m in list(sys.modules.items())
+        if name.startswith("prismor") and isinstance(m, types.ModuleType)
+    ]
+    while stack:
+        mod = stack.pop()
+        if id(mod) in seen:
+            continue
+        seen.add(id(mod))
+        found.append(mod)
+        try:
+            values = list(vars(mod).values())
+        except Exception:      # a module mid-teardown has no usable __dict__
+            continue
+        for value in values:
+            if (isinstance(value, types.ModuleType)
+                    and getattr(value, "__name__", "").startswith("prismor")
+                    and id(value) not in seen):
+                stack.append(value)
+    return found
+
+
+# key -> (module name, attribute path, current value). Functions and methods
+# only: module-level caches are dicts mutated in place, so their identity never
+# changes and they are never mistaken for a patch.
+_SnapKey = Tuple[int, str, str, Any]
+
+
+def _snapshot_callables() -> Dict[_SnapKey, Any]:
+    snap: Dict[_SnapKey, Any] = {}
+    for mod in _live_prismor_modules():
+        name = getattr(mod, "__name__", "?")
+        try:
+            items = list(vars(mod).items())
+        except Exception:
+            continue
+        for attr, value in items:
+            if isinstance(value, (types.FunctionType, types.BuiltinFunctionType)):
+                snap[(id(mod), name, attr, None)] = value
+            elif inspect.isclass(value) and getattr(value, "__module__", "").startswith("prismor"):
+                try:
+                    class_items = list(vars(value).items())
+                except Exception:
+                    continue
+                for cattr, cvalue in class_items:
+                    if isinstance(cvalue, (types.FunctionType, staticmethod, classmethod)):
+                        snap[(id(mod), name, attr, cattr)] = cvalue
+    return snap
+
+
+def _restore(key: _SnapKey, original: Any) -> str:
+    import sys
+
+    _mod_id, mod_name, attr, cattr = key
+    target = next((m for m in _live_prismor_modules() if id(m) == _mod_id), None)
+    if target is None:
+        target = sys.modules.get(mod_name)
+    label = f"{mod_name}.{attr}" + (f".{cattr}" if cattr else "")
+    if target is None:
+        return label
+    try:
+        if cattr is None:
+            setattr(target, attr, original)
+        else:
+            setattr(getattr(target, attr), cattr, original)
+    except Exception:
+        pass
+    return label
+
+
+def _snapshot_sys_modules() -> Dict[str, types.ModuleType]:
+    import sys
+
+    return {n: m for n, m in list(sys.modules.items()) if n.startswith("prismor")}
+
+
+def _restore_sys_modules(before: Dict[str, types.ModuleType]) -> None:
+    """Undo a test's re-import of a ``prismor`` module.
+
+    Several tests drop a module from ``sys.modules`` to reset a module-level
+    cache. When that name is imported again a *second* module object appears,
+    and every module that already did ``from ... import identity as _identity``
+    keeps the first — so the process runs two live copies of one module and a
+    ``monkeypatch.setattr`` lands on whichever copy the test happened to bind,
+    which is not necessarily the one the runtime calls.
+
+    Putting the original object back (on ``sys.modules`` and on its parent
+    package, which is what ``from pkg import sub`` actually reads) keeps one
+    canonical object per name, so patching a module means patching the module.
+    """
+    import sys
+
+    for name, original in before.items():
+        if sys.modules.get(name) is original:
+            continue
+        sys.modules[name] = original
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name) if parent_name else None
+        if parent is not None and getattr(parent, leaf, None) is not original:
+            try:
+                setattr(parent, leaf, original)
+            except Exception:
+                pass
+
+
+# Pristine value of every callable, taken once collection has imported all the
+# test modules (and with them the runtime they exercise). The per-test snapshot
+# below is the primary reference; this one covers a module a test imports for
+# the first time inside its own body, which has no per-test baseline.
+_BASELINE: Dict[_SnapKey, Any] = {}
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    _BASELINE.update(_snapshot_callables())
+
+
+@pytest.fixture(autouse=True)
+def _no_module_state_leaks() -> Any:
+    """Fail the test that leaves a patched ``prismor`` function behind.
+
+    ``monkeypatch.setattr`` / ``mock.patch`` undo themselves and never trip this;
+    a bare ``module.func = lambda: ...`` does. The original is put back either
+    way, so one offender cannot cascade into the rest of the run.
+    """
+    modules_before = _snapshot_sys_modules()
+    before = _snapshot_callables()
+    try:
+        yield
+    finally:
+        _restore_sys_modules(modules_before)
+        after = _snapshot_callables()
+        leaked = []
+        for key, current in after.items():
+            pristine = before.get(key, _BASELINE.get(key, current))
+            if current is not pristine:
+                leaked.append(_restore(key, pristine))
+        leaked = sorted(leaked)
+    if leaked:
+        pytest.fail(
+            "test leaked patched module state (restored, but fix the test): "
+            + ", ".join(leaked)
+            + "\nUse monkeypatch.setattr / mock.patch instead of assigning to a "
+              "module attribute, so the patch is undone when the test ends.",
+            pytrace=False,
+        )
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ import os
 import sys
 import types
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -192,10 +192,11 @@ def _live_prismor_modules() -> List[types.ModuleType]:
     return found
 
 
-# key -> (module name, attribute path, current value). Functions and methods
-# only: module-level caches are dicts mutated in place, so their identity never
-# changes and they are never mistaken for a patch.
-_SnapKey = Tuple[int, str, str, Any]
+# key -> (module object, module name, attribute name, class attribute name).
+# Functions and methods only: module-level caches are dicts mutated in place,
+# so their identity never changes and they are never mistaken for a patch.
+_SnapKey = Tuple[types.ModuleType, str, str, Optional[str]]
+_MISSING = object()
 
 
 def _snapshot_callables() -> Dict[_SnapKey, Any]:
@@ -208,7 +209,7 @@ def _snapshot_callables() -> Dict[_SnapKey, Any]:
             continue
         for attr, value in items:
             if isinstance(value, (types.FunctionType, types.BuiltinFunctionType)):
-                snap[(id(mod), name, attr, None)] = value
+                snap[(mod, name, attr, None)] = value
             elif inspect.isclass(value) and getattr(value, "__module__", "").startswith("prismor"):
                 try:
                     class_items = list(vars(value).items())
@@ -216,25 +217,37 @@ def _snapshot_callables() -> Dict[_SnapKey, Any]:
                     continue
                 for cattr, cvalue in class_items:
                     if isinstance(cvalue, (types.FunctionType, staticmethod, classmethod)):
-                        snap[(id(mod), name, attr, cattr)] = cvalue
+                        snap[(mod, name, attr, cattr)] = cvalue
     return snap
 
 
-def _restore(key: _SnapKey, original: Any) -> str:
+def _resolve(key: _SnapKey) -> Tuple[Any, Optional[str]]:
     import sys
 
-    _mod_id, mod_name, attr, cattr = key
-    target = next((m for m in _live_prismor_modules() if id(m) == _mod_id), None)
+    mod, mod_name, attr, cattr = key
+    target = sys.modules.get(mod_name, mod)
     if target is None:
-        target = sys.modules.get(mod_name)
+        return None, None
+    if cattr is None:
+        return target, attr
+    cls = inspect.getattr_static(target, attr, None)
+    if cls is None:
+        return None, None
+    return cls, cattr
+
+
+def _restore(key: _SnapKey, original: Any) -> str:
+    _mod, mod_name, attr, cattr = key
+    target, target_attr = _resolve(key)
     label = f"{mod_name}.{attr}" + (f".{cattr}" if cattr else "")
-    if target is None:
+    if target is None or target_attr is None:
         return label
     try:
-        if cattr is None:
-            setattr(target, attr, original)
+        if original is _MISSING:
+            if hasattr(target, target_attr):
+                delattr(target, target_attr)
         else:
-            setattr(getattr(target, attr), cattr, original)
+            setattr(target, target_attr, original)
     except Exception:
         pass
     return label
@@ -302,7 +315,12 @@ def _no_module_state_leaks() -> Any:
         _restore_sys_modules(modules_before)
         after = _snapshot_callables()
         leaked = []
-        for key, current in after.items():
+        for key in set(before) | set(after):
+            target, attr = _resolve(key)
+            if target is None or attr is None:
+                current = _MISSING
+            else:
+                current = inspect.getattr_static(target, attr, _MISSING)
             pristine = before.get(key, _BASELINE.get(key, current))
             if current is not pristine:
                 leaked.append(_restore(key, pristine))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,8 +193,10 @@ def _live_prismor_modules() -> List[types.ModuleType]:
 
 
 # key -> (module object, module name, attribute name, class attribute name).
-# Functions and methods only: module-level caches are dicts mutated in place,
-# so their identity never changes and they are never mistaken for a patch.
+# Functions and methods only: data attributes stay outside the snapshot by
+# design to avoid false positives on in-place mutated caches and dicts. A
+# non-callable replaced by a mock is therefore not tracked by this guard —
+# that is an intentional tradeoff for the leak class in #308.
 _SnapKey = Tuple[types.ModuleType, str, str, Optional[str]]
 _MISSING = object()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,5 @@
 """Suite-wide isolation so a leak in one test cannot rewrite another's verdict.
 
-Also wires the bundled framework adapters so they are importable from a
-source checkout without separate package installation.
-
 Two classes of cross-test state used to make ``pytest tests/`` red in ways that
 depended on which files ran before which — so the same test passed alone and
 failed in the suite, and CI signal degraded to "count the failures and hope".
@@ -38,6 +35,25 @@ straight to hook subprocesses) must keep it. Their import-time writes are
 recorded per module by ``pytest_make_collect_report`` and replayed for that
 module's tests, so declaring a home still works — it just no longer escapes into
 the modules collected after it.
+
+Framework adapter imports
+-------------------------
+Make the bundled framework adapters importable from a source checkout.
+
+Installed, ``prismor.langchain`` and friends land inside the same ``prismor/``
+package the runtime ships, so they are ordinary subpackages. In the repo they
+live under ``adapters/<framework>/prismor/<framework>/`` instead — and since
+``prismor/__init__.py`` exists (deliberately: it stops an unrelated installed
+``prismor`` distribution from shadowing the repo-local runtime, see
+PrismorSec/prismor#173), ``prismor`` is a regular package whose ``__path__``
+does not grow when a new sys.path entry appears. Four adapter test modules
+therefore failed at *collection* with ``No module named 'prismor.langchain'``
+unless the extras happened to be pip-installed.
+
+Extending ``__path__`` here fixes all of them in one place, before any test
+module is imported. Each adapter directory also goes on ``sys.path`` so the
+flat ``prismor_<framework>`` implementation modules the shims re-export from
+resolve too. (PrismorSec/prismor#389)
 """
 from __future__ import annotations
 
@@ -210,6 +226,15 @@ def _snapshot_callables() -> Dict[_SnapKey, Any]:
         except Exception:
             continue
         for attr, value in items:
+            if attr.startswith("__") and attr.endswith("__"):
+                # PEP 649 (Python 3.14) gives an annotated module a real
+                # FunctionType ``__annotate__`` that materialises lazily on
+                # first annotation access, i.e. *after* the baseline snapshot.
+                # Skipping module-level dunders here avoids 2 000+ spurious
+                # teardown errors on 3.14+ boxes. The class branch below is
+                # intentionally untouched, so a leaked PolicyEngine.__init__
+                # is still caught.
+                continue
             if isinstance(value, (types.FunctionType, types.BuiltinFunctionType)):
                 snap[(mod, name, attr, None)] = value
             elif inspect.isclass(value) and getattr(value, "__module__", "").startswith("prismor"):

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -12,6 +12,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -33,13 +34,25 @@ def _decision(action="step_up"):
 
 
 class ApprovalClient(unittest.TestCase):
+    def _patch(self, target, name, value):
+        """Patch for the duration of one test.
+
+        These stubs land on shared runtime modules — ``approvals._identity`` IS
+        ``prismor.runtime.enterprise.identity`` — so a bare assignment would
+        leave the whole process looking enrolled to a fake org for every test
+        that ran afterwards. See tests/conftest.py.
+        """
+        patcher = mock.patch.object(target, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def setUp(self):
         os.environ.pop("PRISMOR_APPROVALS", None)
         os.environ["PRISMOR_APPROVAL_POLL"] = "0.01"
         os.environ["PRISMOR_APPROVAL_TIMEOUT"] = "2"
         self._ident = {"device_key": "prism_dev_x", "api_base": "https://cp.example"}
-        approvals._identity.load_identity = lambda: self._ident
-        approvals._identity.revoked_backoff_active = lambda: False
+        self._patch(approvals._identity, "load_identity", lambda: self._ident)
+        self._patch(approvals._identity, "revoked_backoff_active", lambda: False)
         self._posts = []
         self._status_seq = []
 
@@ -50,8 +63,8 @@ class ApprovalClient(unittest.TestCase):
         def fake_status(ident, approval_id, timeout):
             return self._status_seq.pop(0) if self._status_seq else "pending"
 
-        approvals._post_request = fake_post
-        approvals._get_status = fake_status
+        self._patch(approvals, "_post_request", fake_post)
+        self._patch(approvals, "_get_status", fake_status)
 
     def test_not_step_up_returns_false(self):
         self.assertFalse(approvals.await_step_up(_decision(action="block")))
@@ -76,15 +89,16 @@ class ApprovalClient(unittest.TestCase):
         self.assertFalse(approvals.await_step_up(_decision()))
 
     def test_immediate_approved_on_create(self):
-        approvals._post_request = lambda ident, body, timeout: {"id": "a", "status": "approved"}
+        self._patch(approvals, "_post_request",
+                    lambda ident, body, timeout: {"id": "a", "status": "approved"})
         self.assertTrue(approvals.await_step_up(_decision()))
 
     def test_not_enrolled_fails_closed(self):
-        approvals._identity.load_identity = lambda: None
+        self._patch(approvals._identity, "load_identity", lambda: None)
         self.assertFalse(approvals.await_step_up(_decision()))
 
     def test_post_failure_fails_closed(self):
-        approvals._post_request = lambda ident, body, timeout: None
+        self._patch(approvals, "_post_request", lambda ident, body, timeout: None)
         self.assertFalse(approvals.await_step_up(_decision()))
 
 

--- a/tests/test_cloak_output_scrub.py
+++ b/tests/test_cloak_output_scrub.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+import pytest
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -54,7 +57,17 @@ def check(name: str, ok: bool, detail: str = "") -> None:
         print(f"  FAIL  {name}  {detail}")
 
 
+# The hook scripts are shell and parse their JSON payload with jq, failing
+# closed without it (decloak.sh denies outright). Skip rather than fail on a
+# box that hasn't got it — CI installs jq, so nothing is quietly lost there.
+# scrub-stream.sh degrades gracefully, so the tests that only use run_scrub
+# below still run.
+_HAVE_JQ = shutil.which("jq") is not None
+
+
 def run_hook(script: Path, payload: dict) -> dict | None:
+    if not _HAVE_JQ:
+        pytest.skip("jq not installed; cloaking hooks parse their payload with it")
     proc = subprocess.run(
         ["bash", str(script)],
         input=json.dumps(payload),

--- a/tests/test_cloak_prompt_stash.py
+++ b/tests/test_cloak_prompt_stash.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+
+import pytest
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -53,8 +56,14 @@ def check(name: str, ok: bool, detail: str = "") -> None:
 
 _last_stderr = ""
 
+# userprompt-guard.sh parses its payload with jq and exits silently without it.
+# Skip rather than fail where jq is missing; CI installs it.
+_HAVE_JQ = shutil.which("jq") is not None
+
 
 def run(prompt: str, session: str = "sess-A", env: dict | None = None) -> dict | None:
+    if not _HAVE_JQ:
+        pytest.skip("jq not installed; the cloaking prompt guard parses its payload with it")
     global _last_stderr
     payload = {"prompt": prompt, "cwd": str(_HOME), "session_id": session}
     proc = subprocess.run(["bash", str(_GUARD)], input=json.dumps(payload),

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -64,15 +64,25 @@ def test_initialize_database_adds_missing_columns(v158_workspace: Path) -> None:
     assert "recommended_version" in cols
 
 
-def test_connect_ro_self_heals(v158_workspace: Path, monkeypatch) -> None:
+def test_connect_ro_self_heals(v158_workspace: Path) -> None:
+    """A read path must heal a stale DB, not just crash-proof itself.
+
+    The upgrade sequence this reproduces: a v1.5.8 install kept its DB in the
+    workspace, ``get_data_dir`` relocates it to $PRISMOR_HOME on first touch,
+    and the schema is still v1.5.8 until something migrates it. Dashboard reads
+    go through ``_connect_ro``, which is where that migration has to happen.
+
+    Note the read paths query $PRISMOR_HOME only (``_state_query_workspaces``),
+    so the DB has to be relocated there before the read for this to test
+    anything — it is not enough to leave it in the workspace.
+    """
     store._MIGRATED_PATHS.clear()
-    monkeypatch.setattr(
-        store, "list_registered_workspaces", lambda: [v158_workspace]
-    )
+    db = store.get_db_path(v158_workspace)      # relocates ws/.prismor -> $PRISMOR_HOME
+    assert "session_id" not in _columns(db, "supply_chain_events")
+
     # Pre-migration DB: read paths must not crash on the missing session_id col.
     stats = store.get_supply_chain_stats(24)
     assert "kpis" in stats
-    db = store.get_db_path(v158_workspace)
     assert "session_id" in _columns(db, "supply_chain_events")
 
 

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -29,15 +30,22 @@ class DeferResolver(unittest.TestCase):
         self.deferred = deferred
         self.calls = []
 
+    def _patch(self, name, value):
+        """Patch a name on the shared ``deferred`` module for one test only —
+        a bare assignment outlives the test (see tests/conftest.py)."""
+        patcher = mock.patch.object(self.deferred, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _finding(self):
         return {"toolName": "Bash", "evidence_hash": "h1", "ruleId": "r1"}
 
     def test_allow(self):
-        self.deferred._adjudicate = lambda event: "allow"
+        self._patch("_adjudicate", lambda event: "allow")
         self.assertTrue(self.deferred.resolve_defer(self._finding(), {"type": "shell"}, session_id="s"))
 
     def test_deny(self):
-        self.deferred._adjudicate = lambda event: "deny"
+        self._patch("_adjudicate", lambda event: "deny")
         self.assertFalse(self.deferred.resolve_defer(self._finding(), {"type": "shell"}, session_id="s"))
 
     def test_cache_short_circuits_evaluator(self):
@@ -47,7 +55,7 @@ class DeferResolver(unittest.TestCase):
             n["c"] += 1
             return "allow"
 
-        self.deferred._adjudicate = counting
+        self._patch("_adjudicate", counting)
         f, ev = self._finding(), {"type": "shell"}
         self.assertTrue(self.deferred.resolve_defer(f, ev, session_id="s"))
         self.assertTrue(self.deferred.resolve_defer(f, ev, session_id="s"))  # cache hit
@@ -57,7 +65,6 @@ class DeferResolver(unittest.TestCase):
         def boom(event):
             raise RuntimeError("no evaluator")
 
-        self.deferred._adjudicate = self.deferred._adjudicate  # keep real (which catches internally)
         # Force the real _adjudicate to hit its except path via a bad event type.
         self.assertFalse(self.deferred.resolve_defer(self._finding(), None, session_id="s"))
 

--- a/tests/test_inference_hook.py
+++ b/tests/test_inference_hook.py
@@ -649,6 +649,14 @@ class HttpTest(unittest.TestCase):
         cls.ih = ih
         cls.secret = ih.generate_secret()
         cls.ws = Path(tempfile.mkdtemp(prefix="prismor-ih-http-"))
+        cls._ih_handler = InferenceHookHandler
+        cls._orig_ih_attrs = {
+            "workspace": InferenceHookHandler.workspace,
+            "file_config": InferenceHookHandler.file_config,
+            "cli_overrides": InferenceHookHandler.cli_overrides,
+            "config_error": InferenceHookHandler.config_error,
+            "cache": InferenceHookHandler.cache,
+        }
         InferenceHookHandler.workspace = cls.ws
         InferenceHookHandler.file_config = {"defaults": {"signing_secret": cls.secret, "enqueue_approvals": False}}
         InferenceHookHandler.cli_overrides = {}
@@ -665,6 +673,8 @@ class HttpTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.server.shutdown()
+        for k, v in getattr(cls, "_orig_ih_attrs", {}).items():
+            setattr(cls._ih_handler, k, v)
         _restore_env(cls._env)
 
     def _post(self, frame, *, secret=None, path="/v1/inference-hook", headers=None, unsigned=False):

--- a/tests/test_intent_capture.py
+++ b/tests/test_intent_capture.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -22,6 +23,11 @@ from prismor.runtime import scoped_agent  # noqa: E402
 
 
 class CaptureIntent(unittest.TestCase):
+    def _patch(self, target, name, value):
+        patcher = mock.patch.object(target, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def setUp(self):
         # Scoped rules live under $PRISMOR_HOME/scoped/<sid>.json (keyed by session
         # id in the prismor home, not the workspace) — isolate it so tests don't
@@ -34,8 +40,10 @@ class CaptureIntent(unittest.TestCase):
             self.calls.append({"goal": goal, "tools": list(available_tools)})
             return {"allowed_tools": available_tools, "goal": goal}
 
-        # Patch the names capture_intent imports from scoped_agent.
-        scoped_agent.synthesize_scoped_rules = fake_synth
+        # Patch the names capture_intent imports from scoped_agent. Via
+        # mock.patch.object so the stub cannot outlive the test — scoped_agent
+        # is shared with the runtime (see tests/conftest.py).
+        self._patch(scoped_agent, "synthesize_scoped_rules", fake_synth)
 
     def test_no_goal_is_noop(self):
         self.assertIsNone(intent_mod.capture_intent("", workspace=self.ws, session_id="s1"))
@@ -66,7 +74,7 @@ class CaptureIntent(unittest.TestCase):
         def boom(goal, available_tools, workspace):
             raise RuntimeError("synth exploded")
 
-        scoped_agent.synthesize_scoped_rules = boom
+        self._patch(scoped_agent, "synthesize_scoped_rules", boom)
         # Must swallow and return None, not propagate.
         self.assertIsNone(intent_mod.capture_intent("x", workspace=self.ws, session_id="s3"))
 

--- a/tests/test_module_state_leak_guard.py
+++ b/tests/test_module_state_leak_guard.py
@@ -1,0 +1,79 @@
+"""Tests for the _no_module_state_leaks fixture in conftest.py.
+
+Verifies that bare module/class-level attribute modifications (lambdas,
+MagicMocks, None, del) are detected at teardown, reported with the exact
+attribute path, and restored to prevent contamination of subsequent tests.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+import pytest
+
+import prismor.runtime.enterprise.identity as ident
+from prismor.runtime.policy_engine import PolicyEngine
+from tests.conftest import _no_module_state_leaks
+
+
+def test_leak_guard_detects_lambda_leak():
+    orig = ident.load_identity
+    gen = _no_module_state_leaks.__wrapped__()
+    next(gen)
+    ident.load_identity = lambda *a, **k: None
+    with pytest.raises(pytest.fail.Exception, match=r"prismor\.runtime\.enterprise\.identity\.load_identity"):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    assert ident.load_identity is orig
+
+
+def test_leak_guard_detects_magicmock_leak():
+    orig = ident.load_identity
+    gen = _no_module_state_leaks.__wrapped__()
+    next(gen)
+    ident.load_identity = mock.MagicMock(return_value=None)
+    with pytest.raises(pytest.fail.Exception, match=r"prismor\.runtime\.enterprise\.identity\.load_identity"):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    assert ident.load_identity is orig
+
+
+def test_leak_guard_detects_none_leak():
+    orig = ident.load_identity
+    gen = _no_module_state_leaks.__wrapped__()
+    next(gen)
+    ident.load_identity = None
+    with pytest.raises(pytest.fail.Exception, match=r"prismor\.runtime\.enterprise\.identity\.load_identity"):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    assert ident.load_identity is orig
+
+
+def test_leak_guard_detects_del_leak():
+    orig = ident.load_identity
+    gen = _no_module_state_leaks.__wrapped__()
+    next(gen)
+    del ident.load_identity
+    with pytest.raises(pytest.fail.Exception, match=r"prismor\.runtime\.enterprise\.identity\.load_identity"):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    assert ident.load_identity is orig
+
+
+def test_leak_guard_detects_class_method_leak():
+    orig = PolicyEngine.__init__
+    gen = _no_module_state_leaks.__wrapped__()
+    next(gen)
+    PolicyEngine.__init__ = mock.MagicMock(return_value=None)
+    with pytest.raises(pytest.fail.Exception, match=r"PolicyEngine\.__init__"):
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+    assert PolicyEngine.__init__ is orig

--- a/tests/test_org_tool_denies.py
+++ b/tests/test_org_tool_denies.py
@@ -180,7 +180,7 @@ def test_org_allow_does_not_lift_scoped_network_denial(tmp_path, monkeypatch):
     assert any(f.get("ruleId") == "scoped-agent" for f in d.findings)
 
 
-def test_tool_denies_sig_matches_server_format():
+def test_tool_denies_sig_matches_server_format(monkeypatch):
     # Reproduces lib/tool-policy.ts toolDeniesSig: sorted
     # id:tool:action:scope:scopeId lines -> sha256 -> 16 hex.
     import hashlib
@@ -189,7 +189,9 @@ def test_tool_denies_sig_matches_server_format():
         {"id": "b", "tool": "Bash", "action": "deny", "scope": "org", "scopeId": None},
         {"id": "a", "tool": "WebSearch", "action": "deny", "scope": "agent", "scopeId": "codex"},
     ]
-    rp.verify_and_load = lambda: {"settings": {"tool_denies": denies}}  # type: ignore
+    # Via monkeypatch: a bare assignment here left an org policy denying Bash in
+    # place for the rest of the process, so every later shell event blocked.
+    monkeypatch.setattr(rp, "verify_and_load", lambda: {"settings": {"tool_denies": denies}})
     lines = sorted([
         "b:Bash:deny:org:",
         "a:WebSearch:deny:agent:codex",

--- a/tests/test_receipt_signing.py
+++ b/tests/test_receipt_signing.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -33,12 +34,19 @@ class ReceiptSigning(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="prismor-sign-"))
         os.environ["PRISMOR_HOME"] = str(self.home)
-        # Fresh module state per test so the key cache doesn't leak across homes.
-        for mod in ("prismor.runtime.enterprise.receipt_signing",
-                    "prismor.runtime.enterprise.identity"):
-            sys.modules.pop(mod, None)
         from prismor.runtime.enterprise import receipt_signing as signing
         self.signing = signing
+        # Fresh key cache per test, so a key generated under one $PRISMOR_HOME
+        # is not served to the next. Dropping the module from sys.modules does
+        # NOT do this: `from prismor.runtime.enterprise import receipt_signing`
+        # finds the submodule still bound on the parent package and hands back
+        # the same object, cache and all — the re-import never happens.
+        for name, blank in (("_CACHED_KEY", None),
+                            ("_CACHED_PUBKEY_B64", None),
+                            ("_LOAD_ATTEMPTED", False)):
+            patcher = mock.patch.object(signing, name, blank)
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     def _record(self):
         return {

--- a/tests/test_workspace_scope_env.py
+++ b/tests/test_workspace_scope_env.py
@@ -12,6 +12,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO))
@@ -20,17 +21,26 @@ from prismor.runtime.enterprise import workspace_scope as ws  # noqa: E402
 
 
 class EnvScopeOverride(unittest.TestCase):
+    def _patch(self, target, name, value):
+        """Patch for the duration of one test.
+
+        ``ws._identity`` IS ``prismor.runtime.enterprise.identity``: assigning
+        to it directly would leave every later test on this process reading as
+        enrolled to org_1, with a claimed-repo pattern set. See tests/conftest.py.
+        """
+        patcher = mock.patch.object(target, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def setUp(self):
         os.environ.pop("PRISMOR_WORKSPACE_SCOPE", None)
+        self.addCleanup(os.environ.pop, "PRISMOR_WORKSPACE_SCOPE", None)
         self._ident = {"org_id": "org_1", "device_key": "k", "api_base": "https://cp.example"}
-        ws._identity.load_identity = lambda: self._ident
-        ws._identity.revoked_info = lambda: None
-        ws.detect_git_remote = lambda _w: None      # a container: no remote
-        ws.org_managed_patterns = lambda: ["github.com/acme/*"]
-        ws._load_overrides = lambda: {}
-
-    def tearDown(self):
-        os.environ.pop("PRISMOR_WORKSPACE_SCOPE", None)
+        self._patch(ws._identity, "load_identity", lambda: self._ident)
+        self._patch(ws._identity, "revoked_info", lambda: None)
+        self._patch(ws, "detect_git_remote", lambda _w: None)   # a container: no remote
+        self._patch(ws, "org_managed_patterns", lambda: ["github.com/acme/*"])
+        self._patch(ws, "_load_overrides", lambda: {})
 
     def test_repoless_workload_is_local_without_the_override(self):
         # The status quo this exists to fix: silent, total non-reporting.
@@ -65,14 +75,14 @@ class EnvScopeOverride(unittest.TestCase):
     def test_cannot_downgrade_a_repo_the_org_claims(self):
         # The security property: an org-claimed remote outranks the env var, so
         # a deployment cannot opt company code out of governance.
-        ws.detect_git_remote = lambda _w: "github.com/acme/payments"
+        self._patch(ws, "detect_git_remote", lambda _w: "github.com/acme/payments")
         os.environ["PRISMOR_WORKSPACE_SCOPE"] = "personal"
         r = ws.resolve_scope(Path("/srv/agent"))
         self.assertEqual(r["scope"], "managed")
         self.assertEqual(r["reason"], "org_claimed")
 
     def test_unenrolled_stays_local_regardless(self):
-        ws._identity.load_identity = lambda: None
+        self._patch(ws._identity, "load_identity", lambda: None)
         os.environ["PRISMOR_WORKSPACE_SCOPE"] = "managed"
         r = ws.resolve_scope(Path("/srv/agent"))
         self.assertEqual(r["scope"], "local")
@@ -81,7 +91,8 @@ class EnvScopeOverride(unittest.TestCase):
     def test_env_outranks_the_on_disk_override(self):
         # A container's $PRISMOR_HOME is often read-only, so the env var has to
         # win over a stale file written into the image.
-        ws._load_overrides = lambda: {str(Path("/srv/agent").resolve()): "personal"}
+        self._patch(ws, "_load_overrides",
+                    lambda: {str(Path("/srv/agent").resolve()): "personal"})
         os.environ["PRISMOR_WORKSPACE_SCOPE"] = "managed"
         r = ws.resolve_scope(Path("/srv/agent"))
         self.assertEqual(r["scope"], "managed")


### PR DESCRIPTION
### Problem

The test suite leaked a deny-everything `PolicyEngine` and modified module state across test boundaries, making `pytest tests/` red across the suite (e.g., `test_tool_policy_three_state.py::test_ask_produces_step_up_not_block` failing with `AssertionError: assert 'block' == 'step_up'`).

Two leaks compounded to produce the headline symptom:

    - `test_org_tool_denies.py` used a bare `rp.verify_and_load = lambda: ...` assignment, leaving a signed org policy in place that denied Bash org-wide.
    - `test_approvals.py` used a bare `approvals._identity.load_identity = lambda: ...` assignment, making all subsequent workspaces resolve as managed (the gate required for the org overlay to apply).

    Either leak alone is harmless - the bisect needed ~67 files before `test_org_tool_denies.py` to reproduce, because the compound effect only fires when both are installed.

    Additionally:

    - `test_workspace_scope_env.py`, `test_intent_capture.py`, and `test_defer.py` had uncleaned bare assignments on shared module objects.
    - `test_receipt_signing.py` relied on `sys.modules.pop(...)` to clear its key cache, which was a no-op because submodules remained bound to the parent package.
    - `policy_engine.py`'s `_check_execution_targets` ran on synthetic script lines, exceeding `_MAX_SCRIPT_DEPTH` and misattributing nested script provenance.

Closes #308. The `policy_engine.py` change also closes #355.

    ---

    ### Prior art - what already exists

    Standardized all module/attribute patching across test modules on `monkeypatch.setattr` and `unittest.mock.patch.object` with explicit `addCleanup` lifecycles, and added standard pytest autouse teardown fixtures in `tests/conftest.py`.

    ---

    ### Solution - high level

    1. Added `tests/conftest.py` providing suite-wide autouse isolation: per-test isolated `$PRISMOR_HOME`, session-scoped `$HOME`, `sys.modules` restoration, and an autouse `_no_module_state_leaks` fixture that snapshots callable attributes, restores them, and loudly fails any test that leaves bare-patched module attributes behind.
    2. Replaced bare assignments with `monkeypatch`/`mock.patch.object` across all offending test files (`test_approvals.py`, `test_org_tool_denies.py`, `test_workspace_scope_env.py`, `test_intent_capture.py`, `test_defer.py`, `test_db_migration.py`, `test_receipt_signing.py`).
    3. Prevented nested script inspection conflicts in `policy_engine.py` by skipping `_check_execution_targets` on synthetic script lines (see dedicated section below).
    4. Fixed `_no_module_state_leaks` to catch `MagicMock`, `None`, and `del` leaks - not just lambda replacements - by iterating `set(before) | set(after)` and reading current values via `inspect.getattr_static`.
    5. Skipped module-level dunder attributes in `_snapshot_callables` to suppress PEP 649 `__annotate__` false positives on Python 3.14+ (see dedicated section below).

    ---

    ### Deep dive - how it works

    **Module attribute snapshot & teardown guard (`tests/conftest.py`):**
    At collection finish, `_snapshot_callables()` records a baseline of all functions and class methods reachable from the imported `prismor` package. Before each test, it snapshots current callables and `sys.modules`. In the fixture teardown, it iterates the **union** of before and after keys, reads the current attribute via `inspect.getattr_static`, compares against the pristine snapshot, automatically restores modified callables to avoid cascading failures, and calls `pytest.fail()` with the exact module and attribute name that leaked.

    **Why the union of keys catches MagicMock / None / del (not just lambda):**
    The original snapshot filtered strictly for `FunctionType`/`BuiltinFunctionType`. Replacing a function with a `MagicMock` caused the attribute to drop out of the `after` snapshot, so the teardown loop never visited it. Iterating `set(before) | set(after)` and reading via `inspect.getattr_static` means every key seen in `before` is re-checked whatever the attribute holds now.

    **PEP 649 dunder skip (Python 3.14+):**
    PEP 649 gives an annotated module a module-level `__annotate__` that is a genuine `types.FunctionType`, materialised lazily on first annotation access - i.e. *after* `pytest_collection_finish` takes `_BASELINE`. This caused 2,411 spurious teardown errors on Python 3.14 boxes (one per test). Fix: skip any module-level attribute whose name starts and ends with `__` in `_snapshot_callables`. The class branch is intentionally unchanged, so a leaked `PolicyEngine.__init__` is still caught.

    **Canonical module identity restoration:**
    Tests that drop modules from `sys.modules` to clear caches can orphan references held by other modules (`from ... import foo as _foo`). `_restore_sys_modules` ensures one canonical module object exists on both `sys.modules` and its parent package.

    **Receipt signing cache:**
    Patches `_CACHED_KEY`, `_CACHED_PUBKEY_B64`, and `_LOAD_ATTEMPTED` directly via `mock.patch.object` instead of trying to re-import the module.

    ---

    ### policy_engine.py - script-line gating (closes #355)

    `_check_execution_targets` is now guarded with `and not event.get("_script_line")` so that invocation-tree walking maintains proper depth limits and provenance tracking when Prismor evaluates synthetic script lines.

    This matches the existing pattern already applied to five sibling per-command checks at lines  **1453, 1650, 1669, 1690, 1767, and 1888** - each gates on `not event.get("_script_line")` for the same reason. The new guard is a one-line, exact-precedent change; it does not weaken any detection on real shell events.

    --------


   ### Files changed

| File | Why it changed |
|---|---|
| `tests/conftest.py` | Suite-wide isolation fixtures (env isolation, `sys.modules` restoration, callable leak detection with MagicMock/None/del and dunder-skip for PEP 649). Preserves the full adapter `__path__` wiring docstring from `main` (referencing #173, #389). |
| `tests/test_org_tool_denies.py` | Converted bare `rp.verify_and_load = lambda` to `monkeypatch.setattr`. |
| `tests/test_approvals.py` | Replaced bare assignments on `_identity` with `_patch()` helper using `mock.patch.object` + `addCleanup`. |
| `tests/test_workspace_scope_env.py` | Converted all bare assignments on `ws._identity` and module functions to scoped `_patch()` helper. |
| `tests/test_receipt_signing.py` | Patched key cache attributes directly with `mock.patch.object` instead of ineffective `sys.modules.pop`. |
| `tests/test_intent_capture.py` | Converted `scoped_agent.synthesize_scoped_rules` assignment to `_patch()` helper. |
| `tests/test_defer.py` | Converted `self.deferred._adjudicate` assignments to scoped `_patch()` helper. |
| `tests/test_db_migration.py` | Relocated DB to `$PRISMOR_HOME` in `test_connect_ro_self_heals` and cleaned test fixtures. |
| `tests/test_cloak_output_scrub.py` | Added `_HAVE_JQ` skip checks when running without `jq` installed. |
| `tests/test_cloak_prompt_stash.py` | Added `_HAVE_JQ` skip checks when running without `jq` installed. |
| `tests/test_module_state_leak_guard.py` | New: regression tests verifying that leaks via lambda, MagicMock, None, del, and class methods (`PolicyEngine.__init__`) are detected and restored. |
| `tests/test_inference_hook.py` | `tearDownClass` now saves and restores `workspace`, `file_config`, `cli_overrides`, `config_error`, and `cache` to their initial class defaults. |
| `prismor/runtime/policy_engine.py` | Gated `_check_execution_targets` with `and not event.get("_script_line")` (closes #355). |

    ---

    ### Testing

    ```bash
    # Full test suite (randomized) - no ignores needed; all adapter files pass cleanly
    pytest tests/ -q
    # Result: 1 failed, 2440 passed, 17 skipped, 0 errors
    # (the 1 pre-existing failure in test_cli.py::TestCloakEnvImport is on main too - unrelated)

    # Ordered run
    pytest tests/ -q -p no:randomly
    # Result: 1 failed, 2440 passed, 17 skipped, 0 errors

    # Deliberate leak test (canary)
    pytest tests/test_module_state_leak_guard.py -v
    # Result: 5 passed - lambda, MagicMock, None, del, and class method leaks all detected

    # Policy validation & bytecode check
    prismor policy validate prismor/runtime/default_policy.yaml
    python3 -m py_compile prismor/runtime/policy_engine.py tests/conftest.py

  [✓] bash scripts/run_security_tests.sh passes
  [✓] Added or updated tests covering the new behavior
  [✓] prismor policy validate prismor/runtime/default_policy.yaml - policy rule changed
  ──────
  ### Security checklist

  [✓] No detection patterns hardcoded in Python - all rules live in YAML
  [✓] No real secrets, keys, or credentials in code, tests, fixtures, or docs
  [✓] No real secret values printed, logged, or serialized (used @@secret:<name>@@)
  [✓] No guardrail weakened; if one was, it is called out and justified above
  [✓] Docs that describe this behavior (SKILL.md, docs/, AGENTS.md) are still accurate
  ──────
  ### Diff size

Lines changed: +542 / -39 · Justification: most additions are the test harness isolation, snapshot/restore guard in tests/conftest.py, the MagicMock/del fix, PEP 649 dunder skip, and the new regression test file tests/test_module_state_leak_guard.py.