### PR TITLE
fix(modes): make a governance mode usable on a real machine

### DIFF
--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1842,10 +1842,15 @@ def main(argv: Optional[List[str]] = None) -> None:
                 _sandbox_status = _sandbox.docker_status()
                 _sandbox_ready = bool(_sandbox_status.get("cli_found") and _sandbox_status.get("server_reachable"))
                 if not _sandbox_ready:
+                    # Containment is a layer on top of policy, not the policy.
+                    # Every rule, egress check and tag rule has already run
+                    # against this command by the time we get here, so a missing
+                    # runtime means "not contained", not "not screened".
+                    # Blocking instead — which is what this did — bricked every
+                    # shell command the moment Docker stopped, which is how a
+                    # team ends up uninstalling Prismor to get through the
+                    # afternoon. Skip the sandbox, say so loudly, keep screening.
                     reason = _sandbox_status.get("error") or "Docker is not reachable"
-                    if str(_sandbox_cfg.get("mode", "observe")).lower() == "enforce":
-                        sys.stderr.write(f"Prismor sandbox blocked this action: {reason}\n")
-                        raise SystemExit(2)
                     sys.stderr.write(_color("[prismor] ", _YELLOW) + f"sandbox unavailable; running without sandbox: {reason}\n")
                 else:
                     update = _sandbox.claude_updated_input(
@@ -2664,16 +2669,17 @@ def main(argv: Optional[List[str]] = None) -> None:
                           f"{total} rules would block without it.")
                 else:
                     print(f"  Rules     {blocking} of {total} block")
-                # Apply-time preflight cannot see a runtime that went away
-                # afterwards, and the symptom (every shell call blocked) does
-                # not name its cause. Report it where someone would look.
+                # Apply-time degradation cannot see a runtime that went away
+                # afterwards, so check the live host too. Commands still run and
+                # are still screened — what is missing is container isolation,
+                # and that is what this line has to say, precisely.
                 if not previewing:
                     problem = sandbox_preflight(mode)
                     if problem is not None:
