### PR TITLE
Release 1.46.0 — run the surfaces as a container, and let short sessions be seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## [Unreleased]
 
+## [1.46.0] — 2026-09-07
+
+### Added
+- **Prismor runs as a container.** `packaging/docker/` carries an image, an
+  entrypoint that enrolls on first boot, and a compose file that stands the
+  proxy up beside n8n with its identity and session store on a volume. The
+  surfaces that front an agent Prismor cannot hook are long-lived servers, so
+  they want a supervisor and a restart policy rather than a shell someone
+  remembers to keep open. `PRISMOR_ENROLL_TOKEN` makes the container a device
+  in the console; `PRISMOR_AGENT_NAME` is what the per-agent kill switch and
+  mode override target; `PRISMOR_WORKSPACE_SCOPE=managed` is required because a
+  container has no git remote to claim and would otherwise resolve as personal
+  and report nothing. Enrollment failure is not fatal — a proxy that refused to
+  start because the control plane was unreachable would take the agent down
+  with it. Docs: `docs/deploy-docker.md`.
+
+### Fixed
+- **A short proxy session never reached the console.** The session snapshot the
+  console and `prismor sessions` read was rebuilt every 25 events — right for
+  amortizing a quadratic re-analysis on a long-lived surface, wrong for a
+  proxy session that is often a single chat turn. A governed n8n agent whose
+  install command was blocked logged five events and produced no session row
+  anywhere an operator looks: findings reached the sinks, but the session they
+  belonged to did not exist. The snapshot is now flushed on shutdown, on
+  SIGTERM as well as SIGINT so a container stop counts, and only when there is
+  something unsnapshotted to write.
+
+
 ## [1.45.3] — 2026-09-07
 
 ### Fixed

--- a/docs/deploy-docker.md
+++ b/docs/deploy-docker.md
@@ -1,0 +1,91 @@
+# Deploying Prismor as a service
+
+`prismor proxy` and `prismor eval-server` are long-lived surfaces rather than
+per-call hooks: they front an agent Prismor cannot hook, so they run beside it
+rather than inside it. `packaging/docker/` holds an image and a compose file
+that stand one up next to n8n, wired to your SIEM and to the console.
+
+```bash
+cd packaging/docker
+cp prismor.env.example prismor.env      # enrollment token, agent name, mode
+docker compose up -d
+```
+
+Then set the OpenAI credential's **Base URL** inside n8n to
+`http://prismor:7080/v1` — the compose network resolves `prismor` — and the
+workflow is governed. See [n8n.md](n8n.md) for the walkthrough with
+screenshots.
+
+## What the container needs to keep
+
+```yaml
+volumes:
+  - prismor_home:/var/lib/prismor                                # keep this
+  - ./policy.yaml:/var/lib/prismor/.prismor/policy.yaml:ro       # this path exactly
+```
+
+`$PRISMOR_HOME` holds the device identity, the session store and the audit
+trail. Without a volume, every restart is a new unenrolled device and the trail
+starts over.
+
+The policy path is the one that catches people. A workspace's policy is read
+from `<workspace>/.prismor/policy.yaml`; mounted one level up, the file is
+silently ignored — the surface still enforces the bundled defaults, so it looks
+like it is working while no sink you configured ever fires.
+
+## Sending findings to your SIEM
+
+Sinks are declared under `settings.outputs` in that policy file and dispatched
+the moment a finding is produced — *before* the block is returned to the agent,
+so a SIEM sees denied calls, not just allowed ones. Every sink is best-effort:
+one that is down warns on stderr and never blocks a tool call.
+
+```yaml
+settings:
+  outputs:
+    - type: otel                          # any OpenTelemetry collector
+      endpoint: http://otel-collector:4318
+      headers: { "Authorization": "Bearer ${OTEL_TOKEN}" }
+    - type: splunk                        # HEC, OCSF body
+      url: https://splunk.example.com:8088/services/collector
+      token: ${SPLUNK_HEC_TOKEN}
+    - type: prismor                       # the console; needs no config
+```
+
+`webhook`, `syslog`, `datadog` and `file` (json / cef / ocsf) are also
+available — see [telemetry-sinks.md](telemetry-sinks.md). Every `${VAR}`
+resolves from the container's environment, so tokens live in `prismor.env` and
+never in the policy file you commit.
+
+A delivered finding carries the rule, the verdict and the identity of what
+proposed it:
+
+```json
+{ "severity": "HIGH", "category": "remote_execution", "action": "block",
+  "agent": "prismor-proxy", "agent_name": "n8n-agent",
+  "session_id": "proxy-1788780852-1", "mode": "enforce",
+  "title": "Blocks curl | bash, wget | sh fetch-and-execute chains" }
+```
+
+## Seeing it in the console
+
+Two environment variables decide whether this container is a device you can
+watch and control, or a black box that merely enforces:
+
+- `PRISMOR_ENROLL_TOKEN` — enrolls on first boot, which is what creates the
+  device, its sessions and its per-agent controls in the console. Enrollment
+  failure is deliberately not fatal: a proxy that refuses to start because the
+  control plane is unreachable would take the agent down with it.
+- `PRISMOR_WORKSPACE_SCOPE=managed` — a container has no git remote to claim,
+  so without this the workspace resolves as *personal* and reports nothing.
+
+`PRISMOR_AGENT_NAME` is what the console shows the surface as, and what the
+per-agent kill switch and mode override target. Give each deployment its own
+(`n8n-prod`, `n8n-staging`) or they share one row.
+
+## Stop it politely
+
+The session snapshot the console reads is rebuilt periodically and again on
+shutdown, so `docker stop` (SIGTERM) flushes the session in flight while
+`docker kill` (SIGKILL) leaves it on disk as a log with no session row. Compose
+does the right thing by default; a supervisor configured to `kill -9` does not.

