### PR TITLE
telemetry: carry the agent's tool_use_id so one call is one node

### DIFF
--- a/prismor/runtime/enterprise/telemetry.py
+++ b/prismor/runtime/enterprise/telemetry.py
@@ -198,6 +198,12 @@ def build_record(
         # parent session. See hooks.py (_normalize_claude).
         "subagent_id": _subagent_id(event),
         "subagent_type": _subagent_type(event),
+        # The agent's own id for this tool call. One call produces several
+        # records (pre-call screening, post-call result screening), so the
+        # dashboard needs a key to fold them back into a single node instead
+        # of drawing the same command twice. Opaque agent-generated id, no
+        # user content — carried in redacted mode.
+        "tool_use_id": _tool_use_id(event),
         # Repo + policy scope so the org dashboard can show which repo an event
         # came from and whether it ran under an admin-granted exemption (vs full
         # org policy). Only managed/company repos report, so the repo identifier
@@ -267,6 +273,33 @@ def _tool_name(event: Dict[str, Any], extra: Dict[str, Any]) -> Optional[str]:
         return str(meta["tool_name"])
     # Fall back to the normalized event type as a coarse tool name.
     return str(event.get("type")) if event.get("type") else None
+
+
+# Field names different agents use for their per-tool-call id, in the raw hook
+# payload we pass through untouched.
+_TOOL_USE_ID_KEYS = ("tool_use_id", "toolUseId", "call_id", "callId", "tool_call_id", "toolCallId")
+
+
+def _tool_use_id(event: Dict[str, Any]) -> Optional[str]:
+    """The agent's id for the tool call this record is about, if it gave one.
+
+    Set directly on metadata by the inference-hook path; for hook agents it
+    lives in the raw payload (Claude's ``tool_use_id``, Codex's ``call_id``,
+    ...). Both the pre- and post-call record for one call carry the same id.
+    """
+    meta = event.get("metadata")
+    if not isinstance(meta, dict):
+        return None
+    sources = [meta]
+    raw = meta.get("raw")
+    if isinstance(raw, dict):
+        sources.append(raw)
+    for src in sources:
+        for key in _TOOL_USE_ID_KEYS:
+            val = src.get(key)
+            if val:
+                return str(val)[:120]
+    return None
 
 
 def _subagent_id(event: Dict[str, Any]) -> Optional[str]:

--- a/tests/test_enterprise_telemetry.py
+++ b/tests/test_enterprise_telemetry.py
@@ -103,6 +103,28 @@ def test_record_carries_agent_instance_name():
     telemetry.assert_redacted(named)  # names are labels, never evidence
 
 
+def test_tool_use_id_pairs_pre_and_post_records():
+    # One tool call produces a pre-call and a post-call record. Both must carry
+    # the agent's own call id so the dashboard folds them into one node instead
+    # of drawing the same command twice.
+    pre = {"type": "shell", "command": "cat secrets.txt",
+           "agent_event": "PreToolUse",
+           "metadata": {"tool_name": "Bash",
+                        "raw": {"tool_use_id": "toolu_014sX7Bh", "tool_name": "Bash"}}}
+    post = {**pre, "agent_event": "PostToolUse"}
+    a = telemetry.build_record(SECRET_FINDING, pre, extra={})
+    b = telemetry.build_record(SECRET_FINDING, post, extra={})
+    assert a["tool_use_id"] == b["tool_use_id"] == "toolu_014sX7Bh"
+    # Codex-style call_id on the raw payload, and the inference-hook path which
+    # sets it on metadata directly.
+    codex = {"type": "shell", "metadata": {"raw": {"call_id": "call_7"}}}
+    assert telemetry.build_record(SECRET_FINDING, codex, extra={})["tool_use_id"] == "call_7"
+    inline = {"type": "shell", "metadata": {"tool_use_id": "t1"}}
+    assert telemetry.build_record(SECRET_FINDING, inline, extra={})["tool_use_id"] == "t1"
+    # Absent on agents that do not report one - never invented.
+    assert telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={})["tool_use_id"] is None
+
+
 def test_evidence_hash_is_stable_and_distinct():
     a = telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={})
     b = telemetry.build_record(SECRET_FINDING, SECRET_EVENT, extra={})


### PR DESCRIPTION
## The bug

A single tool call is screened more than once — before it runs, and again on its result (the contextual layer, #330) — and each pass emits its own telemetry record. Nothing on the record tied those passes back to one call, so the console drew the same command once per pass: one `cat` of a file rendered as four identical nodes in the session graph (four, not two, because that machine had the dispatcher installed in both user- and project-scope settings — both passes ran twice).

## The fix

`build_record` now carries `tool_use_id`: the agent's own id for the call, read from `metadata.tool_use_id` (the inference-hook path already sets it) or from the raw hook payload — Claude's `tool_use_id`, Codex's `call_id`, and the other spellings agents use.

- Opaque agent-generated id, no user content, so it ships in redacted mode alongside `subagent_id`.
- Outside the chain hash (`chain.normalized_fields`) and the signed receipt — existing verifiers and receipt bundles are unaffected.
- `None` for agents that report no id; never invented.

The console groups the session trail on it (prismor-web-preview#191).

## Testing

- `tests/test_enterprise_telemetry.py::test_tool_use_id_pairs_pre_and_post_records` — pre/post pairing, Codex-style `call_id`, the inference-hook metadata path, and absence when the agent reports none.
- Replayed the four real recorded events from the reported session through `build_record`: all four → the same id → one node.
- Every suite touching `build_record` passes (96 tests).