### PR TITLE
Release 1.49.0 — a session per conversation, and a prompt you can read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.49.0] — 2026-09-08
+
+### Added
+- **One proxy session per conversation.** The session id was the proxy's own —
+  process start plus pid — so every conversation the surface ever handled piled
+  into a single session, which is a log file rather than a session. A chat UI
+  sends its whole history every turn, so the opening exchange is the one thing
+  constant within a conversation and different between them: hashing it threads
+  a chatbot's turns together and keeps two chats apart. A caller that knows its
+  own id can send `X-Prismor-Session` (sanitized, not trusted verbatim); a
+  request with no conversation falls back to the process session. Snapshots are
+  now per session, and every session the process touched is flushed on
+  shutdown.
+- **The prompt is stored in its parts, not only as a blob.** Policy still reads
+  the flattened system-plus-messages text, because the rules that matter are
+  category rules over combined text — but that blob is the wrong thing to
+  *show*, and the session view was showing it: the message a person typed
+  arrived welded to the workflow's system prompt, with no way to tell which was
+  which. The event now also carries `user_message` and `system`, and the
+  session view leads with what the person actually said.
+
+
 ## [1.48.0] — 2026-09-08
 
 ### Added

--- a/docs/llm-proxy.md
+++ b/docs/llm-proxy.md
@@ -44,6 +44,25 @@ Denied calls are replaced, not deleted: the turn keeps a text block explaining
 the refusal. An agent handed a silent no-op simply tries again; one told why
 stops.
 
