### PR TITLE
fix(scope): the MCP mirror is not a gateway fan-out point

### DIFF
--- a/prismor/runtime/scoped_agent.py
+++ b/prismor/runtime/scoped_agent.py
@@ -159,12 +159,19 @@ def _gateway_upstreams(entry, home):
     aggregates every upstream under ONE server name, so scoping must see
     through it to the upstreams -- otherwise the only family is
     ``mcp__<gateway>__*`` and no task prompt ever names it, so every gatewayed
-    MCP tool is denied by omission."""
+    MCP tool is denied by omission.
+
+    ``--mirror`` is not a fan-out point: it serves the agent's own built-ins
+    under one family and fronts nothing, so it keeps ``mcp__<mirror>__*``.
+    Expanding it would replace that family with upstreams it does not serve,
+    leaving the mirrored built-ins matching no family at all — denied by
+    omission, which is the failure this function exists to prevent. Same guard
+    as ``_gateway_inner_servers``."""
     if not isinstance(entry, dict):
         return None
     args = entry.get("args") or []
     argv = " ".join(str(a) for a in args)
-    if "mcp-gateway" not in argv:
+    if "mcp-gateway" not in argv or "--mirror" in args:
         return None
     cfg = None
     for i, a in enumerate(args):

--- a/tests/test_scope_mirrored_builtins.py
+++ b/tests/test_scope_mirrored_builtins.py
@@ -148,6 +148,63 @@ def test_gateway_fronted_servers_get_their_own_families(tmp_path):
     assert "mcp__prismor-tools__*" in fams
 
 
+def test_mirror_is_not_expanded_when_a_gateway_config_exists(tmp_path, monkeypatch):
+    """A mirror entry carries no --config, so the upstream lookup falls back to
+    ~/.prismor/mcp-gateway.json. On any machine that also runs the gateway that
+    file exists, and expanding the mirror against it replaced
+    ``mcp__prismor-tools__*`` with families the mirror does not serve — leaving
+    every mirrored built-in matching no family, i.e. denied by omission.
+
+    The test above only caught this where a real gateway config happened to be
+    present, so it passed in CI and failed on a developer box. Force the
+    condition with a fake HOME instead.
+    """
+    import json as _json
+    from prismor.runtime.scoped_agent import discover_mcp_families
+
+    home = tmp_path / "home"
+    (home / ".prismor").mkdir(parents=True)
+    (home / ".prismor" / "mcp-gateway.json").write_text(
+        _json.dumps({"mcpServers": {"cfdocs": {}, "mslearn": {}}}))
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".mcp.json").write_text(_json.dumps({"mcpServers": {
+        "prismor-tools": {"command": "python3",
+                          "args": ["-m", "x", "mcp-gateway", "--mirror"]},
+    }}))
+
+    fams = discover_mcp_families(ws)
+    assert "mcp__prismor-tools__*" in fams
+    # It must not inherit the gateway's upstreams, which it does not front.
+    assert "mcp__prismor-tools__cfdocs__*" not in fams
+    assert "mcp__prismor-tools__mslearn__*" not in fams
+
+
+def test_gateway_without_config_still_expands_against_the_default(tmp_path, monkeypatch):
+    """The --config fallback is load-bearing for a real gateway entry; only the
+    mirror is exempt. Guards against fixing the mirror by breaking the default."""
+    import json as _json
+    from prismor.runtime.scoped_agent import discover_mcp_families
+
+    home = tmp_path / "home"
+    (home / ".prismor").mkdir(parents=True)
+    (home / ".prismor" / "mcp-gateway.json").write_text(
+        _json.dumps({"mcpServers": {"cfdocs": {}}}))
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".mcp.json").write_text(_json.dumps({"mcpServers": {
+        "prismor": {"command": "prismor", "args": ["mcp-gateway", "--mode", "enforce"]},
+    }}))
+
+    fams = discover_mcp_families(ws)
+    assert "mcp__prismor__cfdocs__*" in fams
+    assert "mcp__prismor__*" not in fams
+
+
 def test_gateway_family_token_matches_the_fronted_server_name(tmp_path):
     from prismor.runtime.scoped_agent import _mcp_family_tokens
     assert "filesystem" in _mcp_family_tokens("mcp__prismor__filesystem__*")


