### PR TITLE
fix(hooks): honor action: warn in the legacy enforce bridge

### DIFF
--- a/prismor/runtime/hooks.py
+++ b/prismor/runtime/hooks.py
@@ -545,13 +545,22 @@ def legacy_should_block(
     semantics: on a pre-action event, block a finding whose category is in the
     policy's ``block_categories`` — with the same read carve-out as the modern
     path. Only invoked by cli.py when installed with ``--mode enforce``.
+
+    A rule that declares a reporting action (``warn``/``log``) is honored as a
+    report even inside a blocking category, mirroring the carve-out
+    ``PolicyEngine._resolve_mode`` already applies on the modern path. Without
+    it a warn-intended rule hard-blocks purely because of the company its
+    category keeps.
     """
+    from prismor.runtime.contract import BLOCK, VERDICTS
     if not block_categories:
         return None
     if not _is_pre_action(str(event.get("agent_event", ""))):
         return None
     for finding in findings:
         if finding.get("contextInert"):
+            continue
+        if str(finding.get("action") or BLOCK).lower() not in VERDICTS:
             continue
         if finding.get("category") in block_categories:
             if (

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -146,6 +146,47 @@ class TestLegacyEnforceBridge(unittest.TestCase):
         self.assertIsNotNone(legacy_should_block(
             [{"category": "secret_access"}], event, self.CATS))
 
+    def test_reporting_action_is_not_blocked(self):
+        """warn/log are reports, not verdicts — even inside a block category."""
+        event = {"agent_event": "PreToolUse", "type": "shell"}
+        for action in ("warn", "log"):
+            self.assertIsNone(legacy_should_block(
+                [{"category": "destructive_command", "action": action}], event, self.CATS),
+                f"action: {action} should not block")
+
+    def test_verdict_actions_still_block(self):
+        """Every real verdict keeps blocking; absent action still defaults to block."""
+        event = {"agent_event": "PreToolUse", "type": "shell"}
+        for action in ("block", "step_up", "defer", "modify"):
+            self.assertIsNotNone(legacy_should_block(
+                [{"category": "destructive_command", "action": action}], event, self.CATS),
+                f"action: {action} must still block")
+        self.assertIsNotNone(legacy_should_block(
+            [{"category": "destructive_command"}], event, self.CATS))
+
+    def test_warn_finding_does_not_mask_a_later_block(self):
+        """A warn finding is skipped, not treated as the decision for the event."""
+        event = {"agent_event": "PreToolUse", "type": "shell"}
+        findings = [
+            {"category": "destructive_command", "action": "warn"},
+            {"category": "secret_exfiltration", "action": "block"},
+        ]
+        blocking = legacy_should_block(findings, event, self.CATS)
+        self.assertIsNotNone(blocking)
+        self.assertEqual(blocking["category"], "secret_exfiltration")
+
+    def test_shipped_warn_rule_does_not_block_under_the_bridge(self):
+        """End-to-end: the bundled policy is legacy, and its action: warn rules
+        must not hard-block when installed --mode enforce."""
+        from prismor.runtime.policy_engine import PolicyEngine
+        engine = PolicyEngine()
+        self.assertTrue(engine.is_legacy_policy)
+        event = {"agent_event": "PreToolUse", "type": "shell",
+                 "command": "npm install -g typescript", "tool": "Bash"}
+        findings = engine.evaluate(event, 0)
+        self.assertTrue(any(f.get("ruleId") == "pkg-install-global" for f in findings))
+        self.assertIsNone(legacy_should_block(findings, event, engine.block_categories))
+
 
 class TestIsLegacyPolicy(unittest.TestCase):
     """PolicyEngine.is_legacy_policy gates the enforce bridge."""


### PR DESCRIPTION
## Problem

`legacy_should_block()` decides whether to deny a call using **only the finding's
category**. It never looks at the rule's `action`:

```python
for finding in findings:
    if finding.get("contextInert"):
        continue
    if finding.get("category") in block_categories:   # <- action never consulted
```

So a rule that explicitly declares `action: warn` still hard-blocks, purely
because of the company its category keeps. This is not a corner case: the
**bundled `default_policy.yaml` is itself a legacy policy** (it sets
`block_categories`, and sets no `default_mode` and no rule-level `mode`), so
every install running `--mode enforce` takes this path.

23 shipped rules are `action: warn` inside a blocking category:

```
$ python3 -c "...PolicyEngine()..."
is_legacy_policy: True
action:warn rules inside a block_category: 23
   pkg-install-global            dependency_risk
   persistence-shell-profile     persistence
   lockfile-direct-edit          dependency_risk
   npm-git-install               dependency_risk
   pkg-install-unsafe-flags      dependency_risk
   ... (18 more)
```

Reproduction — the same three findings, down each path:

| Command | rule | `action` | modern path | legacy bridge |
|---|---|---|---|---|
| `npm install -g typescript` | `pkg-install-global` | `warn` | allow | **BLOCK** |
| `echo ... >> ~/.zshrc` | `persistence-shell-profile` | `warn` | allow | **BLOCK** |
| `vim package-lock.json` | `lockfile-direct-edit` | `warn` | allow | **BLOCK** |

Installing a global npm package is denied outright. These are exactly the
everyday actions whose false positives make people turn enforcement off, which
is its own security failure.

Two places in the tree already document the opposite behavior:

- `contract.py`: *"`warn`/`log` are reporting actions: they produce findings but
  **never a blocking decision**, so they are not verdicts."*
- `docs/prismor-runtime.md`: *"`warn` / `log` — Surface the finding; **the action
  still proceeds**."*

The modern path honors this. Only the legacy bridge does not.

Closes #

## Prior art — what already exists

- [x] **I reused an existing mechanism.** `contract.VERDICTS` is already the
      canonical set of actions that constitute a real verdict
      (`block`, `step_up`, `defer`, `modify`), with `warn`/`log` deliberately
      excluded. The fix filters on it rather than naming actions inline, so a
      future verdict added to `contract.py` is picked up here for free.

      I also followed `PolicyEngine._resolve_mode`, which already applies this
      exact carve-out on the modern path and documents it:
      *"The floor only applies to rules whose action is 'block'; a rule that
      explicitly declares action: 'warn' is honored as a warning even inside a
      core category — otherwise a warn-intended rule silently hard-blocks."*
      This PR makes the legacy bridge say the same thing.

      `hooks.py` already imports from `contract` locally inside `should_block`;
      the new import follows that style.

**Tangential updates:** none. No docs changed — `docs/prismor-runtime.md` and
`contract.py` already describe the fixed behavior; the code was the thing out of
line with them.

## Solution — high level

- Skip a finding in `legacy_should_block()` when its `action` is not a real
  verdict, mirroring the carve-out `_resolve_mode` already applies.
- Reuse `contract.VERDICTS` as the source of truth instead of hardcoding a list.
- A missing/empty `action` still defaults to `block`, so existing legacy
  policies that never set `action` are bit-for-bit unchanged.
- Add tests for the reporting actions, every verdict action, and an end-to-end
  case against the real bundled policy.

## Deep dive — how it works

`cli.py` calls this bridge only when `engine.is_legacy_policy` **and** the hooks
were installed `--mode enforce`. The bridge exists so upgrading an install does
not silently stop blocking: a pre-`mode` policy keeps its original
`block_categories` semantics.

The new guard sits after the `contextInert` check and before the category test:

```python
if str(finding.get("action") or BLOCK).lower() not in VERDICTS:
    continue
```

Ordering matters. It is a `continue`, not a `return None` — a warn finding is
**skipped**, not treated as the decision for the event. If a `warn` finding and a
`block` finding fire on the same command, the `block` still governs; a `return`
would have let any warn rule that happened to match first shadow a real deny.
`test_warn_finding_does_not_mask_a_later_block` covers exactly that.

`or BLOCK` preserves the fail-closed default: a finding with no `action` key, or
an empty one, is still a block. That is what keeps genuinely old policies
working — they predate `action` entirely.

What this deliberately does **not** do:

- It does not touch `step_up`, `defer`, or `modify`. All three stay in `VERDICTS`
  and keep blocking through this path. `step_up` in particular must still stop
  the call to route it to a human, so narrowing the check to `action == "block"`
  would have weakened a guardrail.
- It does not switch the bridge to `contract.strongest()`. The bridge documents
  itself as replicating the original first-match semantics, and changing the
  selection rule is a separate concern from the warn bug.
- It does not touch `default_policy.yaml`. The rules are already correct; the
  engine was not reading them.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/hooks.py` | The bug. `legacy_should_block()` now skips findings whose `action` is a reporting action rather than a verdict, and its docstring records the carve-out and why. |
| `tests/test_hooks.py` | Four cases added to `TestLegacyEnforceBridge`: `warn`/`log` do not block; all four verdicts plus a missing `action` still do; a warn finding does not mask a later block; and an end-to-end check that `npm install -g typescript` is not blocked under the real bundled policy. |

## Testing

```
python3 -m pytest tests/test_hooks.py -q -p no:randomly     # 34 passed
bash scripts/run_security_tests.sh                          # All checks passed
python3 -m pytest tests/ -q -p no:randomly                  # 22 failed, 2366 passed
```

The full suite has 22 pre-existing failures on `main`. I diffed the FAILED sets
with and without this patch: **identical, zero new failures, zero resolved**
(baseline 22 / with fix 22), and 4 more tests passing — the ones added here.

- [x] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [ ] If a policy rule changed — n/a, no rule changed
- [ ] If an integration changed — n/a

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No real secret values printed, logged, or serialized
- [x] No guardrail weakened. This is the one to scrutinize, so explicitly: the
      only findings that stop blocking are those whose rule author wrote
      `action: warn` or `action: log`. Every verdict action still blocks, a
      missing `action` still blocks, and the change cannot make a `block` rule
      permissive. It narrows enforcement to what the policy actually asked for.
- [x] Docs that describe this behavior are still accurate — they already
      described the post-fix behavior.

## Diff size

Lines changed: +50 / -0 (9 in `hooks.py`, 41 test)
