### PR TITLE
Release 1.45.1 — the proxy stops scanning a project it does not govern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [1.45.1] — 2026-09-07
+
+### Fixed
+- **The proxy still refused benign traffic on account of a `CLAUDE.md` it
+  should never have read.** 1.45.0 moved its default workspace off cwd, which
+  was the right diagnosis and an incomplete fix: the new default lives inside
+  `$PRISMOR_HOME`, and $PRISMOR_HOME ships a `CLAUDE.md` of its own -- so the
+  instruction-file scan found the same security-project text one directory up
+  and went on blocking every request at score 0.91 with
+  `source: project_memory`. The scan is now skipped for the proxy entirely.
+  It governs an agent it does not host, so instruction files beside its own
+  store describe the machine it runs on and say nothing about the traffic it
+  is judging; scanning them is not a stricter check, it is a check on the
+  wrong subject.
+
 ## [1.45.0] — 2026-09-07
 
 ### Added

--- a/docs/llm-proxy.md
+++ b/docs/llm-proxy.md
@@ -95,15 +95,16 @@ The real credential is read from the environment variable named by
 ## Workspace
 
 The proxy reads policy and stores its sessions in `$PRISMOR_HOME/surfaces/proxy`
-unless `--workspace` says otherwise. That default is deliberate: this surface is
-a long-lived server governing somebody else's agent, so the directory it was
-launched from is not evidence about the traffic -- but the instruction-file
-scan reads that directory's `CLAUDE.md` / `AGENTS.md` and attributes what it
-finds to every event. Start the proxy inside a security repo whose own docs
-quote the attack strings its rules match and every request is refused with
-`source: project_memory`. It looks like a false positive on the agent; it is a
-true positive on the wrong subject. Pass `--workspace` only to enforce a
-specific repo's policy on purpose.
+unless `--workspace` says otherwise, and it does not scan instruction files
+(`CLAUDE.md`, `AGENTS.md`) near that directory at all. Both follow from what
+this surface is: a long-lived server governing an agent it does not host,
+usually in another container. The files beside its own workspace describe the
+machine it runs on, not the traffic it judges -- and a security project's
+instruction file quotes the attack strings its own rules match, as does the one
+$PRISMOR_HOME ships, so scanning them refused every request with
+`source: project_memory`, benign traffic included. That is not a weaker check;
+it is a check on the wrong subject. `--workspace` still points the proxy at a
+specific repo's policy for anyone who means it.
 
 ## Governing n8n (and other hosted builders)
 

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.45.0"
+__version__ = "1.45.1"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -113,6 +113,16 @@ def _block_reason(finding: Dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+# Surfaces whose workspace is a store, not a project the agent works in.
+# The proxy governs an agent it does not host -- often in another container --
+# so the instruction files near ITS OWN directory say nothing about the traffic
+# it is judging, while a CLAUDE.md that quotes attack strings (a security repo's
+# does, and $PRISMOR_HOME ships one) makes every request a block attributed to
+# source: project_memory. Scanning the wrong project is not a weaker check, it
+# is a check on the wrong subject.
+_NO_PROJECT_AGENTS = frozenset({"prismor-proxy"})
+
+
 def evaluate_tool_call(
     *,
     event: Dict[str, Any],
@@ -277,7 +287,8 @@ def evaluate_tool_call(
             # Claude's real SessionStart event — engine.evaluate already ran the
             # content rules above; add the drift check on top.
             findings.extend(check_memory_drift(meta.get("memory_digests") or {}))
-        elif _session_seq == 0 and event.get("type") != "prompt":
+        elif (_session_seq == 0 and event.get("type") != "prompt"
+              and agent not in _NO_PROJECT_AGENTS):
             _mem = _read_project_memory(Path(meta.get("cwd") or workspace))
             if _mem["content"]:
                 _mem_event = {

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -294,5 +294,31 @@ def test_default_workspace_is_not_the_launch_directory(monkeypatch, tmp_path):
     assert ws.is_dir()
 
 
+def test_proxy_never_scans_the_instruction_files_near_its_store(monkeypatch, tmp_path):
+    """The proxy judges traffic, not whatever CLAUDE.md sits near its workspace.
+
+    It governs an agent it does not host, so instruction files beside its own
+    directory describe nothing it is screening -- while a security project's
+    CLAUDE.md quotes the attack strings its own rules match ($PRISMOR_HOME
+    ships one), which scored 0.91 and refused every request with
+    source: project_memory, benign traffic included.
+    """
+    from prismor.runtime import hooks
+    from prismor.runtime.runtime import evaluate_tool_call
+
+    scanned = []
+    monkeypatch.setattr(hooks, "_read_project_memory",
+                        lambda ws: scanned.append(ws) or {"content": "", "files": [], "digests": {}})
+
+    event = {
+        "type": "tool_result",
+        "response": '{"query": "annual leave"}',
+        "metadata": {"tool_name": "get_hr_policy", "cwd": str(tmp_path)},
+    }
+    evaluate_tool_call(event=event, workspace=tmp_path, agent="prismor-proxy",
+                       mode="enforce", session_id="proxy-memory-scan", persist=False)
+    assert scanned == [], "the proxy scanned a project it does not govern"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q", "-p", "no:randomly"]))


### PR DESCRIPTION
1.45.0's workspace default was the right diagnosis and an incomplete fix: `$PRISMOR_HOME` ships its own `CLAUDE.md`, so the instruction-file scan found the same text one directory up and kept blocking every request at 0.91 with `source: project_memory`.

The scan is now skipped for the proxy surface. It governs an agent it does not host, so instruction files beside its own store describe the machine it runs on, not the traffic it judges.

Includes the version bump and changelog for 1.45.1.