### PR DESCRIPTION
## Problem

#323 fixed five defects that only appear when the MCP gateway and the built-in
mirror are installed together. One of them — *"the mirror is not a fan-out
point"* — was fixed in `_gateway_inner_servers`, but **not in its twin**
`_gateway_upstreams`, which is the one `_gateway_expansion` actually calls.

```python
# _gateway_inner_servers  (fixed in #323)
if "mcp-gateway" not in args or "--mirror" in args:
    return []

# _gateway_upstreams  (the one _gateway_expansion calls)
if "mcp-gateway" not in argv:      # <- no --mirror guard
    return None
```

A mirror entry carries no `--config`, so the upstream lookup falls back to
`~/.prismor/mcp-gateway.json`. **On any machine that also runs the gateway, that
file exists**, and the mirror inherits servers it does not front. Since
`discover_mcp_families` applies the expansion as `expansion.get(fam, [fam])`, the
real family is *replaced*:

| | families for a workspace whose only MCP server is the mirror |
|---|---|
| expected | `mcp__prismor-tools__*` |
| actual on `main` | `mcp__prismor-tools__cfdocs__*`, `mcp__prismor-tools__mslearn__*` |

The consequence is a **scope that widens on the wrong word**. The static
fallback allows an MCP family when the goal names one of its tokens. Because the
mirror now carries the token `cfdocs`, the goal *"use cfdocs to look up workers"*
allows `mcp__prismor-tools__cfdocs__search` — a call routed through the mirror to
a server the mirror never served, permitted by a scope that should never have
heard of it.

**Before — `origin/main` (23439e6)**

![before](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/mirror-fanout/mirror-before.png)

**After — this PR**