-                        print(_color("  Sandbox", _RED) +
-                              f"   unavailable ({problem}) — this mode enforces it, "
-                              f"so every shell command is being blocked")
-                        print("            fix Docker, or re-apply with --observe")
+                        print(_color("  Sandbox", _YELLOW) +
+                              f"   unavailable ({problem}) — commands run "
+                              f"unsandboxed; rules, egress and tag rules still apply")
+                        print("            start Docker for container isolation")
                 print(f"  Policy    {workspace / '.prismor' / 'policy.yaml'}")
                 if has_drifted(workspace):
                     print(_color("  Drift", _YELLOW) +

--- a/prismor/runtime/modes.py
+++ b/prismor/runtime/modes.py
@@ -31,6 +31,7 @@ Two merge hazards this module exists to get right:
 """
 from __future__ import annotations
 
+import copy
 from datetime import date
 from functools import lru_cache
 from pathlib import Path
@@ -206,15 +207,14 @@ def needs_container_runtime(mode: Dict[str, Any]) -> bool:
 
 
 def sandbox_preflight(mode: Dict[str, Any]) -> Optional[str]:
-    """Why this mode would not work on this host, or None if it would.
+    """Why this mode's sandbox will not work on this host, or None if it will.
 
-    The failure this guards against is not subtle. `cli.py` blocks the tool call
-    outright when an enforcing sandbox has no runtime behind it, so applying
-    such a mode on a host without Docker leaves an agent whose every shell
-    command dies with ``Prismor sandbox blocked this action``. That is the
-    "developer rips the guardrails out to get through the afternoon" failure the
-    modes exist to avoid, so it is worth refusing at apply time rather than
-    discovering per command.
+    Containment is one axis of a posture, not the posture itself: a mode whose
+    sandbox cannot start still has its rules, its egress allowlist and its tag
+    rules, and all of those work on a host with no Docker. So this reports the
+    problem and :func:`apply_mode` degrades that one axis to ``observe`` — it
+    is not a reason to refuse the whole mode, which would leave the workspace
+    with no policy at all.
     """
     if not needs_container_runtime(mode):
         return None
@@ -223,6 +223,20 @@ def sandbox_preflight(mode: Dict[str, Any]) -> Optional[str]:
     if status.get("cli_found") and status.get("server_reachable"):
         return None
     return str(status.get("error") or "Docker is not reachable")
+
+
+def degrade_sandbox(mode: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of ``mode`` whose sandbox observes instead of enforcing.
+
+    Used when the host has no container runtime. Every other axis is left
+    exactly as the mode declares it, so what the operator loses is container
+    isolation, not the rules, the egress allowlist or the tag rules.
+    """
+    degraded = copy.deepcopy(mode)
+    sandbox = degraded.get("sandbox") or {}
+    sandbox["mode"] = "observe"
+    degraded["sandbox"] = sandbox
+    return degraded
 
 
 def _command_allowlists(mode: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -396,20 +410,23 @@ def apply_mode(
     policy_path = workspace / ".prismor" / "policy.yaml"
     notes: List[str] = []
 
-    # An --observe build compiles the sandbox to observe, so it needs no
-    # runtime; --force is the operator saying they know and want it anyway
-    # (staging a policy for a host that will have Docker, most legitimately).
-    if not observe and not force:
+    # An --observe build already compiles the sandbox to observe, so it needs no
+    # runtime. Otherwise: if the host cannot reach a container runtime, degrade
+    # that one axis rather than refusing the mode. Refusing left the workspace
+    # with no policy at all — strictly worse than a posture whose rules, egress
+    # allowlist and tag rules all work and whose containment is a warning.
+    #
+    # Deliberately NOT gated on `force`. `force` means "overwrite a policy I did
+    # not generate"; conflating it with "skip the runtime check" is what let
+    # `prismor setup` write an enforcing sandbox onto a host with no Docker.
+    if not observe:
         problem = sandbox_preflight(mode)
         if problem is not None:
-            raise ModeError(
-                f"mode '{mode_id}' enforces a Docker sandbox and this host cannot "
-                f"reach one ({problem}). Every shell command would be blocked, not "
-                f"just sandboxed. Options: start or install Docker; apply with "
-                f"--observe to run the posture without enforcing it; use "
-                f"trusted-workspace, whose sandbox degrades to a warning; or "
-                f"re-run with --force if this policy is being staged for another "
-                f"host."
+            mode = degrade_sandbox(mode)
+            notes.append(
+                f"no container runtime here ({problem}) — sandbox set to "
+                f"observe; rules, egress and tag rules are unaffected. Start "
+                f"Docker and re-apply for container isolation."
             )
 
     if policy_path.exists():

--- a/prismor/runtime/modes.yaml
+++ b/prismor/runtime/modes.yaml
@@ -233,7 +233,7 @@ modes:
       - "Supply chain        : BLOCKED. Confusion, URL installs, and typosquats denied."
       - "Read-only work      : FREE. Inspection commands never prompt."
     friction:
-      - "Requires Docker     : the sandbox enforces, so no runtime means no shell."
+      - "Wants Docker        : without it the sandbox observes; rules still enforce."
       - "Network destinations: a vendor API outside the list needs an explicit entry."
       - "Private registries  : an internal index URL is denied, not prompted."
       - "Dependency changes  : adding a package prompts for approval."

--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -1149,20 +1149,20 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
     disabled = [r["id"] for r in rules if not r["on"]]
     if mode == "enforce" and gov_mode not in (None, "custom"):
         def _write_policy():
+            # force=True is only "overwrite whatever policy is already here" —
+            # setup is the tool whose job that is. It does not skip the
+            # container-runtime check: apply_mode degrades the sandbox axis on
+            # a host with no Docker and reports it in `notes`.
             from prismor.runtime.modes import apply_mode, ModeError
             try:
                 _, notes = apply_mode(target, gov_mode, force=True)
-                return True, f"mode '{gov_mode}' compiled" + (f" — {notes[-1]}" if notes else "")
             except ModeError as e:
-                # Most commonly: this mode enforces a Docker sandbox and no
-                # runtime is reachable on this host. Fall back to the same
-                # posture with nothing enforcing rather than leave the
-                # workspace with no policy at all.
-                try:
-                    apply_mode(target, gov_mode, force=True, observe=True)
-                    return True, f"compiled in observe (enforcing build refused: {e})"
-                except ModeError as e2:
-                    return False, str(e2)[:70]
+                return False, str(e)[:70]
+            detail = f"mode '{gov_mode}' compiled"
+            degraded = [n for n in notes if "sandbox set to observe" in n]
+            if degraded:
+                detail += " — no Docker here, sandbox observes"
+            return True, detail
         _spinner_run(f"Compiling governance mode '{gov_mode}'", _write_policy)
     elif mode == "enforce":
         def _write_policy():

--- a/prismor/runtime/trifecta.py
+++ b/prismor/runtime/trifecta.py
@@ -74,10 +74,21 @@ DEFAULT_INCOMPATIBLE = [[UNTRUSTED, CRITICAL]]
 #                Glob, Task, TodoWrite — none of them external ingest. Only an
 #                MCP tool result is attacker-influenceable, so the tag is
 #                scoped to events the normalizer marked with an mcp_server.
+#   memory       The SessionStart scan of the workspace's own instruction
+#                files (CLAUDE.md, AGENTS.md). It fires on EVERY session, so
+#                tagging it untrusted armed `untrusted_content then
+#                critical_action -> block` before the user typed anything and
+#                the first shell call of every session died. It is also the
+#                same content as an in-workspace `file_read`, which is
+#                already excluded above, so tagging it here was inconsistent
+#                as well as fatal. Nothing is lost: the memory event's content
+#                is still scanned by the prompt-injection rules and checked
+#                against the TOFU baseline by memory_guard — this set only
+#                feeds the combination rules.
 #
-# Neither narrowing loses the tools that matter: WebFetch and WebSearch are
-# tagged by name in TOOL_TAG_DEFAULTS, which resolves before inference runs.
-_UNTRUSTED_EVENT_TYPES = {"memory", "subagent_spawn"}
+# None of these narrowings lose the tools that matter: WebFetch and WebSearch
+# are tagged by name in TOOL_TAG_DEFAULTS, which resolves before inference runs.
+_UNTRUSTED_EVENT_TYPES = {"subagent_spawn"}
 _CRITICAL_EVENT_TYPES = {"file_write", "shell"}
 _CRITICAL_FINDING_CATEGORIES = {
     "destructive_command",

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -14,6 +14,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from prismor.runtime import modes
@@ -40,8 +42,9 @@ def _docker_ready():
 
     Applied at class level so a suite that is about policy compilation does not
     silently become a test of whether the developer has Docker installed —
-    `apply_mode` refuses an enforcing sandbox it cannot back. Uses ``new=`` so
-    no mock argument is injected into the test methods.
+    without it, `apply_mode` degrades the sandbox axis and the compiled output
+    differs from what these tests are asserting. Uses ``new=`` so no mock
+    argument is injected into the test methods.
     """
     return mock.patch(
         "prismor.runtime.sandbox.docker_status", new=lambda: dict(_DOCKER_OK)
@@ -404,20 +407,40 @@ def _docker(available):
 
 
 class TestSandboxPreflight(unittest.TestCase):
-    """An enforcing sandbox with no runtime behind it blocks every shell call
-    (cli.py raises SystemExit(2) rather than degrading), so applying such a mode
-    on a host without Docker produces a wholly broken agent. These pin both that
-    it is caught and — just as important — that it is not over-caught."""
+    """A host with no container runtime loses containment, not the posture.
+    These pin that the sandbox axis degrades on its own, that the rest of the
+    mode still lands, and that the check is not over-applied to modes which
+    never needed a runtime."""
 
-    def test_dev_safe_refuses_to_apply_without_a_runtime(self):
+    def test_dev_safe_applies_with_a_degraded_sandbox_without_a_runtime(self):
+        ws = _workspace()
         with _docker(False), _unmanaged():
-            with self.assertRaises(modes.ModeError) as ctx:
-                modes.apply_mode(_workspace(), "dev-safe")
-        message = str(ctx.exception)
-        self.assertIn("docker", message.lower())
-        # The remedies matter more than the diagnosis.
-        self.assertIn("--observe", message)
-        self.assertIn("trusted-workspace", message)
+            path, notes = modes.apply_mode(ws, "dev-safe")
+        self.assertTrue(path.exists())
+        written = yaml.safe_load(path.read_text(encoding="utf-8"))
+        sandbox = (written.get("settings") or {}).get("sandbox") or {}
+        self.assertEqual(sandbox.get("mode"), "observe")
+        self.assertTrue(any("sandbox set to observe" in n for n in notes), notes)
+        # Degrading containment must not quietly degrade anything else.
+        self.assertNotIn("mode_observe", written.get("settings") or {})
+        enforcing = [r for r in written.get("rules") or []
+                     if r.get("mode") == "enforce"]
+        self.assertTrue(enforcing, "the mode's rules must still enforce")
+        egress = (written.get("settings") or {}).get("egress") or {}
+        self.assertEqual(egress.get("default"), "deny")
+
+    def test_degrading_is_not_gated_on_force(self):
+        """`force` means "overwrite a foreign policy", never "skip the runtime
+        check" — conflating them is what let setup write an enforcing sandbox
+        onto a host with no Docker."""
+        ws = _workspace()
+        with _docker(False), _unmanaged():
+            path, _ = modes.apply_mode(ws, "dev-safe", force=True)
+        written = yaml.safe_load(path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            ((written.get("settings") or {}).get("sandbox") or {}).get("mode"),
+            "observe",
+        )
 
     def test_dev_safe_applies_when_a_runtime_is_present(self):
         with _docker(True), _unmanaged():
@@ -429,11 +452,6 @@ class TestSandboxPreflight(unittest.TestCase):
         enforce and nothing to require."""
         with _docker(False), _unmanaged():
             path, _ = modes.apply_mode(_workspace(), "dev-safe", observe=True)
-        self.assertTrue(path.exists())
-
-    def test_force_stages_a_policy_for_another_host(self):
-        with _docker(False), _unmanaged():
-            path, _ = modes.apply_mode(_workspace(), "dev-safe", force=True)
         self.assertTrue(path.exists())
 
     def test_trusted_workspace_is_unaffected(self):

--- a/tests/test_setup_wizard_governance.py
+++ b/tests/test_setup_wizard_governance.py
@@ -12,10 +12,12 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from prismor.runtime import setup_wizard
-from prismor.runtime.modes import ModeError, load_modes
+from prismor.runtime.modes import load_modes
 
 
 class TestWizardSteps(unittest.TestCase):
@@ -58,25 +60,32 @@ class TestInstallCompilesMode(unittest.TestCase):
         policy = (self.target / ".prismor" / "policy.yaml").read_text(encoding="utf-8")
         self.assertIn(f"mode: {mode_id}", policy)
 
-    def test_docker_unavailable_falls_back_to_observe_build(self):
-        mode_id = next(iter(load_modes()))
-
-        def _refuse_enforce(workspace, mid, force=False, observe=False):
-            if not observe:
-                raise ModeError("Docker is not reachable")
-            path = workspace / ".prismor" / "policy.yaml"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(f"# observe build of {mid}\n", encoding="utf-8")
-            return path, []
-
+    def test_install_on_a_host_with_no_docker_keeps_the_posture(self):
+        """The wizard used to pass force=True, which ALSO skipped the runtime
+        check, so setup wrote an enforcing sandbox onto a host with no Docker —
+        strictly more dangerous than the `mode apply` it wraps. Now the sandbox
+        axis degrades and everything else still lands."""
         with mock.patch("prismor.runtime.setup_wizard._REPO_ROOT", Path("/nonexistent")), \
-             mock.patch("prismor.runtime.modes.apply_mode", side_effect=_refuse_enforce):
+             mock.patch("prismor.runtime.sandbox.docker_status",
+                        new=lambda: {"cli_found": False, "server_reachable": False,
+                                     "error": "docker CLI not found"}), \
+             mock.patch("prismor.runtime.enterprise.workspace_scope.is_managed",
+                        return_value=False):
             setup_wizard._do_install(
                 self.target, "enforce", rules=[], agents=[], cloak=False,
-                scope="project", gov_mode=mode_id,
+                scope="project", gov_mode="dev-safe",
             )
-        policy = (self.target / ".prismor" / "policy.yaml").read_text(encoding="utf-8")
-        self.assertIn("observe build", policy)
+        written = yaml.safe_load(
+            (self.target / ".prismor" / "policy.yaml").read_text(encoding="utf-8")
+        )
+        settings = written.get("settings") or {}
+        self.assertEqual(settings.get("mode_id"), "dev-safe")
+        self.assertEqual((settings.get("sandbox") or {}).get("mode"), "observe")
+        # Not the blunt observe build: the rules and egress must still enforce.
+        self.assertNotIn("mode_observe", settings)
+        self.assertEqual((settings.get("egress") or {}).get("default"), "deny")
+        self.assertTrue([r for r in written.get("rules") or []
+                         if r.get("mode") == "enforce"])
 
 
 if __name__ == "__main__":

--- a/tests/test_trifecta.py
+++ b/tests/test_trifecta.py
@@ -64,6 +64,43 @@ def test_local_unmapped_tool_result_is_not_untrusted():
     assert classify_tool_tags(ev, "tool_result", set(), tt) == {UNTRUSTED}
 
 
+def test_session_start_memory_is_not_untrusted():
+    """SessionStart scans the workspace's own CLAUDE.md/AGENTS.md and emits a
+    `memory` event. Tagging that untrusted armed `untrusted_content then
+    critical_action -> block` on EVERY session before the user typed anything,
+    so the first shell call always died — the modes installed fine and then
+    nothing worked. It is the same content as an in-workspace `file_read`,
+    which is already trusted.
+    """
+    tt = {"defaults_enabled": False}
+    assert classify_tool_tags(_ev("memory", "memory"), "memory", set(), tt) == set()
+    # The genuinely untrusted instruction channel keeps its tag.
+    assert classify_tool_tags(
+        _ev("Task", "subagent_spawn"), "subagent_spawn", set(), tt
+    ) == {UNTRUSTED}
+
+
+def test_real_trifecta_still_blocks_after_the_memory_narrowing(tmp_path):
+    """The narrowing must not cost the control it exists for: fetched web
+    content followed by a shell command is still a completed sequence."""
+    tt = {}
+    fetch_tags = classify_tool_tags(_ev("WebFetch", "network"), "network", set(), tt)
+    assert fetch_tags == {UNTRUSTED}
+    bash_tags = classify_tool_tags(_ev("Bash", "shell"), "shell", set(), tt)
+    assert bash_tags == {CRITICAL}
+
+    trifecta_rule = normalize_incompatible([[UNTRUSTED, CRITICAL]])
+    ledger = TagLedger(tmp_path, "s-" + uuid.uuid4().hex)
+    ledger.record(fetch_tags, 0, "WebFetch")
+    assert ledger.completes(bash_tags, trifecta_rule, 1)
+
+    # ...whereas a session that only ever read its own memory does not.
+    clean = TagLedger(tmp_path, "s-" + uuid.uuid4().hex)
+    clean.record(classify_tool_tags(_ev("memory", "memory"), "memory", set(), tt),
+                 0, "memory")
+    assert not clean.completes(bash_tags, trifecta_rule, 1)
+
+
 def test_workspace_read_is_trusted_but_outside_read_is_not(tmp_path):
     """The read-then-anything cliff: a workspace read must not taint a session."""
     tt = {"defaults_enabled": False}


### PR DESCRIPTION
Found by installing 1.47.0 on a clean box (st3ve) and then actually using it, plus a report from a laptop with no Docker.

## 1. Every mode blocked the first shell command of every session
`SessionStart` scans the workspace's own `CLAUDE.md`/`AGENTS.md` and emits a `memory` event, and `memory` was in `trifecta._UNTRUSTED_EVENT_TYPES`. So `untrusted_content then critical_action -> block` was armed before the user typed anything:

```
allowed  SessionStart
BLOCKED  git status   :: Forbidden tool combination: 'Bash' completes tag sequence
BLOCKED  ls -la / echo hello / npm test
```
Each command in its **own** session passed, so it was the sequence, not the rule matching the command. This is the "mode works but not at installation" report.

`memory` is the same content as an in-workspace `file_read`, which this set already excludes — so tagging it was inconsistent as well as fatal. The content is still scanned by the injection rules and checked against the TOFU baseline; this set only feeds combination rules. **The real trifecta is preserved and asserted:** WebFetch → Bash still blocks.

## 2. `prismor setup` wrote an enforcing sandbox onto hosts with no Docker
`_do_install` passed `force=True` to overwrite an existing policy, and in `apply_mode` `force` **also** skipped the runtime preflight — so setup installed exactly the configuration standalone `mode apply` refuses. `force` now means only "overwrite a policy I did not generate".

## 3. `mode apply dev-safe` refused outright without Docker
Leaving the workspace with **no policy at all**. Containment is one axis of a posture, not the posture. Now it degrades:

```
Applied mode 'dev-safe' -> .prismor/policy.yaml
  · no container runtime here (docker CLI not found) — sandbox set to observe;
    rules, egress and tag rules are unaffected. Start Docker and re-apply.
```
sandbox `observe`, egress still `deny`, 30 rules still enforcing. At run time a missing runtime now warns and keeps screening instead of `exit 2`, so a stopped daemon no longer bricks every shell command.

## Verification (st3ve, PATH that hides docker)
| | before | after |
|---|---|---|
| `git status` after SessionStart | BLOCKED | allowed |
| `rm -rf /` | BLOCKED | BLOCKED |
| exfil to off-list host | BLOCKED | BLOCKED |
| `git status` after WebFetch | BLOCKED | BLOCKED |
| `mode apply dev-safe`, no Docker | refused, no policy | applied, sandbox degraded |
| wizard install, no Docker | enforcing sandbox (broken) | sandbox observes, 30 rules enforce |

- `bash scripts/run_security_tests.sh` — all passed
- `pytest tests/ -q -p no:randomly` — 21 failed / 2495 passed, FAILED set byte-identical to the v1.46.0 baseline (diffed), i.e. all pre-existing