+## One session per conversation
+
+A chat UI sends its whole history every turn, so the opening exchange is the
+one thing constant across a conversation and different between conversations.
+The proxy hashes it and threads a chatbot's turns into one session — without
+that, every conversation the process ever proxied lands in a single session
+keyed on the proxy's pid, which is a log file rather than a session.
+
+A caller that knows its own conversation id can say so with an
+`X-Prismor-Session` header; it is sanitized, not trusted verbatim, and appended
+to the surface's own id. A request with no conversation at all (a bare
+completion, a health probe) falls back to the process session.
+
+The prompt is stored both ways. Policy reads the flattened blob, because the
+rules that matter are category rules over combined text; the session view shows
+the parts — the message the person typed, and the system prompt the workflow
+wrapped around it — because a reader wants the sentence they wrote, not their
+sentence welded to a workflow's instructions.
+
 ## Streaming
 
 Refusing after the client has already read the bytes is not enforcement. Text

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.48.0"
+__version__ = "1.49.0"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -3913,9 +3913,12 @@ function renderNodePanel(ev){
 // already in context at session start -- and the panel described events
 // without ever showing them.
 const ARTIFACT_FIELDS = [
-  ['prompt','Prompt'], ['command','Command'], ['path','Path'], ['url','URL'],
+  // What the person said comes first; the system prompt the workflow wraps
+  // around it, and the flattened blob policy actually read, come after.
+  ['user_message','User message'], ['command','Command'], ['path','Path'], ['url','URL'],
   ['response','Tool output'], ['stdout','stdout'], ['stderr','stderr'],
   ['content','Content'], ['mcp_server','MCP server'], ['mcp_tool','MCP tool'],
+  ['system','System prompt'], ['prompt','Full prompt evaluated'],
   ['model','Model'], ['provider','Provider'], ['surface','Surface'],
   ['subagent_type','Subagent'], ['cwd','Working dir'],
 ];

--- a/prismor/runtime/proxy.py
+++ b/prismor/runtime/proxy.py
@@ -53,9 +53,11 @@ the agent it is supposed to be governing.
 """
 from __future__ import annotations
 
+import hashlib
 import hmac
 import json
 import os
+import re
 import signal
 import ssl
 import sys
@@ -223,6 +225,59 @@ def extract_prompt(body: Dict[str, Any]) -> str:
     return "\n".join(p for p in parts if p)
 
 
+def prompt_parts(body: Dict[str, Any]) -> Dict[str, str]:
+    """The prompt broken back into the pieces a person recognises.
+
+    ``extract_prompt`` flattens system and messages into one blob because the
+    rules are category rules over combined text. That blob is the right thing
+    to evaluate and the wrong thing to *show*: a reader looking at a session
+    wants the sentence they typed, not their sentence welded to the workflow's
+    system prompt.
+    """
+    system = body.get("system") or body.get("instructions")
+    out: Dict[str, str] = {}
+    if system:
+        out["system"] = _text_of(system)
+    last_user = ""
+    for msg in body.get("messages") or []:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        if role == "system" and "system" not in out:
+            out["system"] = _text_of(msg.get("content"))
+        elif role == "user":
+            last_user = _text_of(msg.get("content"))
+    if not last_user and isinstance(body.get("input"), (str, list)):
+        last_user = _text_of(body["input"])
+    if last_user:
+        out["user_message"] = last_user
+    return out
+
+
+def conversation_key(body: Dict[str, Any]) -> str:
+    """A stable id for the conversation this request belongs to.
+
+    A chat UI sends its whole history every turn, so the opening exchange is
+    the one thing that stays constant across a conversation and differs
+    between conversations. Hashing it threads a chatbot's turns into one
+    session instead of dumping every conversation the process ever proxied
+    into a single one keyed on the proxy's pid.
+    """
+    system = ""
+    first_user = ""
+    raw_system = body.get("system") or body.get("instructions")
+    if raw_system:
+        system = _text_of(raw_system)
+    for msg in body.get("messages") or []:
+        if isinstance(msg, dict) and str(msg.get("role") or "") == "user":
+            first_user = _text_of(msg.get("content"))
+            break
+    if not (system or first_user):
+        return ""
+    seed = (system[:2000] + "\x00" + first_user[:2000]).encode("utf-8", "replace")
+    return hashlib.sha256(seed).hexdigest()[:12]
+
+
 def response_tool_calls(provider: str, body: Dict[str, Any]) -> List[Tuple[str, Any]]:
     """``(tool_name, arguments)`` for every tool call in a completed response."""
     calls: List[Tuple[str, Any]] = []
@@ -268,8 +323,11 @@ class Screen:
         self.mode = mode
         self.session_id = session_id
         self.agent_name = agent_name
-        self._events = 0
-        self._unsnapshotted = 0
+        # session id -> [events, unsnapshotted]. A proxy outlives any one
+        # conversation, so counting per process would snapshot on a boundary
+        # that means nothing.
+        self._counts: Dict[str, List[int]] = {}
+        self._conversations: Dict[str, str] = {}
         # Serialized for the same reason the MCP gateway serializes: the
         # trifecta TagLedger is order-dependent, and concurrent evaluations
         # could let the completing half of a forbidden tag pair through.
@@ -277,10 +335,32 @@ class Screen:
 
     # -- events ----------------------------------------------------------
 
-    def _base(self, agent_event: str, subject: Optional[str]) -> Dict[str, Any]:
+    def session_for(self, body: Dict[str, Any], explicit: str = "") -> str:
+        """The session this request belongs to.
+
+        An explicit ``X-Prismor-Session`` header wins -- a caller that knows
+        its own conversation id should say so. Otherwise the conversation is
+        recognised from its opening exchange, so a chatbot's turns land in one
+        session and two chats do not merge into the proxy's lifetime.
+        """
+        if explicit:
+            token = re.sub(r"[^A-Za-z0-9_.:-]", "-", explicit)[:64]
+            return f"{self.session_id}-{token}"
+        key = conversation_key(body)
+        if not key:
+            return self.session_id
+        with self._lock:
+            sid = self._conversations.get(key)
+            if not sid:
+                sid = f"{self.session_id}-{key}"
+                self._conversations[key] = sid
+        return sid
+
+    def _base(self, agent_event: str, subject: Optional[str],
+              session_id: str = "") -> Dict[str, Any]:
         return {
             "ts": datetime.now(timezone.utc).isoformat(),
-            "session_id": self.session_id,
+            "session_id": session_id or self.session_id,
             "agent": PROXY_AGENT,
             "agent_event": agent_event,
             "metadata": {
@@ -291,15 +371,22 @@ class Screen:
         }
 
     def prompt_event(self, provider: str, model: str, prompt: str,
-                     subject: Optional[str]) -> Dict[str, Any]:
-        event = self._base("prompt", subject)
+                     subject: Optional[str], session_id: str = "",
+                     parts: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        event = self._base("prompt", subject, session_id)
         event["metadata"].update({"provider": provider, "model": model,
                                   "tool_name": "llm_request"})
+        # The flattened blob is what policy reads; the parts are what a person
+        # reads in the session view.
+        for key, value in (parts or {}).items():
+            if value:
+                event["metadata"][key] = value
         event.update({"type": "prompt", "prompt": prompt})
         return event
 
     def tool_event(self, tool_name: str, arguments: Any, provider: str,
-                   model: str, subject: Optional[str]) -> Dict[str, Any]:
+                   model: str, subject: Optional[str],
+                   session_id: str = "") -> Dict[str, Any]:
         """Shape a model-proposed tool call as the event a hook would produce.
 
         This is the whole reason the surface earns its place. ``shape_call_event``
@@ -309,7 +396,7 @@ class Screen:
         of still lands on the generic payload path rather than being waved
         through.
         """
-        event = self._base("PreToolUse", subject)
+        event = self._base("PreToolUse", subject, session_id)
         event["metadata"].update({"provider": provider, "model": model,
                                   "tool_name": tool_name, "proposed": True})
         try:
@@ -358,7 +445,7 @@ class Screen:
                     workspace=self.workspace,
                     agent=PROXY_AGENT,
                     mode=self.mode,
-                    session_id=self.session_id,
+                    session_id=str(event.get("session_id") or self.session_id),
                     agent_name=self.agent_name,
                     subject=resolve_subject(subject),
                     persist=False,
@@ -370,38 +457,46 @@ class Screen:
             return None
 
     def _persist(self, event: Dict[str, Any]) -> None:
-        """Append the event; rebuild the session snapshot every N events."""
+        """Append the event; rebuild that session's snapshot every N events."""
+        sid = str(event.get("session_id") or self.session_id)
         try:
             from prismor.runtime.store import append_session_event
-            append_session_event(self.workspace, self.session_id, event)
+            append_session_event(self.workspace, sid, event)
         except Exception as exc:
             sys.stderr.write(f"[prismor-proxy] session log error: {exc}\n")
             return
-        self._events += 1
-        self._unsnapshotted += 1
-        if self._events % SNAPSHOT_EVERY:
+        counts = self._counts.setdefault(sid, [0, 0])
+        counts[0] += 1
+        counts[1] += 1
+        if counts[0] % SNAPSHOT_EVERY:
             return
-        self.snapshot()
+        self.snapshot(sid)
 
-    def snapshot(self) -> None:
+    def snapshot(self, session_id: str = "") -> None:
         """Rebuild the session snapshot the console and `prismor sessions` read.
 
-        Called every SNAPSHOT_EVERY events and again when the surface stops. A
-        proxy session is often one chat turn -- the n8n agent that produced a
-        blocked install command logged five events -- so a purely periodic
-        rebuild left short sessions with a session log on disk and no session
-        anywhere an operator looks.
+        Called every SNAPSHOT_EVERY events for one session, and for every
+        session the process touched when the surface stops. A conversation is
+        often a handful of events -- the n8n agent that produced a blocked
+        install command logged five -- so a purely periodic rebuild left short
+        sessions with a log on disk and no session anywhere an operator looks.
         """
-        if not self._unsnapshotted:
-            return
-        self._unsnapshotted = 0
+        targets = [session_id] if session_id else list(self._counts)
+        for sid in targets:
+            counts = self._counts.get(sid)
+            if not counts or not counts[1]:
+                continue
+            counts[1] = 0
+            self._snapshot_one(sid)
+
+    def _snapshot_one(self, sid: str) -> None:
         try:
             from prismor.runtime.cli import analyze_events
             from prismor.runtime.store import read_session_events, save_session_snapshot
-            events = read_session_events(self.workspace, self.session_id)
+            events = read_session_events(self.workspace, sid)
             save_session_snapshot(
                 workspace=self.workspace,
-                session_id=self.session_id,
+                session_id=sid,
                 agent=PROXY_AGENT,
                 agent_name=self.agent_name or PROXY_AGENT,
                 source="proxy",
@@ -409,7 +504,7 @@ class Screen:
                 events=events,
                 analysis=analyze_events(events, repo_root=self.workspace,
                                         workspace=self.workspace,
-                                        session_id=self.session_id),
+                                        session_id=sid),
             )
         except Exception as exc:  # best-effort, exactly as the runtime path is
             sys.stderr.write(f"[prismor-proxy] snapshot error: {exc}\n")
