### PR TITLE
fix(modes): say NOTE and skip, and stop calling a skipped sandbox drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## [Unreleased]
 
+## [1.47.2] — 2026-09-08
+
+### Changed
+- **One `NOTE:` wherever a missing Docker skips the sandbox.** `mode apply`,
+  `mode show`, `prismor setup` and the hook path each phrased it differently,
+  and none of them led with the thing the reader needs first — that the
+  sandbox was *skipped*, not that something failed. All four now say so in one
+  wording, and callers key off the `NOTE:` prefix rather than the prose.
+
+  ```
+  · NOTE: Docker is not available here (docker CLI not found) — the sandbox
+    is skipped. Rules, egress and tag rules still enforce; start Docker and
+    re-apply for container isolation.
+  ```
+
+### Fixed
+- **A Docker-less install reported itself as hand-edited drift.** Skipping the
+  sandbox makes the written policy legitimately differ from the catalogue
+  mode's compile, and `has_drifted` compared against the undegraded article —
+  so `mode show` told every such install "the policy has been hand-edited
+  since this mode was applied" the moment it was written. The skip is now
+  stamped as provenance (`settings.mode_sandbox_skipped`, the same shape as
+  `mode_observe`) and drift is computed against what the policy actually is.
+
 ## [1.47.1] — 2026-09-08
 
 ### Fixed

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.47.1"
+__version__ = "1.47.2"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/cli.py
+++ b/prismor/runtime/cli.py
@@ -1851,7 +1851,11 @@ def main(argv: Optional[List[str]] = None) -> None:
                     # team ends up uninstalling Prismor to get through the
                     # afternoon. Skip the sandbox, say so loudly, keep screening.
                     reason = _sandbox_status.get("error") or "Docker is not reachable"
