### PR TITLE
feat(sinks): export findings over OTLP/HTTP to any OpenTelemetry collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## [Unreleased]
 
+### Added
+- **`type: otel` telemetry sink** — findings export over OTLP/HTTP to any
+  OpenTelemetry collector, so Prismor's decisions land in the observability
+  stack a team already runs (Grafana, Honeycomb, Datadog, an OTel-fed SIEM)
+  without Prismor knowing which one is downstream. Emitted as *logs*, not
+  spans: a finding is a point-in-time detection, not a unit of work with a
+  duration. Every field the generic event carries — including runtime extras
+  like `agent`, `mode` and `subject` — becomes a `prismor.*` log attribute, so
+  the sink does not need updating when the event grows a field. No new
+  dependency: OTLP/JSON is a POST, built with the same stdlib `urllib` as the
+  webhook and Splunk sinks, and it inherits their best-effort dispatch, so a
+  collector that is down warns on stderr and never blocks a tool call.
+
+  ```yaml
+  outputs:
+    - type: otel
+      endpoint: http://localhost:4318        # /v1/logs appended if absent
+      headers: { "Authorization": "Bearer ${OTEL_TOKEN}" }
+  ```
+
 ## [1.44.0] — 2026-08-27
 
 ### Added

--- a/prismor/runtime/sinks.py
+++ b/prismor/runtime/sinks.py
@@ -20,6 +20,9 @@ Supported sink types (configured under ``settings.outputs`` in policy.yaml):
     - type: datadog            # Datadog Logs intake (OCSF body)
       api_key: ${DD_API_KEY}
       site: datadoghq.com
+    - type: otel               # OpenTelemetry collector (OTLP/HTTP logs)
+      endpoint: http://localhost:4318   # base URL; the sink appends /v1/logs
+      headers: { "Authorization": "Bearer ${OTEL_TOKEN}" }
     - type: prismor              # first-party control-plane sink
       # No config needed — the device key + endpoint come from the enrolled
       # identity at ~/.prismor/identity.json (see `prismor enroll`). Sends a
@@ -198,6 +201,85 @@ def _dispatch_datadog(cfg: Dict[str, Any], event: Dict[str, Any]) -> None:
     req.add_header("User-Agent", _http_user_agent())
     with urllib.request.urlopen(req, timeout=float(cfg.get("timeout_seconds", 3))) as resp:
         resp.read(16)