@@ -497,11 +592,14 @@ class StreamScreen:
     """
 
     def __init__(self, screen: Screen, provider: str, model: str,
-                 subject: Optional[str]) -> None:
+                 subject: Optional[str], session_id: str = "") -> None:
         self.screen = screen
         self.provider = provider
         self.model = model
         self.subject = subject
+        # The request's conversation, so a streamed tool call lands in the
+        # same session as the prompt that produced it.
+        self.session_id = session_id or screen.session_id
         self.blocked: List[str] = []
         self._pending: List[bytes] = []      # raw SSE lines held back
         self._tool_name: str = ""
@@ -594,7 +692,8 @@ class StreamScreen:
         """Evaluate the completed tool call; release it or replace it."""
         arguments = _loads("".join(self._tool_json) or "{}")
         event = self.screen.tool_event(self._tool_name, arguments,
-                                       self.provider, self.model, self.subject)
+                                       self.provider, self.model, self.subject,
+                                       session_id=self.session_id)
         try:
             decision = self.screen.evaluate(event, self.subject)
         except Exception:
@@ -821,7 +920,13 @@ class ProxyHandler(BaseHTTPRequestHandler):
         """
         assert self.screen is not None
         prompt = extract_prompt(body)
-        event = self.screen.prompt_event(provider, model, prompt, subject)
+        # Resolved once per request and reused for the tool calls the response
+        # proposes, so a turn's prompt and its consequences share a session.
+        self._session_id = self.screen.session_for(
+            body, self.headers.get("x-prismor-session") or "")
+        event = self.screen.prompt_event(provider, model, prompt, subject,
+                                         session_id=self._session_id,
+                                         parts=prompt_parts(body))
         try:
             decision = self.screen.evaluate(event, subject)
         except Exception:
