### PR TITLE
Release 1.49.1 — one prompt, one turn, and no code webfont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.49.1] — 2026-09-08
+
+### Fixed
+- **One prompt became three turns.** Claude Code runs a hook registered in both
+  the user's `settings.json` and the project's, once each, and gives the
+  dispatcher no way to tell the copies apart — so the same message was logged
+  more than once and the session view opened a turn for every copy, reading as
+  if the person had said it three times. Events with the same type and content
+  inside a ten-second window collapse to one, and a repeated prompt no longer
+  opens a turn of its own. A genuine repeat — the agent running `ls` twice,
+  minutes apart — still shows twice.
+
+### Changed
+- **The bundled webfont for code is gone.** Command text and ids now use the
+  platform's own monospace stack rather than a downloaded display face, which
+  was a strong opinion the dashboard did not need and one more render-blocking
+  request on every load. Row chips read in the UI face — they are labels, not
+  code.
+- Session tree spacing, turn separators and lane labels tightened; the selected
+  row now takes the accent colour instead of a flat grey.
+
+
 ## [1.49.0] — 2026-09-08
 
 ### Added

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.49.0"
+__version__ = "1.49.1"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -7,7 +7,7 @@
 <link rel="icon" type="image/png" href="https://prismor.dev/Prismor_Logo.png" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script>
   (function () {
@@ -48,9 +48,11 @@
     --chart-palette-4: #A8D5F7;
     --chart-palette-5: #A7F3D0;
     --chart-palette-6: #FCA5A5;
-    /* Same faces as prismor.dev: Inter for UI, JetBrains Mono for code/ids */
+    /* Inter for UI. Code keeps a monospace stack, but the platform's own --
+       a downloaded display face for command text was a strong opinion the app
+       did not need, and one fewer webfont is one fewer render-blocking load. */
     --font-ui: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
   }
   html[data-theme="dark"] {
     --gray-50: #1a1a1d; --gray-100: #202024; --gray-200: #2c2c33;
@@ -954,7 +956,7 @@
   .drawer-toggle .icon { width: 12px; height: 12px; vertical-align: -1.5px; }
   .scoped-tag .icon { width: 11px; height: 11px; vertical-align: -1.5px; }
 
-  /* ── Monospace surfaces (code, ids, editors) — JetBrains Mono like the site ── */
+  /* ── Monospace surfaces (code, ids, editors) — the platform's own face ── */
   code, .yaml-editor, .sess-id, .sess-drawer-sessid, .event-sess-id,
   td.mono, .finding-cmd, .trigger-detail, .rule-id, .user-id, .adv-pill,
   .policy-meta .path { font-family: var(--font-mono); }
@@ -1081,29 +1083,38 @@
   .art-pre { font-family:var(--font-mono); font-size:10.5px; line-height:1.45; color:var(--gray-700);
     background:var(--gray-50); border:1px solid var(--gray-200); border-radius:7px;
     padding:7px 9px; margin:0; max-height:200px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
-  .sess-tree { padding:10px 4px 16px; font-size:12px; }
-  .tree-turn { margin-bottom:2px; }
+  .sess-tree { padding:8px 6px 14px; font-size:12.5px; }
+  /* A turn is the unit people scan for, so it gets the separator and the
+     breathing room; lanes and rows inside it stay quiet. */
+  .tree-turn { margin-bottom:2px; padding-bottom:2px; }
+  .tree-turn + .tree-turn { border-top:1px solid var(--gray-100); padding-top:4px; }
   .tree-row { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
-    background:none; border:0; padding:5px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+    background:none; border:0; padding:6px 8px; border-radius:8px; cursor:pointer; color:inherit; }
   .tree-row:hover { background:var(--gray-50); }
+  .tree-row.turn { padding:7px 8px; }
+  .tree-row.lane .tree-lane-label { font-size:11px; text-transform:uppercase; letter-spacing:.05em;
+    color:var(--gray-500); }
   .tree-caret { width:12px; flex:none; color:var(--gray-400); transition:transform .12s ease; }
   .tree-row.collapsed .tree-caret { transform:rotate(-90deg); }
   .tree-turn-label { font-weight:700; color:var(--gray-800); }
-  .tree-turn-sub { color:var(--gray-500); font-weight:400; margin-left:6px;
+  .tree-turn-sub { color:var(--gray-500); font-weight:400; margin-left:8px; min-width:0;
     overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-  .tree-count { margin-left:auto; flex:none; font-size:10px; font-weight:600; color:var(--gray-600);
-    background:var(--gray-100); border-radius:10px; padding:1px 7px; }
+  .tree-count { margin-left:auto; flex:none; font-size:10px; font-weight:600; color:var(--gray-500);
+    background:var(--gray-100); border-radius:10px; padding:1px 7px; min-width:20px; text-align:center; }
+  .tree-row.turn .tree-count { color:var(--gray-700); }
   .tree-children { margin-left:14px; padding-left:10px; border-left:1px solid var(--gray-200); }
   .tree-children.hidden { display:none; }
   .tree-lane-label { font-weight:600; color:var(--gray-700); }
-  .tree-leaf { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
-    background:none; border:0; padding:4px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+  .tree-leaf { display:flex; align-items:center; gap:9px; width:100%; text-align:left;
+    background:none; border:0; padding:5px 8px; border-radius:8px; cursor:pointer; color:inherit; }
   .tree-leaf:hover { background:var(--gray-50); }
-  .tree-leaf.sel { background:var(--gray-100); box-shadow:inset 2px 0 0 var(--gray-800); }
+  .tree-leaf.sel { background:var(--gray-100); box-shadow:inset 2px 0 0 var(--accent); }
+  .tree-leaf.sel .tree-text { color:var(--gray-900); font-weight:500; }
   .tree-dot { width:8px; height:8px; border-radius:50%; flex:none; background:var(--green-500); }
   .tree-dot.warn { background:#f59e0b; }
   .tree-dot.block { background:#ef4444; }
-  .tree-id { flex:none; font-family:var(--font-mono); font-size:10px; color:var(--gray-400); }
+  .tree-id { flex:none; font-size:10px; font-weight:600; letter-spacing:.02em;
+    color:var(--gray-500); background:var(--gray-100); border-radius:5px; padding:1px 6px; }
   .tree-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gray-700); }
   .tree-leaf.blocked .tree-text { color:#b91c1c; font-weight:600; }
   .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); }
@@ -3781,10 +3792,17 @@ function groupTrail(trail){
   const turns = [];
   let cur = null;
   trail.forEach((ev,i)=>{
-    if (!cur || ev.type === 'prompt'){
-      cur = { label:'Turn '+(turns.length+1), sub:'', lanes:new Map(), count:0 };
+    // A new turn starts at a prompt the agent has not just been given. The
+    // same prompt arriving twice is one turn: a hook registered in two
+    // settings scopes runs twice per message, and three identical turns read
+    // as the person having said it three times.
+    const text = ev.type === 'prompt' ? eventSummary(ev) : '';
+    const repeat = cur && text && cur.promptText === text;
+    if (!cur || (ev.type === 'prompt' && !repeat)){
+      cur = { label:'Turn '+(turns.length+1), sub:'', promptText:text, lanes:new Map(), count:0 };
       turns.push(cur);
     }
+    if (repeat) return;  // already represented by the turn it opened
     if (ev.type === 'prompt' && !cur.sub) cur.sub = eventSummary(ev).slice(0,90);
     const lane = eventLane(ev);
     if (!cur.lanes.has(lane)) cur.lanes.set(lane, []);

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -3381,6 +3381,48 @@ def set_project_rule_states(workspace: Path, disabled_ids: List[str]) -> Dict[st
 _TRAIL_ROWS = 250
 
 
+#: Two hook processes firing for one action land within a second of each other;
+#: a legitimate repeat of the same command is slower than this.
+_DUPLICATE_WINDOW_S = 10.0
+
+
+def _drop_duplicate_events(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse the same event logged more than once.
+
+    A hook registered in two settings scopes -- the user's and the project's --
+    runs twice for one action, and Claude Code offers no way to tell the copies
+    apart at dispatch time. Left alone, one prompt became three turns in the
+    session view, each identical, which reads as the agent having said the same
+    thing three times.
+
+    Same type and same content within a few seconds is one action. A real
+    repeat (the agent running `ls` twice) is either slower than the window or
+    genuinely worth showing twice.
+    """
+    seen: Dict[Tuple[str, str], float] = {}
+    out: List[Dict[str, Any]] = []
+    for ev in events:
+        key = (str(ev.get("type") or ""), str(ev.get("action") or "")[:400])
+        stamp = _epoch_of(ev.get("_tsRaw"))
+        previous = seen.get(key)
+        if previous is not None and stamp is not None and abs(previous - stamp) <= _DUPLICATE_WINDOW_S:
+            continue
+        if stamp is not None:
+            seen[key] = stamp
+        out.append(ev)
+    return out
+
+
+def _epoch_of(value: Any) -> Optional[float]:
+    if not value:
+        return None
+    from datetime import datetime as _dt
+    try:
+        return _dt.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
 def _merge_tool_phases(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fold a tool call's PreToolUse and PostToolUse rows into one.
 
@@ -3509,6 +3551,7 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                 detail = (row["command_text"] or row["path_text"] or row["url_text"]
                           or artifacts.get("prompt") or artifacts.get("response") or "")
                 recent_events.append({
+                    "_tsRaw": row["ts"],
                     "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
                     "tsAbs": _absolute_time_store(row["ts"]),
                     "type": row["type"] or "",
@@ -3531,7 +3574,9 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                         "source": enrichment.get("source") or ("finding" if finding_id else ""),
                     },
                 })
-            recent_events = _merge_tool_phases(recent_events)
+            recent_events = _merge_tool_phases(_drop_duplicate_events(recent_events))
+            for item in recent_events:
+                item.pop("_tsRaw", None)
             block_keys = {
                 (item.get("title") or "", item.get("evidence") or "", item.get("ts") or "")
                 for item in recent_blocked

--- a/tests/test_session_artifacts.py
+++ b/tests/test_session_artifacts.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from prismor.runtime.store import (  # noqa: E402
     _ARTIFACT_CHARS,
+    _drop_duplicate_events,
     _merge_tool_phases,
     event_artifacts,
     event_lane,
@@ -95,6 +96,46 @@ class TestMergeToolPhases(unittest.TestCase):
         merged = _merge_tool_phases(events)
         self.assertEqual(len(merged), 1)
         self.assertNotIn("phases", merged[0])
+
+
+class TestDropDuplicateEvents(unittest.TestCase):
+    """One action logged twice is one row.
+
+    Claude Code runs a hook registered in both the user's settings and the
+    project's, once each, and offers no way to tell the copies apart at
+    dispatch. Left alone, one prompt became three identical turns in the
+    session view -- as if the person had said it three times.
+    """
+
+    def _ev(self, action, ts, type_="prompt"):
+        return {"type": type_, "action": action, "_tsRaw": ts}
+
+    def test_the_same_prompt_from_two_hooks_is_one_row(self):
+        events = [
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:01+00:00"),
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:01+00:00"),
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:02+00:00"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 1)
+
+    def test_the_same_command_run_again_later_is_kept(self):
+        """A repeat outside the window is something the agent really did twice."""
+        events = [
+            self._ev("shell: ls", "2026-01-01T00:05:00+00:00", "shell"),
+            self._ev("shell: ls", "2026-01-01T00:00:00+00:00", "shell"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
+
+    def test_different_actions_at_the_same_moment_both_survive(self):
+        events = [
+            self._ev("shell: ls", "2026-01-01T00:00:01+00:00", "shell"),
+            self._ev("shell: pwd", "2026-01-01T00:00:01+00:00", "shell"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
+
+    def test_an_unparseable_timestamp_never_drops_an_event(self):
+        events = [self._ev("prompt: x", "not-a-time"), self._ev("prompt: x", "not-a-time")]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Why three identical turns.** Claude Code runs a hook registered in both `~/.claude/settings.json` and the project's `.claude/settings.json`, once each, and the dispatcher cannot tell the copies apart — so one message was logged more than once and the session view opened a turn per copy. Verified on this machine: both scopes register `UserPromptSubmit`.

Same type and content inside a ten-second window now collapses to one event, and a repeated prompt no longer opens a turn of its own. A genuine repeat (the agent running `ls` twice, minutes apart) still shows twice.

**Font.** The bundled monospace webfont is gone; command text and ids use the platform's own stack, and row chips move to the UI face since they are labels rather than code. One fewer render-blocking request per load.

**Polish.** Turn separators, uppercase lane labels, accent on the selected row, slightly roomier rows.