### PR TITLE
Release 1.48.0 — a session you can actually read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## [Unreleased]
 
+## [1.48.0] — 2026-09-08
+
+### Added
+- **The session view shows what actually happened, not just that something
+  did.** A session is now a tree — turn → lane → event — instead of a flat
+  chain of nodes: a turn begins at each model request, and lanes (Prompts,
+  Tool calls, Shell, Files, Network, Context, MCP) keep two hundred shell
+  calls from burying the one file that was written. Expand all / Collapse all,
+  and every row still opens the same policy panel.
+
+  Each row now carries its artefacts, which the log had held all along and the
+  view had never shown: the full prompt text, what a tool returned, the path
+  touched, the command, the model and provider, and — for a session-start
+  event — the instruction files that were already in context plus any
+  integrity finding against them. A prompt used to render as the word
+  "prompt". Captures are bounded per field, with the truncation made visible,
+  because the session view is a reading surface and the event log remains the
+  record.
+
+### Fixed
+- **Every tool call appeared twice.** A hooked agent logs a `PreToolUse` and a
+  `PostToolUse` for the same call, and the trail listed both — an unbroken
+  column of pairs that reads as a rendering bug. One call is one row now: the
+  pre-call phase carries the verdict, the post-call phase contributes what came
+  back. A post with no pre inside the window still appears, because the call
+  still happened.
+- **A session showed its last 60 events and said nothing about the rest.** For
+  a session with 1458 of them that is the tail of the tail, and with each call
+  double-counted it was really the last 30 calls. The window is 600 events
+  fetched and 250 rows rendered after merging.
+
 ## [1.47.2] — 2026-09-08
 
 ### Changed

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.47.2"
+__version__ = "1.48.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -1062,13 +1062,51 @@
   @media (max-width:900px){ .session-layout { grid-template-columns:1fr; } }
 
   .flow-card {
-    border:1px solid var(--gray-200); border-radius:14px; background:
-      radial-gradient(circle at 1px 1px, var(--gray-200) 1px, transparent 0) 0 0 / 22px 22px,
-      #fff;
+    border:1px solid var(--gray-200); border-radius:14px; background:var(--surface);
     padding:0; overflow:hidden;
   }