+
+
+# OTLP severity numbers (spec): 9 INFO, 13 WARN, 17 ERROR, 21 FATAL.
+_OTLP_SEVERITY = {"CRITICAL": 21, "HIGH": 17, "MEDIUM": 13, "LOW": 9}
+
+
+def _otlp_attr(key: str, value: Any) -> Dict[str, Any]:
+    """One OTLP KeyValue. Everything is stringified — findings carry free-form
+    evidence and nested subjects, and a collector must never reject the batch
+    over a type mismatch."""
+    if isinstance(value, (dict, list)):
+        value = json.dumps(value)
+    return {"key": key, "value": {"stringValue": str(value)}}
+
+
+def _format_otlp_logs(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a Prismor finding event to an OTLP/JSON ExportLogsServiceRequest.
+
+    Logs, not spans: a finding is a point-in-time detection, not a unit of work
+    with a duration. Any OTel collector fans this out to Grafana, Datadog,
+    Honeycomb and friends without Prismor knowing which one is downstream.
+    """
+    sev_name = str(event.get("severity", "LOW")).upper()
+    try:
+        ts = datetime.fromisoformat(str(event.get("@timestamp", "")).replace("Z", "+00:00"))
+    except ValueError:
+        ts = datetime.now(timezone.utc)
+
+    # Everything _build_event and its `extra` produced, minus the fields already
+    # carried by dedicated log-record/resource slots, becomes an attribute — so
+    # runtime extras (agent, mode, workspace, subject) ride along untouched.
+    skip = {"@timestamp", "severity", "title", "source", "hostname"}
+    attributes = [
+        _otlp_attr(f"prismor.{k}", v)
+        for k, v in event.items()
+        if k not in skip and v is not None
+    ]
+
+    return {
+        "resourceLogs": [{
+            "resource": {"attributes": [
+                _otlp_attr("service.name", "prismor"),
+                _otlp_attr("host.name", event.get("hostname") or _hostname()),
+            ]},
+            "scopeLogs": [{
+                "scope": {"name": "prismor.runtime.sinks"},
+                "logRecords": [{
+                    "timeUnixNano": str(int(ts.timestamp() * 1_000_000_000)),
+                    "severityNumber": _OTLP_SEVERITY.get(sev_name, 9),
+                    "severityText": sev_name,
+                    "body": {"stringValue": event.get("title") or event.get("evidence") or "Prismor finding"},
+                    "attributes": attributes,
+                }],
+            }],
+        }],
+    }
+
+
+def _dispatch_otel(cfg: Dict[str, Any], event: Dict[str, Any]) -> None:
+    """OTLP/HTTP logs exporter. Config: endpoint (base URL, /v1/logs appended
+    unless already present), [headers], [timeout_seconds]."""
+    import urllib.request
+
+    endpoint = cfg.get("endpoint") or cfg.get("url")
+    if not endpoint:
+        return
+    url = str(endpoint).rstrip("/")
+    if not url.endswith("/v1/logs"):
+        url = f"{url}/v1/logs"
+    headers = {"Content-Type": "application/json"}
+    extra_headers = cfg.get("headers") or {}
+    if isinstance(extra_headers, dict):
+        for k, v in extra_headers.items():
+            headers[str(k)] = str(v)
+    data = json.dumps(_format_otlp_logs(event)).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    req.add_header("User-Agent", _http_user_agent())
+    with urllib.request.urlopen(req, timeout=float(cfg.get("timeout_seconds", 3))) as resp:
+        resp.read(16)  # drain
 
 
 def _format_cef(event: Dict[str, Any]) -> str:
@@ -432,6 +514,7 @@ _DISPATCHERS = {
     "file": _dispatch_file,
     "splunk": _dispatch_splunk_hec,
     "datadog": _dispatch_datadog,
+    "otel": _dispatch_otel,
 }
 
 

--- a/tests/test_sinks_otel.py
+++ b/tests/test_sinks_otel.py
@@ -1,0 +1,111 @@
+"""Tests for the OTLP/HTTP logs sink."""
+import json
+
+from prismor.runtime import sinks
+
+
+def _event():
+    finding = {
+        "severity": "CRITICAL",
+        "category": "secret_exfiltration",
+        "ruleId": "secret-exfiltration",
+        "action": "block",
+        "title": "Secret file piped to network",
+        "evidence": ".env | curl webhook.site",
+        "id": "sess_4f2a:finding-1",
+    }
+    return sinks._build_event(
+        finding, extra={"agent": "claude", "mode": "enforce", "subject": {"user_id": "alice"}}
+    )
+
+
+def _record(payload):
+    return payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+
+
+def _attrs(payload):
+    return {a["key"]: a["value"]["stringValue"] for a in _record(payload)["attributes"]}
+
+
+def test_otlp_shape():
+    payload = sinks._format_otlp_logs(_event())
+    resource = {
+        a["key"]: a["value"]["stringValue"]
+        for a in payload["resourceLogs"][0]["resource"]["attributes"]
+    }
+    assert resource["service.name"] == "prismor"
+    assert resource["host.name"]
+
+    rec = _record(payload)
+    assert rec["severityNumber"] == 21  # CRITICAL -> FATAL
+    assert rec["severityText"] == "CRITICAL"
+    assert rec["body"]["stringValue"] == "Secret file piped to network"
+    assert int(rec["timeUnixNano"]) > 0
+
+    attrs = _attrs(payload)
+    assert attrs["prismor.rule_id"] == "secret-exfiltration"
+    assert attrs["prismor.action"] == "block"
+    assert attrs["prismor.session_id"] == "sess_4f2a"
+    # Runtime extras ride along without the formatter knowing about them.
+    assert attrs["prismor.agent"] == "claude"
+    assert attrs["prismor.mode"] == "enforce"
+    # Nested values are JSON-encoded, never dropped.
+    assert json.loads(attrs["prismor.subject"])["user_id"] == "alice"
+
+    json.dumps(payload)  # collectors ingest JSON
+
+
+def test_severity_mapping():
+    for name, num in (("LOW", 9), ("MEDIUM", 13), ("HIGH", 17), ("CRITICAL", 21)):
+        ev = sinks._build_event({"severity": name, "title": "t"})
+        assert _record(sinks._format_otlp_logs(ev))["severityNumber"] == num
+
+
+def test_bad_timestamp_does_not_raise():
+    ev = sinks._build_event({"severity": "LOW", "title": "t"})
+    ev["@timestamp"] = "not-a-timestamp"
+    assert int(_record(sinks._format_otlp_logs(ev))["timeUnixNano"]) > 0
+
+
+def test_dispatcher_registered():
+    assert "otel" in sinks._DISPATCHERS
+
+
+def test_otel_post(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, *_):
+            return b""
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = {k.lower(): v for k, v in req.header_items()}
+        captured["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    sinks._dispatch_otel(
+        {"endpoint": "http://localhost:4318", "headers": {"Authorization": "Bearer tok"}},
+        _event(),
+    )
+    assert captured["url"] == "http://localhost:4318/v1/logs"
+    assert captured["headers"]["authorization"] == "Bearer tok"
+    assert _attrs(captured["body"])["prismor.rule_id"] == "secret-exfiltration"
+
+    # An endpoint that already names the signal path is not double-suffixed.
+    sinks._dispatch_otel({"endpoint": "https://otel.example/v1/logs"}, _event())
+    assert captured["url"] == "https://otel.example/v1/logs"
+
+
+def test_missing_endpoint_is_a_noop():
+    sinks._dispatch_otel({}, _event())  # must not raise


### PR DESCRIPTION
## Problem

Prismor's findings can reach a SIEM — `webhook`, `syslog`, `file`, `splunk`, `datadog` are all in `sinks.py` today — but they cannot reach an OpenTelemetry collector, which is where most teams' operational telemetry actually lands. A team running Grafana, Honeycomb, Tempo/Loki, or an OTel-fed pipeline has no supported way to see Prismor decisions next to the rest of their agent telemetry.

Concretely, today the only paths to those backends are: point the `webhook` sink at a collector and get a rejected payload (a collector will not accept Prismor's flat event shape — OTLP/HTTP requires the `resourceLogs` envelope), or stand up a bespoke translator between Prismor and the collector. Both are a "write your own adapter" answer to the single most common observability question an evaluator asks.

There is no issue number for this; it came out of a competitive gap review against OTel-native agent-observability tooling, where "OpenTelemetry-native" is the headline integration claim and the one Prismor could not match.

## Prior art — what already exists

- [x] **I extended an existing pattern.** Which one, and what I followed:
      The sink pattern in `prismor/runtime/sinks.py` — a `_dispatch_<kind>(cfg, event)` function registered in the `_DISPATCHERS` table, configured under `settings.outputs` in policy.yaml. `_dispatch_otel` follows `_dispatch_webhook`/`_dispatch_splunk_hec` line for line: stdlib `urllib.request`, `Content-Type: application/json`, `_http_user_agent()`, `timeout_seconds` with a short default, drain the response. The paired formatter follows `_format_ocsf` — take the generic event from `_build_event`, return a dict, let the caller JSON-encode.

Because the dispatcher table is the only registration point (`policy_engine.py:1060` reads `settings.outputs`, `runtime.py:687-706` hands the list to `sinks.dispatch`), no call site, config loader, or schema needed touching. Registering the key is the whole wiring.

I deliberately did **not** add `opentelemetry-sdk`. OTLP/HTTP with a JSON body is a plain POST, which the existing sinks already know how to do; pulling in the SDK (and its transitive API/proto packages) to format a dict would add a dependency and a second HTTP path for no capability. The SDK earns its place only if someone needs gRPC OTLP or trace-context correlation, and neither is in scope here.

**Tangential updates:** none. No shared helper changed; `_build_event`, `_expand_env`, and `dispatch` are all used as-is.

## Solution — high level

- Adds a `type: otel` sink that exports each finding to an OpenTelemetry collector over OTLP/HTTP, so Prismor decisions land in whatever observability backend a team already runs without Prismor knowing which one is downstream.
- Emits the **logs** signal, not spans: a finding is a point-in-time detection, not a unit of work with a duration.
- Derives log attributes from the generic event rather than enumerating them, so runtime extras (`agent`, `mode`, `workspace`, `subject`) ride along automatically and the formatter needs no update when the event grows a field.
- Zero new dependencies and no new failure mode — stdlib `urllib` like every other sink, inheriting the existing best-effort dispatch.

```yaml
outputs:
  - type: otel
    endpoint: http://localhost:4318        # /v1/logs appended if absent
    headers: { "Authorization": "Bearer ${OTEL_TOKEN}" }
```

## Deep dive — how it works

**Control flow.** Unchanged from every other generic sink. `runtime.py:_forward_to_sinks` passes findings plus an `extra` dict to `sinks.dispatch`; `dispatch` splits off the first-party `prismor` sink, then for each finding builds one event via `_build_event(finding, extra=extra)` and hands it to the dispatcher matching `type`. `_dispatch_otel` is now one of those. `_expand_env` still runs on the config first, so `${OTEL_TOKEN}` in `headers` is substituted before the request is built — verified live, not assumed.

**Payload.** `_format_otlp_logs` returns an `ExportLogsServiceRequest`: one `resourceLogs` entry carrying `service.name=prismor` and `host.name`, one `logRecord` with `timeUnixNano`, `severityNumber`/`severityText`, and `body`. Severity maps onto the OTLP scale — CRITICAL→21 (FATAL), HIGH→17 (ERROR), MEDIUM→13 (WARN), LOW→9 (INFO) — so collector-side severity filters and alert routing work without anyone writing a mapping rule.

**Attributes are derived, not enumerated.** Rather than listing the fields to export, the formatter takes every key in the event that is not already carried by a dedicated log-record or resource slot (`@timestamp`, `severity`, `title`, `source`, `hostname`) and emits it as `prismor.<key>`. That is the one design decision worth arguing about, so: the alternative — an explicit field list — silently drops anything new. `runtime.py` already injects `agent`, `agent_name`, `mode`, `workspace`, `session_id`, and `subject` through `extra`, and that set has grown over time. Deriving means this sink cannot fall behind the event.

**Edge cases handled.**
- *Endpoint suffix.* `/v1/logs` is appended unless already present, so both `http://localhost:4318` and a full signal URL work. Someone pasting the URL their vendor's docs gave them is the common case and must not produce `/v1/logs/v1/logs`.
- *Malformed timestamp.* `datetime.fromisoformat` on a bad `@timestamp` falls back to now rather than raising. A telemetry sink must never be the thing that turns a finding into an exception, and there is a test pinning this.
- *Missing endpoint.* No-ops silently, matching `_dispatch_webhook`/`_dispatch_splunk_hec`. A half-configured sink should be inert, not fatal.
- *Non-scalar values.* `subject` is a dict; `_otlp_attr` JSON-encodes dicts and lists and stringifies everything else, because a collector rejecting an entire batch over one type mismatch would lose findings that have nothing to do with the offending field.
- *Collector down.* Nothing new needed — `dispatch` already swallows sink exceptions with a stderr warning, so an unreachable collector warns and never blocks a tool call.

**Deliberately not done.** No `opentelemetry-sdk` (see prior art). No batching or retry — `dispatch` is per-finding and best-effort by design, and adding a queue here would mean a background thread on the hot path. No traces or metrics signals; logs is the correct semantic home for a detection finding, and adding span export before anyone asks for trace correlation would be inventing structure.

**Security posture:** unchanged. No guardrail touched, no detection logic involved, no new Python patterns. This sink carries no first-party credential — unlike `type: prismor`, whose destination is pinned precisely because it carries the device key, `otel` sends only to an operator-configured endpoint with operator-configured headers, so there is nothing here for a local `policy.yaml` to redirect. It exports the same generic event the `webhook` sink already exports, so it widens no privacy boundary: the redacted-record path belongs to `type: prismor` and is untouched.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/sinks.py` | Adds `_format_otlp_logs` + `_dispatch_otel` + the `_otlp_attr` helper and `_OTLP_SEVERITY` map; registers `"otel"` in `_DISPATCHERS`; documents the config block in the module docstring alongside the other sink types. |
| `tests/test_sinks_otel.py` | New. Covers the behavior — payload shape, severity mapping, timestamp fallback, endpoint-suffix idempotence, header expansion, no-op on missing config. |
| `CHANGELOG.md` | New sink is user-facing configuration; `[Unreleased]` entry with the YAML block, following house style. |

## Testing

```
# new coverage
python3 -m pytest tests/test_sinks_otel.py -p no:randomly -q      # 6 passed

# sink + telemetry neighbourhood
python3 -m pytest tests/ -p no:randomly -q -k "sink or telemetry or output"
# 99 passed, 2 skipped

# CI gate
bash scripts/run_security_tests.sh                                # All security regression checks passed

# full suite, this branch
python3 -m pytest tests/ -p no:randomly -q
# 22 failed, 2368 passed, 24 skipped

# full suite, clean origin/main worktree, same command
# 22 failed, 2362 passed, 24 skipped
```

The 22 failures are pre-existing on `origin/main` and the two FAILED sets are identical — I diffed them from a detached baseline worktree rather than reading red as regression. The delta is +6 passing, exactly the new tests.

Also smoke-tested live against a real HTTP listener standing in for a collector, driven through the full `sinks.dispatch()` path rather than by calling the dispatcher directly: the request arrived on `/v1/logs`, `${SMOKE_TOKEN}` was expanded in the `Authorization` header, the Prismor user-agent was set, severity was 17/HIGH, and all eight `prismor.*` attributes were present including the `extra`-injected `agent` and `mode`.

- [x] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [ ] If a policy rule changed: n/a — no policy rule changed
- [ ] If an integration changed: n/a — no registry entry changed

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML (this PR adds no detection logic at all)
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs (test tokens are literals like `tok`)
- [x] No real secret values printed, logged, or serialized
- [x] No guardrail weakened
- [x] Docs that describe this behavior are still accurate — the sink list lives in the `sinks.py` module docstring, updated here; no `docs/` page enumerates sink types

## Diff size

Lines changed: +214 / -0 · Three files, one of which is the test and one the changelog. The functional change is 83 lines in `sinks.py`, following the existing dispatcher pattern.