![after](https://raw.githubusercontent.com/PrismorSec/prismor/pr-assets/mirror-fanout/mirror-after.png)

### How to replicate

The script is on the assets branch and builds a throwaway `HOME` and workspace,
so it does not touch your real config:

```bash
git fetch origin pr-assets/mirror-fanout
git show origin/pr-assets/mirror-fanout:repro_demo.py > /tmp/repro_demo.py

python3 /tmp/repro_demo.py /path/to/prismor    # on main: ALLOWED
python3 /tmp/repro_demo.py /path/to/prismor    # on this branch: DENIED
```

It sets up exactly this state:

1. `~/.prismor/mcp-gateway.json` lists `cfdocs` + `mslearn` — a gateway config, as
   `prismor mcp-gateway install` writes.
2. The workspace `.mcp.json` lists **only** `prismor-tools`, the mirror
   (`--mirror`, no `--config`), as `prismor mirror on` writes.
3. Ask for the families, then check `mcp__prismor-tools__cfdocs__search` against a
   scope synthesised for the goal *"use cfdocs to look up workers"*.

Or, without the script — this is the whole bug in three lines:

```python
from prismor.runtime.scoped_agent import discover_mcp_families
# workspace .mcp.json = {"prismor-tools": {"args": ["mcp-gateway", "--mirror"]}}
discover_mcp_families(ws)   # main: ['mcp__prismor-tools__cfdocs__*', ...]
```

Closes #

## Prior art — what already exists

- [x] **I extended an existing pattern.** The guard is the one #323 already
      wrote for `_gateway_inner_servers`, applied verbatim to the twin that was
      missed. No new concept: `--mirror` means "serves its own built-ins, fronts
      nothing", and both readers of a gateway spec now agree on that.

**Tangential updates:** none.

**Noted, deliberately not done here:** `_gateway_inner_servers` and
`_gateway_upstreams` are near-duplicates — same job, two bodies, differing only
in exact-vs-substring `mcp-gateway` matching and `Path.home()` vs a passed
`home`. That duplication *is* the root cause of this bug: #323 fixed one copy.
Collapsing them is the right follow-up, but it changes matching semantics in
security code and belongs in its own PR, not smuggled into a two-token fix.

## Solution — high level

- Add the `--mirror` guard to `_gateway_upstreams`, matching `_gateway_inner_servers`.
- Document *why* the mirror is exempt, so the next person changing one copy sees
  the invariant.
- Add a hermetic regression test that forces the condition with a fake `HOME`.
- Add the converse test: a real gateway with no `--config` must still expand
  against the default config.

## Deep dive — how it works

`_gateway_expansion` builds `{family: [expanded families]}` and
`discover_mcp_families` applies it with `expansion.get(fam, [fam])`. That is a
*replacement*, not an addition — deliberately, because registering the bare
gateway family alongside the expanded ones would glob-deny every server it
fronts. So an entry wrongly classified as a gateway does not merely gain extra
families; it **loses its own**.

That is why the mirror must never reach this path: it has no upstreams to expand
into, and the fallback config path guarantees it finds someone else's.

The tricky part is why this survived review. The test #323 shipped,
`test_gateway_fronted_servers_get_their_own_families`, does assert
`"mcp__prismor-tools__*" in fams` — but it never creates
`~/.prismor/mcp-gateway.json`. On a clean CI runner that file is absent,
`_read_json` returns `{}`, no upstreams come back, and the assertion passes for
the wrong reason. It only fails on a machine that has actually run the gateway —
i.e. it passed in CI and failed for anyone dogfooding both features, which is
precisely the audience #323 was written for. `test_mirror_is_not_expanded_when_a_gateway_config_exists`
monkeypatches `Path.home()` to a populated fake, so the condition is forced
rather than inherited from the developer's box.

What this deliberately does **not** do:

- It does not change the `--config` fallback. That fallback is load-bearing for a
  real gateway entry installed without an explicit config, and
  `test_gateway_without_config_still_expands_against_the_default` pins it so a
  future "fix" cannot repair the mirror by breaking the gateway.
- It does not touch `native_alias`. Mirrored *built-ins* (`mcp__prismor-tools__Bash`)
  were already allowed correctly before and after this change — I verified that
  rather than assuming it. This bug is about which families are discovered, not
  about the built-in aliasing #323 fixed.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/scoped_agent.py` | The bug. `_gateway_upstreams` now returns `None` for a `--mirror` entry, and its docstring records the invariant and why expansion would lose the family. |
| `tests/test_scope_mirrored_builtins.py` | Two tests: the mirror is not expanded when a gateway config exists (fails on `main`), and a gateway without `--config` still expands against the default (guards the fix from over-reaching). |

## Testing

```
python3 -m pytest tests/test_scope_mirrored_builtins.py -q -p no:randomly   # 19 passed
bash scripts/run_security_tests.sh                                          # All checks passed
python3 -m pytest tests/ -q -p no:randomly                                   # 21 failed, 2365 passed
```

`main` has 22 pre-existing failures. With this patch: **21 — zero new, one
resolved.** The resolved one is `test_gateway_fronted_servers_get_their_own_families`,
i.e. the test #323 shipped for this very defect, which has been failing outside
CI ever since.

I also confirmed the new tests fail without the patch (2 failed / 17 passed) and
pass with it, both on this machine and under an empty `HOME` that simulates CI.

- [x] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [ ] If a policy rule changed — n/a
- [ ] If an integration changed — n/a

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No real secret values printed, logged, or serialized
- [x] No guardrail weakened. The one verdict that changes goes
      **allowed → denied**: `mcp__prismor-tools__cfdocs__search` under the goal
      "use cfdocs to look up workers". I brute-forced four goals against five
      tool names before and after; that pair is the only difference.
- [x] Docs that describe this behavior are still accurate

## Diff size

Lines changed: +66 / -2 (9 in `scoped_agent.py`, 57 test). Screenshots and the
reproduction script live on `pr-assets/mirror-fanout`, not in the package.