-  .flow-head { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid var(--gray-100); background:#fff; }
+  .flow-head { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 16px; border-bottom:1px solid var(--gray-100); background:var(--surface); }
   .flow-head-title { font-size:12px; font-weight:700; color:var(--gray-800); }
+  /* ── Session tree: turns → lanes → events ── */
+  .tree-toolbar { display:flex; gap:6px; align-items:center; }
+  .tree-btn { font-size:11px; font-weight:600; color:var(--gray-700); background:var(--surface);
+    border:1px solid var(--gray-300); border-radius:7px; padding:4px 9px; cursor:pointer; }
+  .tree-btn:hover { background:var(--gray-50); }
+  .artifacts { margin-top:14px; }
+  .artifacts h4 { font-size:11px; text-transform:uppercase; letter-spacing:.04em; color:var(--gray-500); margin:0 0 8px; }
+  .art-phase { text-transform:none; letter-spacing:0; font-weight:600; color:var(--gray-400); }
+  .art-row { margin-bottom:9px; }
+  .art-label { font-size:10px; font-weight:600; color:var(--gray-500); margin-bottom:2px; }
+  .art-val { font-size:11px; color:var(--gray-700); word-break:break-word; }
+  .art-pre { font-family:var(--font-mono); font-size:10.5px; line-height:1.45; color:var(--gray-700);
+    background:var(--gray-50); border:1px solid var(--gray-200); border-radius:7px;
+    padding:7px 9px; margin:0; max-height:200px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
+  .sess-tree { padding:10px 4px 16px; font-size:12px; }
+  .tree-turn { margin-bottom:2px; }
+  .tree-row { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
+    background:none; border:0; padding:5px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+  .tree-row:hover { background:var(--gray-50); }
+  .tree-caret { width:12px; flex:none; color:var(--gray-400); transition:transform .12s ease; }
+  .tree-row.collapsed .tree-caret { transform:rotate(-90deg); }
+  .tree-turn-label { font-weight:700; color:var(--gray-800); }
+  .tree-turn-sub { color:var(--gray-500); font-weight:400; margin-left:6px;
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .tree-count { margin-left:auto; flex:none; font-size:10px; font-weight:600; color:var(--gray-600);
+    background:var(--gray-100); border-radius:10px; padding:1px 7px; }
+  .tree-children { margin-left:14px; padding-left:10px; border-left:1px solid var(--gray-200); }
+  .tree-children.hidden { display:none; }
+  .tree-lane-label { font-weight:600; color:var(--gray-700); }
+  .tree-leaf { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
+    background:none; border:0; padding:4px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+  .tree-leaf:hover { background:var(--gray-50); }
+  .tree-leaf.sel { background:var(--gray-100); box-shadow:inset 2px 0 0 var(--gray-800); }
+  .tree-dot { width:8px; height:8px; border-radius:50%; flex:none; background:var(--green-500); }
+  .tree-dot.warn { background:#f59e0b; }
+  .tree-dot.block { background:#ef4444; }
+  .tree-id { flex:none; font-family:var(--font-mono); font-size:10px; color:var(--gray-400); }
+  .tree-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gray-700); }
+  .tree-leaf.blocked .tree-text { color:#b91c1c; font-weight:600; }
+  .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); }
   .flow-legend { display:flex; gap:12px; font-size:10px; color:var(--gray-500); }
   .flow-legend span { display:inline-flex; align-items:center; gap:4px; }
   .flow-legend i { width:9px; height:9px; border-radius:3px; display:inline-block; }
@@ -2116,7 +2154,11 @@
     <div>
       <div class="flow-card">
         <div class="flow-head">
-          <span class="flow-head-title">Session flow — click any node for details</span>
+          <span class="flow-head-title">Session — click any row for details</span>
+          <div class="tree-toolbar">
+            <button class="tree-btn" onclick="treeToggleAll(false)">Expand all</button>
+            <button class="tree-btn" onclick="treeToggleAll(true)">Collapse all</button>
+          </div>
           <div class="flow-legend">
             <span><i class="allow"></i>allowed</span>
             <span><i class="warn"></i>warn</span>
@@ -3458,10 +3500,8 @@ function buildPager(containerId, state, loadFn) {
 let _allSessionsCache = [];
 let _sessionViewState = null;
 let _flowSelected = null;
-let _flowResizeObs = null;
 let _flowTrail = [];
 let _flowSelEvent = null;
-const SVGNS = 'http://www.w3.org/2000/svg';
 
 let _agentViewName = null;
 let _backStack = [];
@@ -3717,67 +3757,98 @@ async function sessViewAction(action){
     openSessionView(sid, ws);
   } catch(e){ toast('✗ '+e.message, true); }
 }
+// A session is a tree, not a list. Grouping is turn -> lane -> event: a turn
+// begins at each model request, and lanes keep a hundred shell calls from
+// burying the one file that was written. Every row carries the event's own
+// index, so clicking one still selects it in the detail panel.
+const LANE_LABEL = {
+  prompt:'Prompts', tools:'Tool calls', files:'Files', shell:'Shell',
+  network:'Network', context:'Context', mcp:'MCP', other:'Other',
+};
+const LANE_ORDER = ['prompt','context','tools','shell','files','network','mcp','other'];
+
+function eventLane(ev){
+  const lane = ev.lane || 'other';
+  return LANE_LABEL[lane] ? lane : 'other';
+}
+function eventSummary(ev){
+  const a = ev.artifacts || {};
+  const raw = a.command || a.path || a.url || a.prompt || a.response || a.content
+    || (ev.action||'').replace(/^[a-z_]+:\s*/i,'') || ev.type || 'event';
+  return String(raw).replace(/\s+/g,' ').trim().slice(0,300);
+}
+function groupTrail(trail){
+  const turns = [];
+  let cur = null;
+  trail.forEach((ev,i)=>{
+    if (!cur || ev.type === 'prompt'){
+      cur = { label:'Turn '+(turns.length+1), sub:'', lanes:new Map(), count:0 };
+      turns.push(cur);
+    }
+    if (ev.type === 'prompt' && !cur.sub) cur.sub = eventSummary(ev).slice(0,90);
+    const lane = eventLane(ev);
+    if (!cur.lanes.has(lane)) cur.lanes.set(lane, []);
+    cur.lanes.get(lane).push({ev, i});
+    cur.count++;
+  });
+  turns.forEach(t=>{ if(!t.sub && t.lanes.size) t.sub = eventSummary([...t.lanes.values()][0][0].ev).slice(0,90); });
+  return turns;
+}
+function treeRowEl({cls, caret, label, sub, count, onToggle}){
+  const btn = document.createElement('button');
+  btn.className = 'tree-row '+cls;
+  btn.innerHTML =
+    (caret ? '<svg class="tree-caret" viewBox="0 0 12 12"><path d="M3 4.5 L6 8 L9 4.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>' : '<span class="tree-caret"></span>')+
+    '<span class="'+(cls==='turn'?'tree-turn-label':'tree-lane-label')+'">'+safe(label)+'</span>'+
+    (sub ? '<span class="tree-turn-sub">'+safe(sub)+'</span>' : '')+
+    '<span class="tree-count">'+count+'</span>';
+  btn.onclick = onToggle;
+  return btn;
+}
+function treeLeafEl(ev, idx){
+  const v = flowVerdict(ev);
+  const btn = document.createElement('button');
+  btn.className = 'tree-leaf '+(v==='block'?'blocked':'')+'';
+  btn.dataset.idx = idx;
+  btn.onclick = ()=>selectFlowNode(idx);
+  const text = eventSummary(ev);
+  btn.innerHTML =
+    '<span class="tree-dot '+(v==='block'?'block':(v==='warn'?'warn':''))+'"></span>'+
+    '<span class="tree-id">'+safe((ev.toolTag||ev.type||'ev').toString().slice(0,14))+'</span>'+
+    '<span class="tree-text" title="'+safeAttr(text)+'">'+safe(text)+'</span>'+
+    '<span class="tree-ts">'+safe(ev.ts||'')+'</span>';
+  return btn;
+}
 function renderSessionFlow(trail){
   const canvas = document.getElementById('sessFlowCanvas');
   _flowTrail = trail;
-  if (!trail.length){ canvas.innerHTML = '<div class="flow-empty">No tool calls recorded for this session yet.</div>'; return; }
-  const wrap = document.createElement('div'); wrap.className='flow-wrap';
-  const svg = document.createElementNS(SVGNS,'svg'); svg.setAttribute('class','flow-edges');
-  const nodes = document.createElement('div'); nodes.className='flow-nodes';
-  wrap.appendChild(svg); wrap.appendChild(nodes);
-  canvas.innerHTML=''; canvas.appendChild(wrap);
-  nodes.appendChild(endpointEl('start','Start'));
-  trail.forEach((ev,i)=>{ nodes.appendChild(flowNodeEl(ev,i)); });
-  nodes.appendChild(endpointEl('end','Now'));
-  const draw = ()=>drawFlowEdges(svg, nodes, trail);
-  requestAnimationFrame(draw);
-  if (_flowResizeObs) _flowResizeObs.disconnect();
-  _flowResizeObs = new ResizeObserver(()=>requestAnimationFrame(draw));
-  _flowResizeObs.observe(wrap);
+  if (!trail.length){ canvas.innerHTML = '<div class="flow-empty">Nothing recorded for this session yet.</div>'; return; }
+  const tree = document.createElement('div'); tree.className='sess-tree';
+  groupTrail(trail).forEach(turn=>{
+    const box = document.createElement('div'); box.className='tree-turn';
+    const kids = document.createElement('div'); kids.className='tree-children';
+    const head = treeRowEl({cls:'turn', caret:true, label:turn.label, sub:turn.sub, count:turn.count,
+      onToggle:(e)=>{ kids.classList.toggle('hidden'); e.currentTarget.classList.toggle('collapsed'); }});
+    box.appendChild(head); box.appendChild(kids);
+    LANE_ORDER.filter(l=>turn.lanes.has(l)).forEach(lane=>{
+      const items = turn.lanes.get(lane);
+      const laneKids = document.createElement('div'); laneKids.className='tree-children';
+      const laneHead = treeRowEl({cls:'lane', caret:true, label:LANE_LABEL[lane], sub:'', count:items.length,
+        onToggle:(e)=>{ laneKids.classList.toggle('hidden'); e.currentTarget.classList.toggle('collapsed'); }});
+      items.forEach(({ev,i})=>laneKids.appendChild(treeLeafEl(ev,i)));
+      kids.appendChild(laneHead); kids.appendChild(laneKids);
+    });
+    tree.appendChild(box);
+  });
+  canvas.innerHTML=''; canvas.appendChild(tree);
 }
-function endpointEl(kind,label){
-  const el=document.createElement('div'); el.className='flow-endpoint '+kind;
-  const icon = kind==='start' ? 'i-play' : 'i-radio';
-  el.innerHTML='<div class="dot"><svg class="icon"><use href="#'+icon+'"/></svg></div><div class="lbl">'+safe(label)+'</div>';
-  return el;
-}
-function flowNodeEl(ev,i){
-  const v = flowVerdict(ev);
-  const el=document.createElement('div');
-  el.className='flow-node '+v+((v==='block'||v==='warn')?' branch':'');
-  el.dataset.idx=i;
-  el.onclick=()=>selectFlowNode(i);
-  const chip = ev.toolTag || ev.type || 'tool';
-  const action = (ev.action||'event').replace(/^[a-z_]+:\s*/i,'');
-  el.innerHTML =
-    '<div class="flow-node-top"><span class="flow-node-chip" title="'+safeAttr(chip)+'">'+safe(chip)+'</span></div>'+
-    '<div class="flow-node-action" title="'+safeAttr(ev.action||'')+'">'+safe(action||'event')+'</div>'+
-    '<div class="flow-node-foot"><span class="flow-node-verdict '+v+'">'+({allow:'allowed',warn:'warn',block:'blocked'})[v]+'</span>'+
-      '<span class="flow-node-ts">'+safe(ev.ts||'')+'</span></div>';
-  return el;
-}
-function drawFlowEdges(svg, nodesEl, trail){
-  const host = svg.parentElement;
-  while(svg.firstChild) svg.removeChild(svg.firstChild);
-  svg.setAttribute('width', host.clientWidth);
-  svg.setAttribute('height', host.scrollHeight);
-  const kids=[...nodesEl.children];
-  const hostRect = host.getBoundingClientRect();
-  const scrollY = host.scrollTop;
-  const anchor=(el)=>{ const r=el.getBoundingClientRect(); return {
-    cx: r.left-hostRect.left + r.width/2, t: r.top-hostRect.top+scrollY, b: r.bottom-hostRect.top+scrollY }; };
-  for(let i=0;i<kids.length-1;i++){
-    const a=anchor(kids[i]), b=anchor(kids[i+1]);
-    const x1=a.cx, y1=a.b, x2=b.cx, y2=b.t, my=(y1+y2)/2;
-    let cls=''; const ev = trail[i];
-    if (ev){ const v=flowVerdict(ev); if(v!=='allow') cls=v; }
-    svg.insertAdjacentHTML('beforeend',
-      '<path class="flow-edge '+cls+'" d="M '+x1+' '+y1+' C '+x1+' '+my+', '+x2+' '+my+', '+x2+' '+y2+'"/>');
-  }
+function treeToggleAll(collapse){
+  document.querySelectorAll('#sessFlowCanvas .tree-children').forEach(el=>el.classList.toggle('hidden', collapse));
+  document.querySelectorAll('#sessFlowCanvas .tree-row').forEach(el=>el.classList.toggle('collapsed', collapse));
 }
 function selectFlowNode(idx){
   _flowSelected = idx;
-  document.querySelectorAll('#sessFlowCanvas .flow-node').forEach(n=>{
+  document.querySelectorAll('#sessFlowCanvas .tree-leaf').forEach(n=>{
     n.classList.toggle('sel', parseInt(n.dataset.idx,10)===idx);
   });
   const ev = (_flowTrail||[])[idx];
@@ -3833,7 +3904,44 @@ function renderNodePanel(ev){
           '</div>'+
         '</div>':'')+
     '</div>';
+  panel.insertAdjacentHTML('beforeend', artifactsHtml(ev));
   panel.insertAdjacentHTML('beforeend', nodeActionsHtml(ev));
+}
+
+// What the event actually carried. The log has held this all along -- the
+// prompt text, what a tool returned, the file touched, the instruction files
+// already in context at session start -- and the panel described events
+// without ever showing them.
+const ARTIFACT_FIELDS = [
+  ['prompt','Prompt'], ['command','Command'], ['path','Path'], ['url','URL'],
+  ['response','Tool output'], ['stdout','stdout'], ['stderr','stderr'],
+  ['content','Content'], ['mcp_server','MCP server'], ['mcp_tool','MCP tool'],
+  ['model','Model'], ['provider','Provider'], ['surface','Surface'],
+  ['subagent_type','Subagent'], ['cwd','Working dir'],
+];
+function artifactsHtml(ev){
+  const a = ev.artifacts || {};
+  const rows = ARTIFACT_FIELDS.filter(([k])=>a[k]).map(([k,label])=>{
+    const long = String(a[k]).length > 90 || /\n/.test(String(a[k]));
+    return '<div class="art-row"><div class="art-label">'+safe(label)+'</div>'+
+      (long ? '<pre class="art-pre">'+safe(a[k])+'</pre>'
+            : '<div class="art-val">'+safe(a[k])+'</div>')+'</div>';
+  });
+  if (Array.isArray(a.memory_files) && a.memory_files.length){
+    rows.push('<div class="art-row"><div class="art-label">Instruction files in context</div>'+
+      '<pre class="art-pre">'+safe(a.memory_files.join('\n'))+'</pre></div>');
+  }
+  if (Array.isArray(a.integrity_findings) && a.integrity_findings.length){
+    rows.push('<div class="art-row"><div class="art-label">Integrity</div><pre class="art-pre">'+
+      safe(a.integrity_findings.map(f=>(f.severity||'')+' '+(f.title||'')).join('\n'))+'</pre></div>');
+  }
+  if (a.has_invisible_controls){
+    rows.push('<div class="art-row"><div class="art-label">Warning</div>'+
+      '<div class="art-val" style="color:#b91c1c">Invisible control characters present</div></div>');
+  }
+  if (!rows.length) return '';
+  const phases = (ev.phases||[]).length>1 ? ' <span class="art-phase">pre + post</span>' : '';
+  return '<div class="artifacts"><h4>Artefacts'+phases+'</h4>'+rows.join('')+'</div>';
 }
 
 function nodeActionsHtml(ev){

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -1131,6 +1131,91 @@ _TYPE_LABEL: Dict[str, str] = {
 }
 
 
+# ── Session trail artefacts ──────────────────────────────────────────────────
+#: How much of any one captured string the trail carries. The session view is a
+#: reading surface, not the audit trail -- the full record is the event log, and
+#: shipping an unbounded stdout to the browser makes the page the slow part.
+_ARTIFACT_CHARS = 4000
+_ARTIFACT_LIST = 40
+
+#: Event type -> the lane it belongs to in the session tree. Anything unmapped
+#: lands in "other" rather than being dropped, so a new event type shows up in
+#: the UI the day it is emitted instead of the day someone updates this table.
+_EVENT_LANES = {
+    "prompt": "prompt",
+    "memory": "context",
+    "shell": "shell",
+    "file_read": "files",
+    "file_write": "files",
+    "network": "network",
+    "tool_result": "tools",
+    "mcp_call": "mcp",
+}
+
+
+def _clip(value: Any, limit: int = _ARTIFACT_CHARS) -> str:
+    """One captured string, bounded, with the truncation made visible."""
+    text = value if isinstance(value, str) else ("" if value is None else str(value))
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n… [{len(text) - limit} more characters]"
+
+
+def event_lane(event_type: str, meta: Optional[Dict[str, Any]] = None) -> str:
+    """Which lane of the session tree an event belongs to."""
+    if (meta or {}).get("subagent_id"):
+        # A subagent's work is still shown in its own lane's tree; the caller
+        # groups by subagent first, so this only decides the inner lane.
+        pass
+    return _EVENT_LANES.get(str(event_type or ""), "other")
+
+
+def event_artifacts(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Everything a session view can show about one event.
+
+    The event log has always held far more than the trail exposed -- the prompt
+    text, a command's stdout and stderr, the path written, the instruction
+    files read at session start -- and the session view rendered a type name
+    and nothing else, so "what did this agent actually do" could only be
+    answered by reading JSONL by hand.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    meta = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+    out: Dict[str, Any] = {}
+
+    for key in ("prompt", "command", "stdout", "stderr", "response", "content", "path", "url"):
+        value = raw.get(key)
+        if value not in (None, "", [], {}):
+            out[key] = _clip(value)
+
+    for key in ("mcp_server", "mcp_tool"):
+        if raw.get(key):
+            out[key] = str(raw[key])[:200]
+
+    for key in ("model", "provider", "surface", "cwd", "subagent_id", "subagent_type",
+                "agent_name", "tool_name"):
+        if meta.get(key):
+            out[key] = str(meta[key])[:200]
+
+    # SessionStart carries the instruction files that were already in context
+    # before the agent did anything -- the "what was here already" half.
+    files = meta.get("memory_files")
+    if isinstance(files, list) and files:
+        out["memory_files"] = [str(f)[:300] for f in files[:_ARTIFACT_LIST]]
+    findings = raw.get("integrity_findings")
+    if isinstance(findings, list) and findings:
+        out["integrity_findings"] = [
+            {"title": str(f.get("title") or "")[:200], "severity": str(f.get("severity") or "")}
+            for f in findings[:_ARTIFACT_LIST] if isinstance(f, dict)
+        ]
+    if meta.get("has_invisible_controls"):
+        out["has_invisible_controls"] = True
+    if meta.get("truncated"):
+        out["truncated"] = True
+    return out
+
+
 def _relative_time_store(ts: str) -> str:
     """Return a human-readable relative time string from an ISO timestamp."""
     try:
@@ -3289,6 +3374,44 @@ def set_project_rule_states(workspace: Path, disabled_ids: List[str]) -> Dict[st
     return result
 
 
+#: How many trail rows a session view ships after the Pre/Post merge below.
+_TRAIL_ROWS = 250
+
+
+def _merge_tool_phases(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Fold a tool call's PreToolUse and PostToolUse rows into one.
+
+    A hooked agent logs both phases of every call, so a session view listing
+    raw events showed each command twice -- an unbroken column of pairs that
+    reads as a rendering bug and buries anything else. One call is one row:
+    the pre-call row carries the verdict (the point of a pre-call check), and
+    the post-call row contributes what came back.
+
+    Events arrive newest-first, so the Post phase is seen before its Pre.
+    """
+    merged: List[Dict[str, Any]] = []
+    pending: Dict[Any, Dict[str, Any]] = {}
+    for ev in events:
+        phase = ev.get("agentEvent") or ""
+        key = (ev.get("type"), ev.get("toolTag"), (ev.get("action") or "")[:200])
+        if phase == "PostToolUse":
+            pending[key] = ev
+            continue
+        if phase == "PreToolUse" and key in pending:
+            post = pending.pop(key)
+            for field in ("stdout", "stderr", "response", "content"):
+                value = (post.get("artifacts") or {}).get(field)
+                if value and field not in (ev.get("artifacts") or {}):
+                    ev.setdefault("artifacts", {})[field] = value
+            ev["phases"] = ["PreToolUse", "PostToolUse"]
+        merged.append(ev)
+    # A Post with no Pre in this window is still something that happened.
+    for leftover in pending.values():
+        merged.append(leftover)
+    merged.sort(key=lambda e: e.get("tsAbs") or "", reverse=True)
+    return merged[:_TRAIL_ROWS]
+
+
 def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any]:
     """Return scoped rules + recent blocked findings for a session."""
     from prismor.runtime.scoped_agent import load_scoped_rules, check_scoped_rules
@@ -3338,7 +3461,7 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                 FROM numbered_events e
                 LEFT JOIN findings f ON f.session_id = e.session_id AND f.event_index = e.rn
                 ORDER BY e.ts DESC
-                LIMIT 60
+                LIMIT 600
                 """,
                 (session_id,),
             ):
@@ -3376,14 +3499,22 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                             "source": "inferred-scoped",
                         }
                         verdict = "blocked"
-                detail = row["command_text"] or row["path_text"] or row["url_text"] or ""
+                artifacts = event_artifacts(raw)
+                # A prompt has no command, path or url, so the trail used to
+                # describe the most informative event in a session as the bare
+                # word "prompt".
+                detail = (row["command_text"] or row["path_text"] or row["url_text"]
+                          or artifacts.get("prompt") or artifacts.get("response") or "")
                 recent_events.append({
                     "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
                     "tsAbs": _absolute_time_store(row["ts"]),
                     "type": row["type"] or "",
                     "agentEvent": row["agent_event"] or "",
+                    "lane": event_lane(row["type"] or "", meta if isinstance(meta, dict) else {}),
+                    "artifacts": artifacts,
                     "toolTag": tool_tag or "",
-                    "action": (f"{row['type']}: {detail}" if detail else (row["type"] or "event")),
+                    "action": (f"{row['type']}: {' '.join(str(detail).split())[:300]}"
+                               if detail else (row["type"] or "event")),
                     "verdict": verdict,
                     "severity": (severity or "low").lower(),
                     "policy": {
@@ -3397,6 +3528,7 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                         "source": enrichment.get("source") or ("finding" if finding_id else ""),
                     },
                 })
+            recent_events = _merge_tool_phases(recent_events)
             block_keys = {
                 (item.get("title") or "", item.get("evidence") or "", item.get("ts") or "")
                 for item in recent_blocked

--- a/tests/test_session_artifacts.py
+++ b/tests/test_session_artifacts.py
@@ -1,0 +1,101 @@
+"""The session view's payload: artefacts, lanes, and one row per tool call.
+
+The event log has always held far more than the session view showed -- the
+prompt text, what a tool returned, the instruction files already in context --
+so a session rendered as a column of type names and the question "what did this
+agent actually do" could only be answered by reading JSONL by hand.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime.store import (  # noqa: E402
+    _ARTIFACT_CHARS,
+    _merge_tool_phases,
+    event_artifacts,
+    event_lane,
+)
+
+
+class TestEventArtifacts(unittest.TestCase):
+    def test_prompt_text_is_carried(self):
+        art = event_artifacts({
+            "type": "prompt",
+            "prompt": "You are an HR assistant. What is the leave policy?",
+            "metadata": {"model": "gpt-4o-mini", "provider": "openai", "surface": "llm-proxy"},
+        })
+        self.assertIn("HR assistant", art["prompt"])
+        self.assertEqual(art["model"], "gpt-4o-mini")
+        self.assertEqual(art["surface"], "llm-proxy")
+
+    def test_instruction_files_in_context_are_carried(self):
+        """The 'what was here already' half: SessionStart's memory scan."""
+        art = event_artifacts({
+            "type": "memory",
+            "content": "# CLAUDE.md",
+            "integrity_findings": [{"title": "Instruction file changed", "severity": "HIGH"}],
+            "metadata": {"memory_files": ["/repo/CLAUDE.md", "/repo/AGENTS.md"],
+                         "has_invisible_controls": True},
+        })
+        self.assertEqual(art["memory_files"], ["/repo/CLAUDE.md", "/repo/AGENTS.md"])
+        self.assertEqual(art["integrity_findings"][0]["severity"], "HIGH")
+        self.assertTrue(art["has_invisible_controls"])
+
+    def test_long_capture_is_bounded_and_says_so(self):
+        art = event_artifacts({"type": "shell", "command": "x", "stdout": "y" * (_ARTIFACT_CHARS + 500)})
+        self.assertLess(len(art["stdout"]), _ARTIFACT_CHARS + 200)
+        self.assertIn("more characters", art["stdout"])
+
+    def test_empty_values_are_omitted_not_shown_blank(self):
+        art = event_artifacts({"type": "shell", "command": "ls", "stdout": "", "stderr": None})
+        self.assertEqual(art["command"], "ls")
+        self.assertNotIn("stdout", art)
+        self.assertNotIn("stderr", art)
+
+    def test_unknown_event_type_gets_a_lane_rather_than_vanishing(self):
+        self.assertEqual(event_lane("shell"), "shell")
+        self.assertEqual(event_lane("file_write"), "files")
+        self.assertEqual(event_lane("something_new_next_release"), "other")
+
+
+class TestMergeToolPhases(unittest.TestCase):
+    """One tool call is one row, whichever phases the agent logged."""
+
+    def _ev(self, phase, action, ts, **art):
+        return {"agentEvent": phase, "type": "shell", "toolTag": "Bash",
+                "action": action, "tsAbs": ts, "artifacts": dict(art)}
+
+    def test_pre_and_post_of_one_call_become_one_row(self):
+        # Newest first, the order the query returns.
+        events = [
+            self._ev("PostToolUse", "shell: ls", "2026-01-01T00:00:02", response="a.txt"),
+            self._ev("PreToolUse", "shell: ls", "2026-01-01T00:00:01"),
+        ]
+        merged = _merge_tool_phases(events)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["phases"], ["PreToolUse", "PostToolUse"])
+        # The verdict comes from the pre-call check; the output from the post.
+        self.assertEqual(merged[0]["artifacts"]["response"], "a.txt")
+
+    def test_distinct_calls_are_not_folded_together(self):
+        events = [
+            self._ev("PostToolUse", "shell: b", "2026-01-01T00:00:04"),
+            self._ev("PreToolUse", "shell: b", "2026-01-01T00:00:03"),
+            self._ev("PostToolUse", "shell: a", "2026-01-01T00:00:02"),
+            self._ev("PreToolUse", "shell: a", "2026-01-01T00:00:01"),
+        ]
+        self.assertEqual(len(_merge_tool_phases(events)), 2)
+
+    def test_a_post_with_no_pre_in_the_window_still_appears(self):
+        """The window can cut a pair in half; the call still happened."""
+        events = [self._ev("PostToolUse", "shell: ls", "2026-01-01T00:00:02", response="a.txt")]
+        merged = _merge_tool_phases(events)
+        self.assertEqual(len(merged), 1)
+        self.assertNotIn("phases", merged[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The session view listed events as a chain of nodes labelled by type, so the most informative thing in a session — the prompt — rendered as the word `prompt`. Everything shown here was already in the event log; none of it reached the browser.

**Tree, not a chain.** turn → lane → event. A turn begins at each model request; lanes (Prompts, Tool calls, Shell, Files, Network, Context, MCP) keep two hundred shell calls from burying the one file that was written. Expand all / Collapse all; every row still opens the same policy panel.

**Artefacts per row.** The full prompt text, what the tool returned, the path, the command, model and provider, and for a session-start event the instruction files already in context plus any integrity finding against them. Bounded per field with the truncation visible — this is a reading surface, the log stays the record.

**Two bugs the tree made obvious:**
- every tool call was listed twice (a hooked agent logs Pre and Post for one call) — one call is one row now, pre carrying the verdict, post contributing the output
- the window was the last 60 events of a session that can hold 1458 — and with calls double-counted, really the last 30 calls. Now 600 fetched, 250 rendered

Verified against a real governed n8n session and a 1458-event Claude session: 116 pairs merged, 119 rows carrying tool output, no console errors.