### PR TITLE
fix(scanner): support tomllib on Python <3.11

### DIFF
--- a/prismor/runtime/scanner.py
+++ b/prismor/runtime/scanner.py
@@ -16,7 +16,10 @@ import hashlib
 import json
 import re
 import shlex
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
+    "tomli>=1.1.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

`prismor/runtime/scanner.py` imports `tomllib` unconditionally, but Prismor supports Python >=3.8 and `tomllib` is only included in the standard library starting with Python 3.11.

On Python 3.8–3.10, importing the scanner raises:

`ModuleNotFoundError: No module named 'tomllib'`

This prevents scanner-dependent functionality from running on supported Python versions.

Closes #354

## Prior art — what already exists

- [x] **I extended an existing pattern.** The scanner already uses the `tomllib` API for TOML parsing. The compatibility import aliases `tomli` as `tomllib` on Python versions where the standard-library module is unavailable, so existing parsing code does not need to change.

**Tangential updates:** none

## Solution — high level

- Use the standard-library `tomllib` module on Python 3.11+.
- Fall back to `tomli` on Python 3.8–3.10.
- Add `tomli` as a conditional dependency only when `python_version < '3.11'`.
- Preserve the existing `tomllib` API at all scanner call sites.

## Deep dive — how it works

`scanner.py` first attempts to import the standard-library `tomllib`. If that module is unavailable, it imports `tomli` under the same `tomllib` name.

This keeps the existing TOML parsing code unchanged while restoring compatibility with all Python versions currently advertised by the package.

`pyproject.toml` conditionally installs `tomli` only for Python versions below 3.11, so newer Python environments continue using the standard-library implementation without an unnecessary dependency.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/scanner.py` | Adds the `tomli` compatibility fallback for Python <3.11. |
| `pyproject.toml` | Adds `tomli` as a conditional dependency for Python <3.11. |

## Testing

Tested on Python 3.13.15:

```text
python3 -c "import prismor.runtime.scanner; print('scanner import OK')"
scanner import OK

python3 -m pytest tests/test_scanner_codex.py -q
8 passed

```

Tested on Python 3.10.14:

```text
PYENV_VERSION=3.10.14 pyenv exec python -c "import prismor.runtime.scanner; print('scanner import OK on Python 3.10')"
scanner import OK on Python 3.10

PYENV_VERSION=3.10.14 pyenv exec python -m pytest tests/test_scanner_codex.py -q
8 passed
```

Security regression suite:

```text
bash scripts/run_security_tests.sh
182 passed, 23 skipped
All security regression checks passed.
```

Full suite:

```text
python3 -m pytest tests/ -q
19 failed, 2373 passed, 61 skipped
```

The parent/base revision produces the same 19 failures, confirming they are pre-existing and unrelated to this change.

- [x] `bash scripts/run_security_tests.sh` passes
- [ ] Added or updated tests covering the new behavior
- [ ] If a policy rule changed: not applicable
- [ ] If an integration changed: not applicable

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No real secret values printed, logged, or serialized
- [x] No guardrail weakened
- [x] Docs that describe this behavior remain accurate

## Diff size

Lines changed: +5 / -1 · Small compatibility fix with no unrelated changes.