### PR TITLE
prismor enroll --aws: workload identity enrollment via AWS IAM

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -302,7 +302,7 @@ Deep dive: [Learning](learning.md).
 
 | Command | Key flags | Description |
 |---|---|---|
-| `prismor enroll <token>` | `--label`, `--api-base` | Exchange a single-use org token (minted in the dashboard) for this machine's device identity; pulls the signed org policy. |
+| `prismor enroll <token>` | `--label`, `--api-base`, `--aws`, `--org`, `--aws-region` | Exchange a single-use org token (minted in the dashboard) for this machine's device identity; pulls the signed org policy. `--aws --org <orgId>` enrolls with the workload's AWS IAM role instead of a token (the role must be bound to the org in the console); `--aws-region` picks the regional STS endpoint. |
 | `prismor enroll-status` | — | Show enrollment state, device label, and the applied policy version. |
 | `prismor workspace [managed\|personal\|auto]` | — | With no argument, shows whether this workspace is org-managed (org policy + telemetry) or personal (local-only). Pass `managed`/`personal`/`auto` to set it. Org-claimed repos can't be downgraded, and `personal` is ignored entirely when the org policy sets `allow_personal_workspaces: false`. |
 | `prismor exempt request` | `--reason` | Ask an org admin to relax specific non-floor rules for this repo; served back in the signed policy. |

--- a/docs/connecting-to-the-platform.md
+++ b/docs/connecting-to-the-platform.md
@@ -98,6 +98,24 @@ it is a *service identity* — listed, drilled into and revoked exactly like a
 device. Headless `prismor enroll <token>` inside the workload remains
 equivalent if you prefer token exchange over a long-lived key.
 