-                    sys.stderr.write(_color("[prismor] ", _YELLOW) + f"sandbox unavailable; running without sandbox: {reason}\n")
+                    sys.stderr.write(
+                        _color("[prismor] ", _YELLOW)
+                        + f"NOTE: Docker is not available ({reason}) — the sandbox "
+                          f"is skipped for this call. Policy still applies.\n"
+                    )
                 else:
                     update = _sandbox.claude_updated_input(
                         payload=payload,
@@ -2677,9 +2681,9 @@ def main(argv: Optional[List[str]] = None) -> None:
                     problem = sandbox_preflight(mode)
                     if problem is not None:
                         print(_color("  Sandbox", _YELLOW) +
-                              f"   unavailable ({problem}) — commands run "
-                              f"unsandboxed; rules, egress and tag rules still apply")
-                        print("            start Docker for container isolation")
+                              f"   skipped — Docker is not available ({problem})")
+                        print("            commands run unsandboxed; rules, egress "
+                              "and tag rules still apply")
                 print(f"  Policy    {workspace / '.prismor' / 'policy.yaml'}")
                 if has_drifted(workspace):
                     print(_color("  Drift", _YELLOW) +

--- a/prismor/runtime/modes.py
+++ b/prismor/runtime/modes.py
@@ -225,17 +225,33 @@ def sandbox_preflight(mode: Dict[str, Any]) -> Optional[str]:
     return str(status.get("error") or "Docker is not reachable")
 
 
+# One wording for "Docker is missing, so the sandbox is skipped", used by
+# `mode apply`, `mode show`, `prismor setup` and the hook path. Callers key off
+# the NOTE: prefix rather than the prose, so the sentence can be reworded
+# without breaking them.
+SANDBOX_SKIPPED_NOTE = (
+    "NOTE: Docker is not available here ({reason}) — the sandbox is skipped. "
+    "Rules, egress and tag rules still enforce; start Docker and re-apply for "
+    "container isolation."
+)
+
+
 def degrade_sandbox(mode: Dict[str, Any]) -> Dict[str, Any]:
     """A copy of ``mode`` whose sandbox observes instead of enforcing.
 
     Used when the host has no container runtime. Every other axis is left
     exactly as the mode declares it, so what the operator loses is container
     isolation, not the rules, the egress allowlist or the tag rules.
+
+    The copy is flagged so :func:`compile_mode` can stamp the provenance:
+    without it the written policy differs from the mode's own compile and
+    `mode show` reports the degrade as hand-edited drift.
     """
     degraded = copy.deepcopy(mode)
     sandbox = degraded.get("sandbox") or {}
     sandbox["mode"] = "observe"
     degraded["sandbox"] = sandbox
+    degraded["_sandbox_skipped"] = True
     return degraded
 
 
@@ -328,6 +344,11 @@ def compile_mode(mode: Dict[str, Any], observe: bool = False) -> str:
         # Provenance, so `mode show` can say which posture is being previewed
         # and never reports a dry run as the enforcing article.
         settings["mode_observe"] = True
+    if mode.get("_sandbox_skipped"):
+        # Same idea for a host with no container runtime: the file legitimately
+        # differs from this mode's own compile, and without the stamp
+        # `has_drifted` reads that difference as a hand edit.
+        settings["mode_sandbox_skipped"] = True
     # `selection: explicit` says "the rules listed below are the blocking set",
     # which is only meaningful when the mode names one. An `all` mode carries
     # enforcement in default_mode and must NOT set it, or the floor turns opt-in.
@@ -423,11 +444,7 @@ def apply_mode(
         problem = sandbox_preflight(mode)
         if problem is not None:
             mode = degrade_sandbox(mode)
-            notes.append(
-                f"no container runtime here ({problem}) — sandbox set to "
-                f"observe; rules, egress and tag rules are unaffected. Start "
-                f"Docker and re-apply for container isolation."
-            )
+            notes.append(SANDBOX_SKIPPED_NOTE.format(reason=problem))
 
     if policy_path.exists():
         previous = active_mode(workspace)
@@ -490,6 +507,19 @@ def is_observe_build(workspace: Path) -> bool:
     return bool((raw.get("settings") or {}).get("mode_observe"))
 
 
+def is_sandbox_skipped_build(workspace: Path) -> bool:
+    """Whether this policy was compiled on a host with no container runtime."""
+    import yaml
+    policy_path = workspace / ".prismor" / "policy.yaml"
+    if not policy_path.exists():
+        return False
+    try:
+        raw = yaml.safe_load(policy_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return False
+    return bool((raw.get("settings") or {}).get("mode_sandbox_skipped"))
+
+
 def has_drifted(workspace: Path) -> bool:
     """True when the policy claims a mode but no longer matches its compile.
 
@@ -501,10 +531,14 @@ def has_drifted(workspace: Path) -> bool:
         return False
     policy_path = workspace / ".prismor" / "policy.yaml"
     try:
+        mode = get_mode(mode_id)
+        # A policy compiled where Docker was missing legitimately differs from
+        # the catalogue mode. Compare it against what it actually is, or every
+        # such install reports itself hand-edited the moment it is written.
+        if is_sandbox_skipped_build(workspace):
+            mode = degrade_sandbox(mode)
         current = policy_path.read_text(encoding="utf-8")
-        expected = compile_mode(
-            get_mode(mode_id), observe=is_observe_build(workspace)
-        )
+        expected = compile_mode(mode, observe=is_observe_build(workspace))
     except (OSError, ModeError):
         return False
     # Compare everything below the generated header — the header carries a

--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -1159,9 +1159,8 @@ def _do_install(target: Path, mode: str, rules: List[dict], agents: List[str], c
             except ModeError as e:
                 return False, str(e)[:70]
             detail = f"mode '{gov_mode}' compiled"
-            degraded = [n for n in notes if "sandbox set to observe" in n]
-            if degraded:
-                detail += " — no Docker here, sandbox observes"
+            if any(n.startswith("NOTE:") for n in notes):
+                detail += "  NOTE: Docker not available, sandbox skipped"
             return True, detail
         _spinner_run(f"Compiling governance mode '{gov_mode}'", _write_policy)
     elif mode == "enforce":

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -420,7 +420,8 @@ class TestSandboxPreflight(unittest.TestCase):
         written = yaml.safe_load(path.read_text(encoding="utf-8"))
         sandbox = (written.get("settings") or {}).get("sandbox") or {}
         self.assertEqual(sandbox.get("mode"), "observe")
-        self.assertTrue(any("sandbox set to observe" in n for n in notes), notes)
+        self.assertTrue(any(n.startswith("NOTE:") for n in notes), notes)
+        self.assertTrue(any("Docker is not available" in n for n in notes), notes)
         # Degrading containment must not quietly degrade anything else.
         self.assertNotIn("mode_observe", written.get("settings") or {})
         enforcing = [r for r in written.get("rules") or []
@@ -428,6 +429,16 @@ class TestSandboxPreflight(unittest.TestCase):
         self.assertTrue(enforcing, "the mode's rules must still enforce")
         egress = (written.get("settings") or {}).get("egress") or {}
         self.assertEqual(egress.get("default"), "deny")
+
+    def test_a_degraded_install_does_not_report_itself_as_drift(self):
+        """The written policy legitimately differs from the catalogue mode when
+        the sandbox was skipped. Without the provenance stamp `mode show`
+        called every Docker-less install hand-edited the moment it was made."""
+        ws = _workspace()
+        with _docker(False), _unmanaged():
+            modes.apply_mode(ws, "dev-safe")
+            self.assertTrue(modes.is_sandbox_skipped_build(ws))
+            self.assertFalse(modes.has_drifted(ws))
 
     def test_degrading_is_not_gated_on_force(self):
         """`force` means "overwrite a foreign policy", never "skip the runtime


### PR DESCRIPTION
## NOTE wording
When Docker is not available the sandbox is skipped. All four surfaces that report it — `mode apply`, `mode show`, `prismor setup`, the hook path — said it differently, and none led with the fact the reader needs first: that the sandbox was *skipped*, not that something failed.

```
· NOTE: Docker is not available here (docker CLI not found) — the sandbox is
  skipped. Rules, egress and tag rules still enforce; start Docker and
  re-apply for container isolation.
```
Callers key off the `NOTE:` prefix, not the prose, so it can be reworded without breaking them.

## Fixed: a Docker-less install called itself hand-edited
Found while verifying the wording on st3ve — `mode show` printed this immediately after a clean apply:

```
Drift     the policy has been hand-edited since this mode was applied
```

Skipping the sandbox makes the written policy legitimately differ from the catalogue mode's compile, and `has_drifted` compared against the undegraded article. The skip is now stamped as provenance (`settings.mode_sandbox_skipped`, same shape as `mode_observe`) and drift is computed against what the policy actually is.

## Verified on st3ve (PATH hiding docker)
```
1. mode apply  → NOTE: ... the sandbox is skipped.
2. mode show   → Sandbox   skipped — Docker is not available (docker CLI not found)
                 commands run unsandboxed; rules, egress and tag rules still apply
                 (no Drift line)
3. hook path   → [prismor] NOTE: Docker is not available ... skipped for this call.
                 exit 0 — command allowed through
```

- `bash scripts/run_security_tests.sh` — all passed
- `pytest tests/ -q -p no:randomly` — FAILED set byte-identical to the v1.46.0 baseline