--- a/docs/llm-proxy.md
+++ b/docs/llm-proxy.md
@@ -127,6 +127,14 @@ Every turn is then screened, and a tool the model proposes is judged before n8n
 executes it. Bind beyond loopback only on a trusted network, or put TLS in
 front.
 
+## Running it as a service
+
+It is a long-lived server, so it wants a supervisor, a volume for
+`$PRISMOR_HOME`, and somewhere for its findings to go.
+[deploy-docker.md](deploy-docker.md) has an image, a compose file that stands
+it up beside n8n, and the sink and enrollment configuration that make its
+sessions visible in the console.
+
 ## Modes and failure
 
 `--mode observe` (default) evaluates and logs but never blocks. `--mode enforce`

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -124,6 +124,10 @@ table cover the hook layer and the proxy at once, instead of two.
 
 ## Keep it running
 
+Running both under compose, with a volume for the identity and session store
+and your SIEM wired in, is [deploy-docker.md](deploy-docker.md). By hand, on
+the host:
+
 The proxy is a long-lived server, so run it under whatever supervises your
 other services. On macOS, a launch agent is enough:
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,36 @@
+# Prismor as a service: the governance surfaces that front an agent you cannot
+# hook -- the LLM proxy, and the evaluation server non-Python SDKs call.
+#
+# Build from the repo root so the source tree is in context:
+#   docker build -f packaging/docker/Dockerfile -t prismor .
+FROM python:3.12-slim
+
+# curl is here for the container HEALTHCHECK below, nothing else.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+RUN pip install --no-cache-dir . \
+ && rm -rf /src
+
+# $PRISMOR_HOME holds the device identity, the policy and the session logs. It
+# is a volume in compose: without one, every restart is a new unenrolled device
+# and the audit trail starts over.
+ENV PRISMOR_HOME=/var/lib/prismor \
+    PRISMOR_PROXY_PORT=7080 \
+    PRISMOR_PROXY_MODE=enforce
+RUN useradd --create-home --uid 10001 prismor \
+ && mkdir -p "$PRISMOR_HOME" \
+ && chown -R prismor:prismor "$PRISMOR_HOME"
+USER prismor
+WORKDIR /var/lib/prismor
+
+EXPOSE 7080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD curl -fsS "http://127.0.0.1:${PRISMOR_PROXY_PORT}/health" || exit 1
+
+COPY --chown=prismor:prismor packaging/docker/entrypoint.sh /usr/local/bin/prismor-entrypoint
+ENTRYPOINT ["/usr/local/bin/prismor-entrypoint"]
+CMD ["proxy"]

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -1,0 +1,49 @@
+# n8n with every model call governed by Prismor.
+#
+#   cp prismor.env.example prismor.env   # then edit it
+#   docker compose up -d
+#
+# n8n reaches the proxy at http://prismor:7080/v1 on the compose network. Set
+# that as the Base URL on the OpenAI credential inside n8n -- that one field is
+# the whole integration. See docs/n8n.md.
+services:
+  prismor:
+    build:
+      context: ../..
+      dockerfile: packaging/docker/Dockerfile
+    # image: ghcr.io/prismorsec/prismor:latest   # once published, drop `build`
+    command: ["proxy"]
+    env_file: [prismor.env]
+    volumes:
+      # Device identity, policy and session logs. Losing this volume means a
+      # new device in the console and an audit trail that starts over.
+      - prismor_home:/var/lib/prismor
+      # Policy, including the SIEM sinks. The engine reads a workspace's
+      # policy from <workspace>/.prismor/policy.yaml, so the path matters:
+      # mounted one level up it is silently ignored and no sink ever fires.
+      # Read-only, because the surface reads policy and never edits it.
+      - ./policy.yaml:/var/lib/prismor/.prismor/policy.yaml:ro
+    ports:
+      # Only needed to reach the proxy from the host (a local agent, curl
+      # /health). Containers on this network do not need it published.
+      - "127.0.0.1:7080:7080"
+    restart: unless-stopped
+
+  n8n:
+    image: docker.n8n.io/n8nio/n8n:latest
+    depends_on:
+      prismor:
+        condition: service_healthy
+    environment:
+      - N8N_SECURE_COOKIE=false
+      - N8N_RUNNERS_ENABLED=true
+      - N8N_DIAGNOSTICS_ENABLED=false
+    volumes:
+      - n8n_data:/home/node/.n8n
+    ports:
+      - "5678:5678"
+    restart: unless-stopped
+
+volumes:
+  prismor_home:
+  n8n_data:

