### PR TITLE
Release 1.45.2 — unrouted paths follow the credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [1.45.2] — 2026-09-07
+
+### Fixed
+- **An OpenAI client's credential test failed against the proxy.** `/v1/models`
+  is a path both APIs define and neither route table claims, so it went to the
+  default upstream — Anthropic — and an OpenAI SDK got back
+  `401 invalid x-api-key`. n8n calls exactly that path behind its **Test**
+  button, so the credential reported broken settings while every completion
+  through it worked, which is the worst possible first impression of a surface
+  whose whole pitch is that nothing else has to change. An unrouted path now
+  follows the credential the client presented: `anthropic-version` or
+  `x-api-key` means Anthropic, a bearer means OpenAI, and neither still means
+  the configured default. Routed paths are unaffected.
+
+
 ## [1.45.1] — 2026-09-07
 
 ### Fixed

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.45.1"
+__version__ = "1.45.2"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/proxy.py
+++ b/prismor/runtime/proxy.py
@@ -717,6 +717,18 @@ class ProxyHandler(BaseHTTPRequestHandler):
         for prefix, provider in PROVIDER_ROUTES:
             if path.endswith(prefix) or path == prefix:
                 return provider
+        # An unrouted path is one both APIs define -- /v1/models above all,
+        # which is what an SDK calls to verify a credential. Sending it to the
+        # default upstream answers an OpenAI client with Anthropic's 401
+        # ("invalid x-api-key"), so n8n's Test button says the settings are
+        # broken while every actual completion works. The client already told
+        # us who it thinks it is talking to: Anthropic SDKs stamp
+        # anthropic-version (or send x-api-key), OpenAI SDKs send a bearer.
+        if self.headers.get("anthropic-version") or self.headers.get("x-api-key"):
+            return "anthropic"
+        auth = (self.headers.get("authorization") or "").strip().lower()
+        if auth.startswith("bearer "):
+            return "openai"
         return self.config.default_upstream
 
     def _auth(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -320,5 +320,41 @@ def test_proxy_never_scans_the_instruction_files_near_its_store(monkeypatch, tmp
     assert scanned == [], "the proxy scanned a project it does not govern"
 
 
+class _FakeHeaders(dict):
+    def get(self, key, default=None):  # HTTPMessage lookups are case-insensitive
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+def _provider_for(path, headers):
+    """Call ProxyHandler._provider without standing up a server."""
+    handler = proxy_mod.ProxyHandler.__new__(proxy_mod.ProxyHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.config = proxy_mod.ProxyConfig({})
+    return proxy_mod.ProxyHandler._provider(handler)
+
+
+def test_routed_paths_still_win_over_the_credential_shape():
+    assert _provider_for("/v1/chat/completions", {"Authorization": "Bearer sk-x"}) == "openai"
+    assert _provider_for("/v1/messages", {"Authorization": "Bearer oauth"}) == "anthropic"
+
+
+def test_unrouted_path_follows_the_credential_the_client_presented():
+    """/v1/models is what an SDK calls to verify a credential.
+
+    Sending it to the default upstream answered an OpenAI client with
+    Anthropic's 401, so n8n's Test button reported broken settings while every
+    completion through the same credential worked.
+    """
+    assert _provider_for("/v1/models", {"Authorization": "Bearer sk-x"}) == "openai"
+    assert _provider_for("/v1/models", {"x-api-key": "sk-ant-x"}) == "anthropic"
+    assert _provider_for("/v1/models", {"Authorization": "Bearer oauth",
+                                        "anthropic-version": "2023-06-01"}) == "anthropic"
+    assert _provider_for("/v1/models", {}) == "anthropic"  # config default
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q", "-p", "no:randomly"]))


### PR DESCRIPTION
`/v1/models` went to the default upstream, so an OpenAI client's credential test came back with Anthropic's `401 invalid x-api-key`. n8n calls that path behind its Test button: the credential reported broken settings while every completion through it worked.

Unrouted paths now follow the presented credential (`anthropic-version`/`x-api-key` → Anthropic, bearer → OpenAI, neither → configured default). Routed paths unchanged.