### PR TITLE
ci(windows): stop the block assertion from failing its own step

### DIFF
--- a/.github/workflows/security-regression.yml
+++ b/.github/workflows/security-regression.yml
@@ -61,6 +61,8 @@ jobs:
           python -m build --wheel --outdir dist
           python -m pip install --quiet (Get-ChildItem dist/*.whl).FullName
       - name: prismor setup end to end
+        env:
+          PRISMOR_NO_UPDATE_CHECK: "1"
         run: |
           # pwsh 7.4 turns any non-zero native exit code into a terminating
           # error under the runner's $ErrorActionPreference='Stop', so a
@@ -72,4 +74,9 @@ jobs:
           prismor setup --non-interactive --mode enforce --recommended --agents claude --scope global --no-backfill
           if ($LASTEXITCODE -ne 0) { throw "prismor setup failed with $LASTEXITCODE" }
           prismor check ((-join @('chm','od ','7','77 /tmp/build')))
-          if ($LASTEXITCODE -ne 2) { throw "expected the destructive-command block (exit 2), got $LASTEXITCODE" }
+          $code = $LASTEXITCODE
+          Write-Host "check exit: $code"
+          if ($code -ne 2) { throw "expected the destructive-command block (exit 2), got $code" }
+          # The runner appends `exit $LASTEXITCODE` to every pwsh step, so the
+          # blocked check's own exit 2 would fail the step it just satisfied.
+          exit 0


### PR DESCRIPTION
Follow-up to #331 — that job is still red on main.

`prismor check` on the destructive command exits 2, which is what the step asserts. But the runner appends `exit $LASTEXITCODE` to every pwsh step, so the step then exited 2 and failed. Capture the code, echo it, `exit 0`.

Green run on the same tree: https://github.com/PrismorSec/prismor/actions/runs/33254475478