--- a/packaging/docker/entrypoint.sh
+++ b/packaging/docker/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Enroll (once, if a token is present) and start the requested surface.
+#
+# Enrollment is what puts this container's sessions in the console. It is
+# deliberately not fatal: a proxy that refuses to start because the control
+# plane is unreachable would take the agent down with it, and local policy
+# still applies unenrolled.
+set -eu
+
+if [ -n "${PRISMOR_ENROLL_TOKEN:-}" ] && [ ! -f "${PRISMOR_HOME}/identity.json" ]; then
+  echo "[prismor] enrolling this container..."
+  prismor enroll "${PRISMOR_ENROLL_TOKEN}" \
+    ${PRISMOR_DEVICE_LABEL:+--label "${PRISMOR_DEVICE_LABEL}"} \
+    || echo "[prismor] enrollment failed - continuing with local policy only"
+fi
+
+# A container has no git remote to claim, so without this the workspace reads
+# as personal and nothing reaches the org. See docs/headless.
+export PRISMOR_WORKSPACE_SCOPE="${PRISMOR_WORKSPACE_SCOPE:-managed}"
+
+case "${1:-proxy}" in
+  proxy)
+    shift 2>/dev/null || true
+    exec prismor proxy \
+      --host 0.0.0.0 \
+      --port "${PRISMOR_PROXY_PORT:-7080}" \
+      --mode "${PRISMOR_PROXY_MODE:-enforce}" \
+      --workspace "${PRISMOR_HOME}" \
+      ${PRISMOR_AGENT_NAME:+--agent-name "${PRISMOR_AGENT_NAME}"} \
+      "$@"
+    ;;
+  eval-server)
+    shift
+    exec prismor eval-server \
+      --host 0.0.0.0 \
+      --port "${PRISMOR_EVAL_PORT:-7071}" \
+      --workspace "${PRISMOR_HOME}" \
+      "$@"
+    ;;
+  *)
+    exec prismor "$@"
+    ;;
+esac