@@ -914,7 +1019,8 @@ class ProxyHandler(BaseHTTPRequestHandler):
             return payload
         blocked: Dict[str, str] = {}
         for tool_name, arguments in response_tool_calls(provider, body):
-            event = self.screen.tool_event(tool_name, arguments, provider, model, subject)
+            event = self.screen.tool_event(tool_name, arguments, provider, model, subject,
+                                           session_id=getattr(self, "_session_id", ""))
             try:
                 decision = self.screen.evaluate(event, subject)
             except Exception:
@@ -943,7 +1049,8 @@ class ProxyHandler(BaseHTTPRequestHandler):
         self.send_header("Transfer-Encoding", "chunked")
         self.end_headers()
 
-        stream = StreamScreen(self.screen, provider, model, subject)
+        stream = StreamScreen(self.screen, provider, model, subject,
+                              getattr(self, "_session_id", ""))
         try:
             for frame in _sse_frames(resp):
                 out = stream.feed(frame)

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -1193,10 +1193,13 @@ def event_artifacts(raw: Dict[str, Any]) -> Dict[str, Any]:
         if raw.get(key):
             out[key] = str(raw[key])[:200]
 
-    for key in ("model", "provider", "surface", "cwd", "subagent_id", "subagent_type",
-                "agent_name", "tool_name"):
+    # user_message and system are the prompt taken apart again: what the person
+    # typed, and the instructions the workflow wraps around it.
+    for key in ("user_message", "system", "model", "provider", "surface", "cwd",
+                "subagent_id", "subagent_type", "agent_name", "tool_name"):
         if meta.get(key):
-            out[key] = str(meta[key])[:200]
+            out[key] = (_clip(meta[key]) if key in ("user_message", "system")
+                        else str(meta[key])[:200])
 
     # SessionStart carries the instruction files that were already in context
     # before the agent did anything -- the "what was here already" half.

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -368,15 +368,60 @@ def test_short_session_is_snapshotted_on_shutdown(monkeypatch, tmp_path):
     screen = proxy_mod.Screen(workspace=tmp_path, mode="observe",
                               session_id="short-session", agent_name="n8n")
     saved = []