+### AWS workloads: `prismor enroll --aws`
+
+A workload on AWS (EC2, ECS/EKS task, Lambda) can skip both the token and the
+long-lived key and enroll with the IAM role it already runs as:
+
+```
+prismor enroll --aws --org <orgId>        # role must be bound to the org in the console
+```
+
+The runtime SigV4-signs an `sts:GetCallerIdentity` request with the role's
+credentials and posts the **signed request** — never the credentials — to
+`POST /api/devices/enroll/aws`. The control plane replays it to STS, reads the
+caller's role ARN and, if an admin bound that role (Admin → Integrations →
+Cloud workload identity), mints a service identity with the same payload as a
+token enrollment. The signature covers the control-plane host and the org id
+and expires after five minutes, so a captured request cannot be replayed
+elsewhere. Details: [SSO, provisioning and workload identity](sso-and-provisioning.md).
+
 ## 2. Signed remote policy: verify-before-apply, fail-closed
 
 On the hot path, `remote_policy.check_and_refresh()` (debounced, clamped to

--- a/docs/sso-and-provisioning.md
+++ b/docs/sso-and-provisioning.md
@@ -1,0 +1,104 @@
+# Single Sign-On, Directory Provisioning and Workload Identity
+
+Prismor plugs into the identity infrastructure an organization already runs.
+Three surfaces, each independent:
+
+| Surface | Protocol | Who it covers | Plan |
+|---|---|---|---|
+| Console sign-in | OIDC | People opening the Prismor console | Enterprise |
+| Directory provisioning | SCIM 2.0 (Users + Groups) | Who is a member, and who is an admin | Enterprise |
+| Workload enrollment | AWS IAM (signed STS request) | Agents running on AWS, no shared token | All plans |
+
+Any identity provider that speaks OIDC and SCIM works. Directories such as
+LDAP or Active Directory are federated through the identity provider that
+fronts them; Prismor never binds to a directory itself.
+
+## Console sign-in (OIDC)
+
+An org owner or admin registers the identity provider in **Admin → SSO**:
+
+1. Enter the email domain (for example `acme.com`), the OIDC discovery URL,
+   the client id and the client secret.
+2. Register the redirect URI shown in the form in the identity provider:
+   `https://<your console host>/api/auth/sso/callback`.
+3. Prove domain ownership. The console issues a DNS TXT record value; add it
+   at the domain and click **verify**. Sign-in for that domain routes to the
+   identity provider only after verification, so a stranger cannot capture a
+   domain they do not own.
+
+Users who sign in through the provider land in the org whose domain matched.
+Managing providers requires the `sso` entitlement; sign-in itself is never
+gated, so an org that downgrades keeps its existing users' access.
+
+Self-hosted deployments can also configure a provider through environment
+variables at deploy time; the self-serve flow above needs no redeploy.
+
+## Directory provisioning (SCIM 2.0)
+
+**Admin → Integrations → Directory provisioning** shows the SCIM base URL and
+issues a bearer token (shown once; rotate any time). Point the identity
+provider's SCIM connector at the base URL with that token.
+
+Supported:
+
+- `POST /Users`, `GET /Users?filter=userName eq "…"` (also `externalId`),
+  `GET/PUT/PATCH/DELETE /Users/{id}`, including `active` false/true.
+  Deactivating removes the org membership; the account itself is kept (it may
+  belong to other orgs). Reactivating restores membership.
+- `POST /Groups`, `GET /Groups?filter=displayName eq "…"`,
+  `GET/PUT/PATCH/DELETE /Groups/{id}` with `add` / `remove` / `replace`
+  member operations in the shapes common identity providers send.
+
+### Roles from groups
+
+Role is derived from group membership, never edited by hand for provisioned
+users. In the SCIM card, list the identity-provider group names whose members
+should be org admins under **Admin groups** (comma separated). On every group
+push:
+
+- a user in any listed group becomes **ADMIN**;
+- every other provisioned user is **MEMBER**;
+- **OWNER** is never granted or revoked by SCIM, and the last owner of an org
+  cannot be deprovisioned through SCIM. Ownership stays a console action.
+
+Seat limits apply to provisioning exactly as to invitations.
+
+## Workload identity (AWS IAM)
+
+A deployed agent on AWS usually has no developer machine and no safe place
+for a shared enrollment token. It can enroll with the IAM role it already
+runs as:
+
+1. In **Admin → Integrations → Cloud workload identity**, bind the role:
+   `arn:aws:iam::<account>:role/<RoleName>`. An IAM path in the ARN is
+   dropped on save, because STS reports assumed roles without it. Copy the
+   org id shown there.
+2. On the workload:
+
+   ```bash
+   prismor enroll --aws --org <orgId>
+   # optional: --label task-42 --aws-region eu-west-1 --api-base https://<self-hosted console>
+   ```
+
+The runtime signs an `sts:GetCallerIdentity` request with the role's
+credentials (found the way the AWS SDKs find them: environment, ECS/EKS
+container endpoint, IMDSv2, then `~/.aws/credentials`) and sends only the
+**signed request** to the control plane. The control plane replays it to
+STS, reads the caller's role, and mints a service identity if that role is
+bound to the org. Credentials never leave the workload.
+
+What makes a captured request useless elsewhere:
+
+- the signature covers the control-plane host and the org id, so it cannot be
+  replayed against another server or into another org;
+- the request expires after five minutes;
+- the control plane only ever forwards a fixed `GetCallerIdentity` body to an
+  STS hostname.
+
+The result is a service identity, listed and revocable under **Devices** like
+any agent key. One identity exists per label; re-enrolling under the same
+label replaces it. Containers on EC2 with an IMDS hop limit of one cannot
+reach IMDSv2: prefer task or pod roles there.
+
+See [Connecting a Self-Hosted Runtime to the Prismor Platform](connecting-to-the-platform.md)
+for what the enrolled runtime sends afterwards.

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -17,7 +17,7 @@ Commands:
   uninstall-hooks Remove IDE hooks
   hook-dispatch Internal: called by IDE hooks (not for direct use)
   dashboard     Open the Prismor web dashboard (local server + browser)
-  enroll TOKEN  Enroll this machine into a Prismor org (central observability + policy)
+  enroll TOKEN  Enroll this machine into a Prismor org (central observability + policy); --aws uses the IAM role
   enroll-status Show this machine's enrollment status
   logout        Un-enroll this machine (remove device identity + cached remote policy)
   policy init   Generate a starter policy.yaml for your project
@@ -408,19 +408,36 @@ def main(argv: Optional[List[str]] = None) -> None:
     if args.command == "enroll":
         from prismor.runtime.enterprise import identity as _identity
         token = getattr(args, "token", None) or getattr(args, "token_flag", None)
-        if not token:
+        use_aws = bool(getattr(args, "aws", False))
+        org_id = getattr(args, "org", None) or os.environ.get("PRISMOR_ORG_ID")
+        if use_aws and not org_id:
+            sys.stderr.write(
+                "error: --org <orgId> (or $PRISMOR_ORG_ID) is required with --aws\n"
+                "  Copy it from the console (Admin → Integrations → Cloud workload identity)\n"
+            )
+            raise SystemExit(1)
+        if not use_aws and not token:
             sys.stderr.write(
                 "error: enrollment token required\n"
                 "  Generate one in the Prismor dashboard (Admin → Devices → Enroll)\n"
                 "  then run:  prismor enroll <token>\n"
+                "  On AWS, enroll with the workload's IAM role instead:  prismor enroll --aws --org <orgId>\n"
             )
             raise SystemExit(1)
         try:
-            ident = _identity.enroll(
-                token,
-                base=getattr(args, "api_base", None),
-                label=getattr(args, "label", None),
-            )
+            if use_aws:
+                ident = _identity.enroll_aws(
+                    org_id,
+                    base=getattr(args, "api_base", None),
+                    label=getattr(args, "label", None),
+                    region=getattr(args, "aws_region", None),
+                )
+            else:
+                ident = _identity.enroll(
+                    token,
+                    base=getattr(args, "api_base", None),
+                    label=getattr(args, "label", None),
+                )
         except RuntimeError as exc:
             sys.stderr.write(f"Enrollment failed: {exc}\n")
             raise SystemExit(1)
@@ -3485,6 +3502,10 @@ def build_parser() -> argparse.ArgumentParser:
     enroll_parser.add_argument("--token", dest="token_flag", help="Enrollment token (alternative to positional)")
     enroll_parser.add_argument("--label", help="Human-readable device label (default: hostname)")
     enroll_parser.add_argument("--api-base", help="Control-plane base URL (default: $PRISMOR_API_BASE)")
+    enroll_parser.add_argument("--aws", action="store_true",
+                               help="Enroll with this workload's AWS IAM role (no token); the role must be bound to the org in the console")
+    enroll_parser.add_argument("--org", help="Organization id to enroll into with --aws (default: $PRISMOR_ORG_ID)")
+    enroll_parser.add_argument("--aws-region", help="Use the regional STS endpoint (default: $AWS_REGION, else global)")
 
     enroll_status = subparsers.add_parser("enroll-status", help="Show this machine's enrollment status")
 

--- a/prismor/runtime/enterprise/aws_identity.py
+++ b/prismor/runtime/enterprise/aws_identity.py
@@ -1,0 +1,201 @@
+"""AWS workload identity for enrollment — stdlib only.
+
+A runtime on AWS (EC2, ECS/EKS task, Lambda) already holds IAM role
+credentials. Instead of a shared enrollment token it proves *which role it is*
+by SigV4-signing an ``sts:GetCallerIdentity`` request and handing the signed
+request (not the credentials) to the control plane, which replays it to STS.
+
+Two extra headers are folded into the signature so a captured request is
+useless anywhere else: ``X-Prismor-Server-Id`` (the control-plane host) and
+``X-Prismor-Org`` (the org the workload is enrolling into). STS ignores
+unknown headers but the signature still covers them.
+
+No boto, no ``cryptography``: ``hmac`` + ``hashlib`` + ``urllib``.
+"""
+from __future__ import annotations
+
+import configparser
+import datetime as _dt
+import hashlib
+import hmac
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+STS_BODY = "Action=GetCallerIdentity&Version=2011-06-15"
+_IMDS = "http://169.254.169.254"
+_ECS_RELATIVE_BASE = "http://169.254.170.2"
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution: env → container → IMDSv2 → ~/.aws/credentials
+
+
+def _get_json(url: str, headers: Optional[Dict[str, str]] = None, method: str = "GET",
+              timeout: float = 1.0) -> Optional[Dict[str, Any]]:
+    req = urllib.request.Request(url, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _get_text(url: str, headers: Optional[Dict[str, str]] = None, method: str = "GET",
+              timeout: float = 1.0) -> Optional[str]:
+    req = urllib.request.Request(url, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8")
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def _from_env() -> Optional[Dict[str, str]]:
+    ak = os.environ.get("AWS_ACCESS_KEY_ID")
+    sk = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if ak and sk:
+        return {"access_key": ak, "secret_key": sk,
+                "token": os.environ.get("AWS_SESSION_TOKEN") or ""}
+    return None
+
+
+def _from_container() -> Optional[Dict[str, str]]:
+    """ECS task role / EKS pod identity credential endpoint."""
+    url = os.environ.get("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+    rel = os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    if not url and rel:
+        url = _ECS_RELATIVE_BASE + rel
+    if not url:
+        return None
+    headers = {}
+    tok = os.environ.get("AWS_CONTAINER_AUTHORIZATION_TOKEN")
+    tok_file = os.environ.get("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
+    if not tok and tok_file:
+        try:
+            tok = Path(tok_file).read_text(encoding="utf-8").strip()
+        except OSError:
+            tok = None
+    if tok:
+        headers["Authorization"] = tok
+    return _shape(_get_json(url, headers))
+
+
+def _from_imds() -> Optional[Dict[str, str]]:
+    """IMDSv2 (token-required) instance role credentials."""
+    token = _get_text(f"{_IMDS}/latest/api/token",
+                      {"X-aws-ec2-metadata-token-ttl-seconds": "60"}, method="PUT")
+    if not token:
+        return None
+    h = {"X-aws-ec2-metadata-token": token}
+    role = _get_text(f"{_IMDS}/latest/meta-data/iam/security-credentials/", h)
+    if not role:
+        return None
+    role = role.strip().splitlines()[0]
+    return _shape(_get_json(f"{_IMDS}/latest/meta-data/iam/security-credentials/{role}", h))
+
+
+def _from_profile() -> Optional[Dict[str, str]]:
+    path = Path(os.environ.get("AWS_SHARED_CREDENTIALS_FILE") or Path.home() / ".aws" / "credentials")
+    if not path.exists():
+        return None
+    cp = configparser.RawConfigParser()
+    try:
+        cp.read(path, encoding="utf-8")
+    except (configparser.Error, OSError):
+        return None
+    prof = os.environ.get("AWS_PROFILE") or "default"
+    if not cp.has_section(prof):
+        return None
+    ak = cp.get(prof, "aws_access_key_id", fallback=None)
+    sk = cp.get(prof, "aws_secret_access_key", fallback=None)
+    if not (ak and sk):
+        return None
+    return {"access_key": ak, "secret_key": sk, "token": cp.get(prof, "aws_session_token", fallback="") or ""}
+
+
+def _shape(d: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+    if not d or not d.get("AccessKeyId") or not d.get("SecretAccessKey"):
+        return None
+    return {"access_key": str(d["AccessKeyId"]), "secret_key": str(d["SecretAccessKey"]),
+            "token": str(d.get("Token") or "")}
+
+
+def resolve_credentials() -> Optional[Dict[str, str]]:
+    """Find role credentials the way the AWS SDKs do, minus the config-file role
+    chains. Returns ``{access_key, secret_key, token}`` or None."""
+    for src in (_from_env, _from_container, _from_imds, _from_profile):
+        creds = src()
+        if creds:
+            return creds
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SigV4
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hmac(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def signing_key(secret_key: str, date: str, region: str, service: str) -> bytes:
+    """The four-step SigV4 derived key (date is YYYYMMDD)."""
+    k = _hmac(("AWS4" + secret_key).encode("utf-8"), date)
+    k = _hmac(k, region)
+    k = _hmac(k, service)
+    return _hmac(k, "aws4_request")
+
+
+def sts_host(region: Optional[str]) -> str:
+    return f"sts.{region}.amazonaws.com" if region else "sts.amazonaws.com"
+
+
+def sign_get_caller_identity(creds: Dict[str, str], region: Optional[str], server_id: str,
+                             org_id: str, now: Optional[_dt.datetime] = None) -> Dict[str, Any]:
+    """Build a SigV4-signed ``sts:GetCallerIdentity`` request bound to
+    ``server_id`` and ``org_id``. Returns ``{method, url, headers, body}``
+    ready to be handed to the control plane."""
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date = now.strftime("%Y%m%d")
+    # STS is signed with the region in the credential scope; the global endpoint
+    # takes us-east-1.
+    scope_region = region or "us-east-1"
+    host = sts_host(region)
+
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        "Host": host,
+        "X-Amz-Date": amz_date,
+        "X-Prismor-Org": org_id,
+        "X-Prismor-Server-Id": server_id,
+    }
+    if creds.get("token"):
+        headers["X-Amz-Security-Token"] = creds["token"]
+
+    lower = {k.lower(): " ".join(v.split()) for k, v in headers.items()}
+    signed_names = sorted(lower)
+    canonical_headers = "".join(f"{k}:{lower[k]}\n" for k in signed_names)
+    signed_headers = ";".join(signed_names)
+    canonical_request = "\n".join([
+        "POST", "/", "", canonical_headers, signed_headers, _sha256_hex(STS_BODY.encode("utf-8")),
+    ])
+    scope = f"{date}/{scope_region}/sts/aws4_request"
+    string_to_sign = "\n".join([
+        "AWS4-HMAC-SHA256", amz_date, scope, _sha256_hex(canonical_request.encode("utf-8")),
+    ])
+    sig = hmac.new(signing_key(creds["secret_key"], date, scope_region, "sts"),
+                   string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+    headers["Authorization"] = (
+        f"AWS4-HMAC-SHA256 Credential={creds['access_key']}/{scope}, "
+        f"SignedHeaders={signed_headers}, Signature={sig}"
+    )
+    return {"method": "POST", "url": f"https://{host}/", "headers": headers, "body": STS_BODY}

--- a/prismor/runtime/enterprise/identity.py
+++ b/prismor/runtime/enterprise/identity.py
@@ -251,42 +251,35 @@ def _hostname_label() -> str:
         return "unknown-host"
 
 
-def enroll(token: str, base: Optional[str] = None, label: Optional[str] = None,
-           timeout: float = 20.0) -> Dict[str, Any]:
-    """Exchange a one-time enrollment token for a device identity and persist it.
-
-    Calls ``POST {base}/api/devices/enroll`` with the enrollment token and a
-    human-readable label (defaults to the hostname). On success the response
-    carries ``device_id``, ``org_id``, ``user_id`` and ``device_key``; we store
-    them and return the saved record. Raises RuntimeError with a readable
-    message on any failure (network, non-2xx, malformed response).
-    """
-    import urllib.request
-    import urllib.error
-    from prismor.runtime import __version__ as _ver
-
-    base = (base or api_base()).rstrip("/")
-    label = label or _hostname_label()
+def _receipt_pubkey() -> Optional[str]:
     # Register this device's Ed25519 receipt-signing public key so the control
     # plane can verify signed telemetry receipts and pin the key to the device.
     # Best-effort: None when `cryptography` isn't installed; the server treats it
     # as optional and can still pin trusted-on-first-use from the first receipt.
-    receipt_pubkey = None
     try:
         from prismor.runtime.enterprise import receipt_signing as _signing
-        receipt_pubkey = _signing.public_key_b64()
+        return _signing.public_key_b64()
     except Exception:
-        receipt_pubkey = None
-    payload = json.dumps({
-        "token": token,
+        return None
+
+
+def _enroll_request(path: str, payload: Dict[str, Any], base: str, label: str,
+                    timeout: float, extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """POST an enrollment payload, validate the response, persist the identity."""
+    import urllib.request
+    import urllib.error
+    from prismor.runtime import __version__ as _ver
+
+    payload = {
+        **payload,
         "label": label,
         "platform": _platform(),
         "prismor_version": _ver,
-        "receipt_pubkey": receipt_pubkey,
-    }).encode("utf-8")
+        "receipt_pubkey": _receipt_pubkey(),
+    }
     req = urllib.request.Request(
-        f"{base}/api/devices/enroll",
-        data=payload,
+        f"{base}{path}",
+        data=json.dumps(payload).encode("utf-8"),
         headers={"Content-Type": "application/json"},
         method="POST",
     )
@@ -312,10 +305,54 @@ def enroll(token: str, base: Optional[str] = None, label: Optional[str] = None,
         "org_name": body.get("org_name"),
         "label": label,
         "api_base": base,
+        **(extra or {}),
     }
     save_identity(identity)
     clear_revoked()  # a fresh enrollment supersedes any prior revocation
     return identity
+
+
+def enroll(token: str, base: Optional[str] = None, label: Optional[str] = None,
+           timeout: float = 20.0) -> Dict[str, Any]:
+    """Exchange a one-time enrollment token for a device identity and persist it.
+
+    Calls ``POST {base}/api/devices/enroll`` with the enrollment token and a
+    human-readable label (defaults to the hostname). On success the response
+    carries ``device_id``, ``org_id``, ``user_id`` and ``device_key``; we store
+    them and return the saved record. Raises RuntimeError with a readable
+    message on any failure (network, non-2xx, malformed response).
+    """
+    base = (base or api_base()).rstrip("/")
+    return _enroll_request("/api/devices/enroll", {"token": token}, base,
+                           label or _hostname_label(), timeout)
+
+
+def enroll_aws(org_id: str, base: Optional[str] = None, label: Optional[str] = None,
+               region: Optional[str] = None, timeout: float = 20.0) -> Dict[str, Any]:
+    """Enroll using this workload's AWS IAM role instead of a token.
+
+    Signs ``sts:GetCallerIdentity`` with whatever role credentials the host
+    has (env, container endpoint, IMDSv2, ``~/.aws/credentials``) and posts the
+    *signed request* to ``POST {base}/api/devices/enroll/aws``. The control
+    plane replays it to STS and, if an admin bound that role to ``org_id``,
+    mints a service identity. Credentials never leave the workload.
+    """
+    from urllib.parse import urlparse
+    from prismor.runtime.enterprise import aws_identity as _aws
+
+    base = (base or api_base()).rstrip("/")
+    creds = _aws.resolve_credentials()
+    if not creds:
+        raise RuntimeError(
+            "no AWS credentials found (checked env, container endpoint, IMDSv2, ~/.aws/credentials)"
+        )
+    server_id = urlparse(base).netloc
+    signed = _aws.sign_get_caller_identity(
+        creds, region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"),
+        server_id, org_id,
+    )
+    return _enroll_request("/api/devices/enroll/aws", {"aws": signed}, base,
+                           label or _hostname_label(), timeout, extra={"source": "aws"})
 
 
 def _platform() -> str:

--- a/tests/test_aws_identity.py
+++ b/tests/test_aws_identity.py
@@ -1,0 +1,143 @@
+"""AWS workload-identity enrollment: SigV4 signing + credential resolution.
+
+The signature must be a real SigV4 (checked against the AWS documentation
+signing-key vector) and must fold the control-plane binding headers into
+SignedHeaders, otherwise the control plane rejects the request as replayable.
+"""
+import datetime as dt
+import io
+import json
+import os
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+from prismor.runtime.enterprise import aws_identity as aws
+from prismor.runtime.enterprise import identity as ident
+
+AWS_ENV = (
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", "AWS_REGION", "AWS_DEFAULT_REGION",
+    "PRISMOR_HOME", "PRISMOR_AGENT_KEY",
+)
+
+
+def _offline(*a, **k):
+    raise urllib.error.URLError("offline")
+
+
+class TestSigV4(unittest.TestCase):
+    def test_signing_key_matches_aws_docs_vector(self):
+        key = aws.signing_key("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1", "iam")
+        self.assertEqual(key.hex(), "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9")
+
+    def test_signed_request_shape_and_binding_headers(self):
+        now = dt.datetime(2026, 9, 5, 12, 0, 0, tzinfo=dt.timezone.utc)
+        creds = {"access_key": "AKIAEXAMPLE", "secret_key": "secret", "token": "tok"}
+        req = aws.sign_get_caller_identity(creds, None, "www.prismor.dev", "orgA", now=now)
+        self.assertEqual(req["method"], "POST")
+        self.assertEqual(req["url"], "https://sts.amazonaws.com/")
+        self.assertEqual(req["body"], aws.STS_BODY)
+        h = req["headers"]
+        self.assertEqual(h["X-Amz-Date"], "20260905T120000Z")
+        self.assertEqual(h["X-Prismor-Org"], "orgA")
+        self.assertEqual(h["X-Prismor-Server-Id"], "www.prismor.dev")
+        self.assertEqual(h["X-Amz-Security-Token"], "tok")
+        auth = h["Authorization"]
+        self.assertIn("Credential=AKIAEXAMPLE/20260905/us-east-1/sts/aws4_request", auth)
+        self.assertIn(
+            "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-prismor-org;x-prismor-server-id",
+            auth,
+        )
+        self.assertRegex(auth, r"Signature=[0-9a-f]{64}$")
+
+    def test_signature_is_deterministic_and_binding_sensitive(self):
+        now = dt.datetime(2026, 9, 5, 12, 0, 0, tzinfo=dt.timezone.utc)
+        creds = {"access_key": "AKIA", "secret_key": "s", "token": ""}
+        a = aws.sign_get_caller_identity(creds, "eu-west-1", "h", "orgA", now=now)
+        b = aws.sign_get_caller_identity(creds, "eu-west-1", "h", "orgA", now=now)
+        c = aws.sign_get_caller_identity(creds, "eu-west-1", "h", "orgB", now=now)
+        self.assertEqual(a["headers"]["Authorization"], b["headers"]["Authorization"])
+        self.assertNotEqual(a["headers"]["Authorization"], c["headers"]["Authorization"])
+        self.assertEqual(a["url"], "https://sts.eu-west-1.amazonaws.com/")
+        self.assertNotIn("X-Amz-Security-Token", a["headers"])
+
+
+class TestCredentialResolution(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in AWS_ENV}
+        for k in AWS_ENV:
+            os.environ.pop(k, None)
+        self.home = Path(tempfile.mkdtemp(prefix="prismor-aws-"))
+        os.environ["PRISMOR_HOME"] = str(self.home)
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(self.home / "nope")
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_env_wins(self):
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA1"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "s1"
+        self.assertEqual(aws.resolve_credentials(), {"access_key": "AKIA1", "secret_key": "s1", "token": ""})
+
+    def test_profile_file(self):
+        f = self.home / "creds"
+        f.write_text("[default]\naws_access_key_id = AKIAP\naws_secret_access_key = sp\n", encoding="utf-8")
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(f)
+        with mock.patch.object(urllib.request, "urlopen", _offline):
+            self.assertEqual(aws.resolve_credentials()["access_key"], "AKIAP")
+
+    def test_none_when_nothing_available(self):
+        with mock.patch.object(urllib.request, "urlopen", _offline):
+            self.assertIsNone(aws.resolve_credentials())
+
+    def test_enroll_aws_posts_signed_request_and_saves_identity(self):
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA1"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "s1"
+        seen = {}
+
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["payload"] = json.loads(req.data.decode("utf-8"))
+            return _Resp(json.dumps({
+                "device_id": "d1", "org_id": "orgA", "user_id": "admin", "device_key": "prism_agent_x", "org_name": "Acme",
+            }).encode("utf-8"))
+
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen):
+            rec = ident.enroll_aws("orgA", base="https://cp.example", label="task-1")
+        self.assertEqual(seen["url"], "https://cp.example/api/devices/enroll/aws")
+        signed = seen["payload"]["aws"]
+        self.assertEqual(signed["headers"]["X-Prismor-Server-Id"], "cp.example")
+        self.assertEqual(signed["headers"]["X-Prismor-Org"], "orgA")
+        self.assertEqual(seen["payload"]["label"], "task-1")
+        self.assertEqual(rec["source"], "aws")
+        # Read the file directly: other suites monkeypatch load_identity at module level.
+        saved = json.loads((self.home / "identity.json").read_text(encoding="utf-8"))
+        self.assertEqual(saved["device_key"], "prism_agent_x")
+        self.assertEqual(saved["source"], "aws")
+
+    def test_enroll_aws_without_credentials_is_a_clear_error(self):
+        with mock.patch.object(urllib.request, "urlopen", _offline):
+            with self.assertRaises(RuntimeError) as cm:
+                ident.enroll_aws("orgA", base="https://cp.example")
+        self.assertIn("no AWS credentials", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A deployed agent on AWS (EC2, ECS/EKS task, Lambda) has no developer machine and no safe place for a shared credential, yet today the only ways onto the control plane are `prismor enroll <token>` (a one-time token someone has to hand to the workload) or a long-lived `PRISMOR_AGENT_KEY` baked into the deployment. Both are secrets that must be distributed, rotated and revoked by hand. The workload already has a verifiable identity, its IAM role, and Prismor cannot use it.

`docs/connecting-to-the-platform.md` already flagged "auth on the enroll UX" as a known follow-up for this path.

## Prior art — what already exists

- [x] **I extended an existing pattern.** Enrollment already exchanges a credential for a device identity through `identity.enroll()` → `POST /api/devices/enroll` → `save_identity()`. This PR keeps that flow and swaps what is presented: instead of a token, a SigV4-signed `sts:GetCallerIdentity` request. `enroll()` was refactored onto a shared `_enroll_request(path, payload, ...)` so both paths share the POST, the response validation and the identity file. The CLI reuses the existing `enroll` subcommand (`--aws`), so `enroll-status`, `logout`, the post-enroll policy pull and the discover seed run unchanged.
- [x] **An existing mechanism was close but not sufficient.** `PRISMOR_AGENT_KEY` (`identity._env_identity`) is the deviceless path, but it is itself a long-lived secret the operator must distribute; it cannot derive identity from the platform the workload runs on. There is no HTTP/JWT/OIDC client anywhere in the runtime (only IMDS *blocking* in `egress.py` / `policies.py`), so nothing existing could sign a request.

**Tangential updates:** `docs/cli-reference.md` row for `enroll`; `docs/connecting-to-the-platform.md` gains an "AWS workloads" subsection; new customer-facing `docs/sso-and-provisioning.md` documents the console side (OIDC self-serve, SCIM Users/Groups role mapping, LDAP/AD via the IdP) that ships in the control-plane counterpart PR.

## Solution — high level

- `prismor enroll --aws --org <orgId>` signs `sts:GetCallerIdentity` with whatever role credentials the host has (env → ECS/EKS container endpoint → IMDSv2 → `~/.aws/credentials`) and posts only the **signed request** to `POST /api/devices/enroll/aws`.
- The control plane replays that request to STS, reads the caller's role ARN and, if an org admin bound that role, mints a service identity with the same payload as a token enrollment. Credentials never leave the workload.
- Two headers are folded into the signature, `X-Prismor-Server-Id` (control-plane host) and `X-Prismor-Org`, so a captured request cannot be replayed against another server or into another org; STS also enforces the 5-minute date window.
- Stdlib only (`hmac`, `hashlib`, `urllib`, `configparser`): no boto, no `cryptography`, consistent with the rest of `enterprise/`.

## Deep dive — how it works

1. `aws_identity.resolve_credentials()` walks the sources the AWS SDKs use, minus config-file role chains. Each source returns `{access_key, secret_key, token}` or `None`; the first hit wins. IMDSv2 is token-required (PUT `/latest/api/token` first) with a 1 s timeout so a non-AWS host fails fast.
2. `sign_get_caller_identity(creds, region, server_id, org_id)` builds a canonical request over `content-type;host;x-amz-date;[x-amz-security-token;]x-prismor-org;x-prismor-server-id` and returns `{method, url, headers, body}`. The signing key is derived with the standard four-step HMAC and checked in the tests against the AWS documentation vector. Region selects `sts.<region>.amazonaws.com` (credential scope uses that region; the global endpoint scopes to `us-east-1`).
3. `identity.enroll_aws(org_id, base, label, region)` derives `server_id` from the `--api-base` host, builds the signed request and calls `_enroll_request("/api/devices/enroll/aws", {"aws": signed}, ...)`, which persists `identity.json` with `source: "aws"`.
4. Failure modes handled: no credentials anywhere → `RuntimeError("no AWS credentials found (checked env, container endpoint, IMDSv2, ~/.aws/credentials)")`, exit 1; `--aws` without `--org`/`$PRISMOR_ORG_ID` → usage error before any network call; control-plane 401/403 surface with the server's `error` and `message` (for example `caller is not an IAM role`, `role_not_bound`).
5. Deliberately not done: role chains from `~/.aws/config` (env/container/IMDS/profile cover the deploy targets), and IMDS hop-limit-1 containers (documented: prefer task/pod roles).

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/enterprise/aws_identity.py` | New: credential resolution + SigV4 signing, stdlib only |
| `prismor/runtime/enterprise/identity.py` | Extract `_enroll_request()` from `enroll()`; add `enroll_aws()` |
| `prismor/runtime/cli.py` | `enroll` gains `--aws`, `--org`, `--aws-region`; error text points at the AWS path |
| `tests/test_aws_identity.py` | AWS docs signing-key vector, header shape, binding sensitivity, credential resolution, enroll round-trip, no-credentials error |
| `docs/sso-and-provisioning.md` | New customer-facing doc: OIDC self-serve, SCIM Users/Groups → roles, LDAP/AD via IdP, AWS workload identity |
| `docs/connecting-to-the-platform.md` | "AWS workloads" subsection next to the deviceless-agent section |
| `docs/cli-reference.md` | `enroll` row lists the new flags |

## Testing

```
python3 -m pytest tests/test_aws_identity.py -q            # 8 passed
python3 -m pytest tests/ -q -p no:randomly                  # st3ve: 21 failed / 2408 passed on main vs identical FAILED set on this branch
bash scripts/run_security_tests.sh                          # st3ve: All security regression checks passed
bash scripts/verify_registry.sh                             # ✓ registry verified
```

Live on st3ve against the control-plane counterpart (real STS round trip, screenshots in the comment below): no credentials → clear error; IAM *user* credentials → `401 caller is not an IAM role`; assumed bound role → service identity minted, `enroll-status` verified by the control plane; same role against an org that did not bind it → `403 role_not_bound`.

- [x] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [ ] If a policy rule changed: n/a
- [x] If an integration changed: `bash scripts/verify_registry.sh` (no registry change; still green)

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML (no rules touched)
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs (test uses the public AWS documentation example key)
- [x] No real secret values printed, logged, or serialized (credentials are read and used in-process only; the identity file stores the minted device key exactly as token enrollment does)
- [x] No guardrail weakened
- [x] Docs that describe this behavior are still accurate

## Diff size

Lines changed: +557 / −33 · Justification: one new 200-line module is the SigV4 signer + credential resolution, both stdlib; a third of the diff is documentation and tests.