--- a/packaging/docker/policy.yaml
+++ b/packaging/docker/policy.yaml
@@ -1,0 +1,47 @@
+# Policy for the containerised surface. Mounted read-only at
+# $PRISMOR_HOME/.prismor/policy.yaml by docker-compose.yml -- that exact path,
+# because the engine reads a workspace's policy from <workspace>/.prismor/.
+#
+# The rules themselves come from Prismor's bundled default policy and, once the
+# container is enrolled, from the signed org policy your admins publish. What
+# belongs here is deployment-local: which mode to run in, and where findings go
+# besides the console.
+version: "1.0"
+
+settings:
+  # Where a finding goes the moment it is produced -- before the block is
+  # returned to the agent, so a SIEM sees denied calls too. Every sink is
+  # best-effort: one that is down warns on stderr and never blocks a tool call.
+  # Delete the ones you do not use; ${VARS} resolve from prismor.env.
+  outputs:
+    # Your own collector, if you already run one.
+    - type: otel
+      endpoint: http://otel-collector:4318      # /v1/logs is appended
+      headers: { "Authorization": "Bearer ${OTEL_TOKEN}" }
+
+    # - type: splunk                            # HTTP Event Collector, OCSF body
+    #   url: https://splunk.example.com:8088/services/collector
+    #   token: ${SPLUNK_HEC_TOKEN}
+    #   sourcetype: prismor:prismor:ocsf
+
+    # - type: datadog
+    #   api_key: ${DD_API_KEY}
+    #   site: datadoghq.com
+
+    # - type: syslog
+    #   host: siem.example.com
+    #   port: 514
+    #   facility: local7
+
+    # - type: webhook                           # anything that takes JSON
+    #   url: https://siem.example.com/ingest
+    #   headers: { "X-API-Key": "${SIEM_TOKEN}" }
+
+    # - type: file                              # format: json | cef | ocsf
+    #   path: /var/lib/prismor/audit.log
+    #   format: ocsf
+
+    # The first-party control-plane sink. Needs no config -- the device key and
+    # endpoint come from enrollment -- and is what puts these findings on the
+    # session view in the Prismor dashboard.
+    - type: prismor

--- a/packaging/docker/prismor.env.example
+++ b/packaging/docker/prismor.env.example
@@ -1,0 +1,28 @@
+# Copy to prismor.env and fill in. docker-compose.yml reads it via env_file.
+
+# --- Console (optional) -----------------------------------------------------
+# Enrollment is what makes this container a device in the Prismor console, with
+# its sessions, its per-agent kill switch and its mode override. Get a token
+# from Settings - Devices - Enroll. Without it the surface still enforces local
+# policy; it just reports to nobody.
+PRISMOR_ENROLL_TOKEN=
+PRISMOR_DEVICE_LABEL=n8n-prod
+
+# The name this surface reports under, so the console can tell it apart from
+# every other agent on the same device and target it individually.
+PRISMOR_AGENT_NAME=n8n-agent
+
+# A container has no git remote to claim, so the workspace would otherwise read
+# as personal and report nothing. Leave this as managed.
+PRISMOR_WORKSPACE_SCOPE=managed
+
+# --- Surface ----------------------------------------------------------------
+PRISMOR_PROXY_MODE=enforce      # observe = evaluate and log, never block
+PRISMOR_PROXY_PORT=7080
+
+# --- Secrets referenced by policy.yaml --------------------------------------
+# Every ${VAR} in a sink config is resolved from this environment, so tokens
+# live here rather than in the policy file you commit.
+SPLUNK_HEC_TOKEN=
+OTEL_TOKEN=
+SIEM_TOKEN=

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.45.3"
+__version__ = "1.46.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/proxy.py
+++ b/prismor/runtime/proxy.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import hmac
 import json
 import os
+import signal
 import ssl
 import sys
 import threading
@@ -268,6 +269,7 @@ class Screen:
         self.session_id = session_id
         self.agent_name = agent_name
         self._events = 0
+        self._unsnapshotted = 0
         # Serialized for the same reason the MCP gateway serializes: the
         # trifecta TagLedger is order-dependent, and concurrent evaluations
         # could let the completing half of a forbidden tag pair through.
@@ -376,8 +378,23 @@ class Screen:
             sys.stderr.write(f"[prismor-proxy] session log error: {exc}\n")
             return
         self._events += 1