-    monkeypatch.setattr(proxy_mod.Screen, "snapshot",
-                        lambda self: saved.append(self.session_id))
+    monkeypatch.setattr(proxy_mod.Screen, "_snapshot_one",
+                        lambda self, sid: saved.append(sid))
 
-    assert screen._events == 0
-    proxy_mod.Screen._persist(screen, {"type": "prompt", "prompt": "hello"})
+    screen._persist({"type": "prompt", "prompt": "hello", "session_id": "short-session"})
     assert saved == [], "no periodic rebuild is due after one event"
 
-    proxy_mod.Screen.snapshot(screen)
+    screen.snapshot()
     assert saved == ["short-session"], "shutdown must flush what is unsnapshotted"
+
+
+def test_prompt_parts_separate_what_the_person_said(tmp_path):
+    """The flattened blob is for policy; the parts are for the reader."""
+    body = {"messages": [
+        {"role": "system", "content": "You are an ops assistant with shell access."},
+        {"role": "user", "content": "Install the monitoring agent."},
+    ]}
+    parts = proxy_mod.prompt_parts(body)
+    assert parts["user_message"] == "Install the monitoring agent."
+    assert "ops assistant" in parts["system"]
+    # The blob still carries both, because that is what the rules read.
+    assert "ops assistant" in proxy_mod.extract_prompt(body)
+    assert "monitoring agent" in proxy_mod.extract_prompt(body)
+
+
+def test_one_session_per_conversation_not_per_process(tmp_path):
+    """Two chats through one proxy are two sessions; one chat stays one."""
+    screen = proxy_mod.Screen(workspace=tmp_path, mode="observe",
+                              session_id="proxy-1", agent_name="n8n")
+    sys_msg = {"role": "system", "content": "You are an HR assistant."}
+    chat_a_turn1 = {"messages": [sys_msg, {"role": "user", "content": "leave policy?"}]}
+    chat_a_turn2 = {"messages": [sys_msg, {"role": "user", "content": "leave policy?"},
+                                 {"role": "assistant", "content": "24 days"},
+                                 {"role": "user", "content": "and carry over?"}]}
+    chat_b = {"messages": [sys_msg, {"role": "user", "content": "wfh policy?"}]}
+
+    a1 = screen.session_for(chat_a_turn1)
+    a2 = screen.session_for(chat_a_turn2)
+    b1 = screen.session_for(chat_b)
+    assert a1 == a2, "a later turn of the same chat must stay in its session"
+    assert a1 != b1, "a different chat must not merge into it"
+    assert a1.startswith("proxy-1-")
+
+
+def test_an_explicit_session_header_wins(tmp_path):
+    screen = proxy_mod.Screen(workspace=tmp_path, mode="observe",
+                              session_id="proxy-1", agent_name="n8n")
+    sid = screen.session_for({"messages": []}, "n8n chat/42")
+    assert sid == "proxy-1-n8n-chat-42", "the header is sanitized, not trusted verbatim"
+
+
+def test_a_request_with_no_conversation_falls_back_to_the_process(tmp_path):
+    screen = proxy_mod.Screen(workspace=tmp_path, mode="observe",
+                              session_id="proxy-1", agent_name="n8n")
+    assert screen.session_for({}) == "proxy-1"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two things the new session view made obvious.

**Sessions.** The id was the proxy's own — process start plus pid — so every conversation the surface ever handled piled into one session. A chat UI sends its whole history every turn, so the opening exchange is constant within a conversation and different between them; hashing it threads a chatbot's turns together and keeps two chats apart. `X-Prismor-Session` overrides it for callers that know their own id (sanitized, not trusted verbatim). Snapshots are per session, and shutdown flushes every session the process touched.

**Prompts.** Only the flattened system-plus-messages blob was stored — right for policy, wrong for a reader, since the sentence a person typed arrived welded to the workflow's system prompt. The event now carries `user_message` and `system` too, and the session view leads with what was actually said.

Verified on real n8n traffic: two chats through one proxy produced two sessions, each showing its own question, system prompt listed separately.