+        self._unsnapshotted += 1
         if self._events % SNAPSHOT_EVERY:
             return
+        self.snapshot()
+
+    def snapshot(self) -> None:
+        """Rebuild the session snapshot the console and `prismor sessions` read.
+
+        Called every SNAPSHOT_EVERY events and again when the surface stops. A
+        proxy session is often one chat turn -- the n8n agent that produced a
+        blocked install command logged five events -- so a purely periodic
+        rebuild left short sessions with a session log on disk and no session
+        anywhere an operator looks.
+        """
+        if not self._unsnapshotted:
+            return
+        self._unsnapshotted = 0
         try:
             from prismor.runtime.cli import analyze_events
             from prismor.runtime.store import read_session_events, save_session_snapshot
@@ -1096,10 +1113,25 @@ def run_proxy(host: str = "127.0.0.1", port: int = 7080,
         print("[prismor] auth pass-through (no virtual keys configured)")
     print(f"[prismor] point an agent at it:  ANTHROPIC_BASE_URL={base} claude")
     print(f"[prismor]                        OPENAI_BASE_URL={base}/v1 codex")
+    def _stop(signum, _frame):
+        # SIGTERM is how a container stops, so the flush has to hang off the
+        # signal rather than only off KeyboardInterrupt.
+        raise KeyboardInterrupt
+
+    for _sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(_sig, _stop)
+        except (ValueError, OSError):
+            pass  # not the main thread, or the platform lacks the signal
+
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\n[prismor] proxy stopped.")
+    finally:
+        # Sessions here are often a single chat turn, well under the periodic
+        # rebuild, so without this the console never sees them at all.
+        ProxyHandler.screen.snapshot()
 
 
 if __name__ == "__main__":

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -356,5 +356,28 @@ def test_unrouted_path_follows_the_credential_the_client_presented():
     assert _provider_for("/v1/models", {}) == "anthropic"  # config default
 
 
+def test_short_session_is_snapshotted_on_shutdown(monkeypatch, tmp_path):
+    """A session shorter than the rebuild interval must still be visible.
+
+    The rebuild is periodic because re-analysing the whole log on every event
+    is quadratic for a long-lived surface. But a proxy session is often one
+    chat turn -- the n8n agent that produced a blocked install command logged
+    five events -- so periodic-only left a session log on disk and no session
+    in `prismor sessions`, the dashboard or the console.
+    """
+    screen = proxy_mod.Screen(workspace=tmp_path, mode="observe",
+                              session_id="short-session", agent_name="n8n")
+    saved = []
+    monkeypatch.setattr(proxy_mod.Screen, "snapshot",
+                        lambda self: saved.append(self.session_id))
+
+    assert screen._events == 0
+    proxy_mod.Screen._persist(screen, {"type": "prompt", "prompt": "hello"})
+    assert saved == [], "no periodic rebuild is due after one event"
+
+    proxy_mod.Screen.snapshot(screen)
+    assert saved == ["short-session"], "shutdown must flush what is unsnapshotted"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q", "-p", "no:randomly"]))


### PR DESCRIPTION
`packaging/docker/` stands the proxy up beside n8n: an image, an entrypoint that enrolls on first boot, a compose file, a policy with the SIEM sinks, and `prismor.env.example`. Docs: `docs/deploy-docker.md`.

Three things a deployment gets wrong on its own, now defaulted and documented:
- policy is read from `<workspace>/.prismor/policy.yaml` — mounted one level up it is silently ignored while the surface keeps enforcing bundled defaults, so it looks fine and no sink fires
- a container has no git remote to claim, so `PRISMOR_WORKSPACE_SCOPE=managed` is required or the workspace resolves personal and reports nothing
- enrollment failure is not fatal, or an unreachable control plane takes the governed agent down with it

Also fixes why none of this was visible at session level: the snapshot was rebuilt every 25 events, and a proxy session is often one chat turn. The blocked n8n install command logged five events — findings reached the sinks, the session existed nowhere. Now flushed on shutdown, SIGTERM included.

Verified against the built image: a blocked fetch-and-execute delivered to a webhook sink carrying `agent_name` and `session_id`, and the session row present after `docker stop` and absent after `docker kill`.