### PR TITLE
Release 1.49.2 — keep long commands inside the card, one severity scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## [Unreleased]
 
+## [1.49.2] — 2026-09-08
+
+### Fixed
+- **Long commands painted outside the policy card.** A flex item's `min-width`
+  is `auto`, so an unbroken shell string refused to shrink and the reason text
+  ran past the card's border into the page. Both halves of the row now shrink,
+  and the value wraps on any character, because a command line often has no
+  spaces to break on.
+- **The code block sliced its last line in half.** Its height was a round
+  number rather than a multiple of the line height, so the bottom row was cut
+  through the middle and read as a broken box instead of a scrollable one.
+
+### Changed
+- **Severity reads as one scale.** It ran across four unrelated hues —
+  critical in violet, high in pink, medium in yellow, low in blue — so the most
+  urgent badge looked the calmest. One ramp now: red, orange, amber, grey. The
+  policy card drops its pink fill for a neutral surface with a verdict-coloured
+  edge, so a card is a container and the colour means the verdict.
+- **Lane icons** from [keyline-icons](https://github.com/keyline-icons/keyline-icons)
+  (MIT, 24×24 stroke grid), inlined as a sprite: no request, no dependency.
+- Applied the parts of [ui-skills](https://github.com/ibelick/ui-skills)'
+  baseline that fit plain CSS: tabular figures for timestamps, no invented
+  letter-spacing, and the accent colour used once per view.
+
+
 ## [1.49.1] — 2026-09-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.49.1] — 2026-09-08
+
+### Fixed
+- **One prompt became three turns.** Claude Code runs a hook registered in both
+  the user's `settings.json` and the project's, once each, and gives the
+  dispatcher no way to tell the copies apart — so the same message was logged
+  more than once and the session view opened a turn for every copy, reading as
+  if the person had said it three times. Events with the same type and content
+  inside a ten-second window collapse to one, and a repeated prompt no longer
+  opens a turn of its own. A genuine repeat — the agent running `ls` twice,
+  minutes apart — still shows twice.
+
+### Changed
+- **The bundled webfont for code is gone.** Command text and ids now use the
+  platform's own monospace stack rather than a downloaded display face, which
+  was a strong opinion the dashboard did not need and one more render-blocking
+  request on every load. Row chips read in the UI face — they are labels, not
+  code.
+- Session tree spacing, turn separators and lane labels tightened; the selected
+  row now takes the accent colour instead of a flat grey.
+
+
 ## [1.49.0] — 2026-09-08
 
 ### Added

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.49.0"
+__version__ = "1.49.1"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.49.1"
+__version__ = "1.49.2"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -188,10 +188,10 @@
     display: inline-block; padding: 1px 6px; border-radius: 4px;
     font-size: 10px; font-weight: 500;
   }
-  .sev-critical { background: #ede9fe; color: #6d28d9; border: 1px solid #c4b5fd; }
-  .sev-high     { background: #fce7f3; color: #be185d; border: 1px solid #f9a8d4; }
-  .sev-medium   { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
-  .sev-low      { background: #e0f2fe; color: #0369a1; border: 1px solid #7dd3fc; }
+  .sev-critical { background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; }
+  .sev-high     { background: #fff7ed; color: #c2410c; border: 1px solid #fed7aa; }
+  .sev-medium   { background: #fffbeb; color: #b45309; border: 1px solid #fde68a; }
+  .sev-low      { background: var(--gray-100); color: var(--gray-600); border: 1px solid var(--gray-200); }
 
   /* Risk bar */
   .risk-wrap { display: flex; align-items: center; gap: 6px; }
@@ -354,12 +354,12 @@
     border-radius: 7px; padding: 10px; margin-bottom: 10px;
   }
   .drawer-policy-card {
-    border: 1px solid #f9a8d4; background: #fdf2f8;
-    border-radius: 6px; padding: 8px; margin-top: 8px;
+    border: 1px solid var(--gray-200); background: var(--gray-50);
+    border-left: 3px solid #ef4444;
+    border-radius: 6px; padding: 9px 10px; margin-top: 8px; min-width: 0;
   }
-  .drawer-policy-card.allowed {
-    border-color: #bbf7d0; background: #f0fdf4;
-  }
+  .drawer-policy-card.allowed { border-left-color: #22c55e; }
+  .drawer-policy-card.warned  { border-left-color: #f59e0b; }
   .trail-row {
     display: flex; align-items: flex-start; gap: 8px;
     padding: 7px 0; border-bottom: 1px solid var(--gray-50);
@@ -373,8 +373,13 @@
   .trail-meta { font-size: 10px; color: var(--gray-400); margin-bottom: 2px; display: flex; gap: 5px; flex-wrap: wrap; }
   .drawer-rule-row {
     display: flex; align-items: flex-start; gap: 8px; margin-bottom: 8px;
-    font-size: 11px;
+    font-size: 11px; min-width: 0;
   }
+  /* A flex item's min-width is auto, so an unbroken command string refuses to
+     shrink and paints straight out of the card. Both halves need the override,
+     and the value needs somewhere to wrap: shell text has no spaces to break on. */
+  .drawer-rule-row > * { min-width: 0; }
+  .drawer-rule-row > div { overflow-wrap: anywhere; word-break: break-word; }
   .drawer-rule-label { color: var(--gray-400); min-width: 80px; flex-shrink: 0; }
   .drawer-rule-tags  { display: flex; gap: 4px; flex-wrap: wrap; }
 
@@ -1080,9 +1085,14 @@
   .art-row { margin-bottom:9px; }
   .art-label { font-size:10px; font-weight:600; color:var(--gray-500); margin-bottom:2px; }
   .art-val { font-size:11px; color:var(--gray-700); word-break:break-word; }
-  .art-pre { font-family:var(--font-mono); font-size:10.5px; line-height:1.45; color:var(--gray-700);
+  /* 12 lines exactly: a max-height that is not a multiple of line-height slices
+     the last row in half, which reads as a broken box rather than a scroll. */
+  .art-pre { font-family:var(--font-mono); font-size:10.5px; line-height:1.5; color:var(--gray-700);
     background:var(--gray-50); border:1px solid var(--gray-200); border-radius:7px;
-    padding:7px 9px; margin:0; max-height:200px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
+    padding:8px 10px; margin:0; max-height:calc(12 * 1.5 * 10.5px + 16px); overflow:auto;
+    white-space:pre-wrap; overflow-wrap:anywhere; tab-size:2; }
+  .art-pre::-webkit-scrollbar { width:8px; height:8px; }
+  .art-pre::-webkit-scrollbar-thumb { background:var(--gray-300); border-radius:4px; }
   .sess-tree { padding:8px 6px 14px; font-size:12.5px; }
   /* A turn is the unit people scan for, so it gets the separator and the
      breathing room; lanes and rows inside it stay quiet. */
@@ -1092,8 +1102,7 @@
     background:none; border:0; padding:6px 8px; border-radius:8px; cursor:pointer; color:inherit; }
   .tree-row:hover { background:var(--gray-50); }
   .tree-row.turn { padding:7px 8px; }
-  .tree-row.lane .tree-lane-label { font-size:11px; text-transform:uppercase; letter-spacing:.05em;
-    color:var(--gray-500); }
+  .tree-row.lane .tree-lane-label { font-size:11px; text-transform:uppercase; color:var(--gray-500); }
   .tree-caret { width:12px; flex:none; color:var(--gray-400); transition:transform .12s ease; }
   .tree-row.collapsed .tree-caret { transform:rotate(-90deg); }
   .tree-turn-label { font-weight:700; color:var(--gray-800); }
@@ -1104,6 +1113,8 @@
   .tree-row.turn .tree-count { color:var(--gray-700); }
   .tree-children { margin-left:14px; padding-left:10px; border-left:1px solid var(--gray-200); }
   .tree-children.hidden { display:none; }
+  .tree-lane-icon { width:14px; height:14px; flex:none; color:var(--gray-400); }
+  .tree-row.lane:hover .tree-lane-icon { color:var(--gray-600); }
   .tree-lane-label { font-weight:600; color:var(--gray-700); }
   .tree-leaf { display:flex; align-items:center; gap:9px; width:100%; text-align:left;
     background:none; border:0; padding:5px 8px; border-radius:8px; cursor:pointer; color:inherit; }
@@ -1113,11 +1124,11 @@
   .tree-dot { width:8px; height:8px; border-radius:50%; flex:none; background:var(--green-500); }
   .tree-dot.warn { background:#f59e0b; }
   .tree-dot.block { background:#ef4444; }
-  .tree-id { flex:none; font-size:10px; font-weight:600; letter-spacing:.02em;
+  .tree-id { flex:none; font-size:10px; font-weight:600;
     color:var(--gray-500); background:var(--gray-100); border-radius:5px; padding:1px 6px; }
   .tree-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gray-700); }
   .tree-leaf.blocked .tree-text { color:#b91c1c; font-weight:600; }
-  .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); }
+  .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); font-variant-numeric:tabular-nums; }
   .flow-legend { display:flex; gap:12px; font-size:10px; color:var(--gray-500); }
   .flow-legend span { display:inline-flex; align-items:center; gap:4px; }
   .flow-legend i { width:9px; height:9px; border-radius:3px; display:inline-block; }
@@ -1658,6 +1669,18 @@
 </style>
 </head>
 <body>
+<svg style="display:none" aria-hidden="true">
+  <!-- Lane icons from keyline-icons (MIT), 24x24 stroke grid. -->
+  <symbol id="kl-context" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5C4 3.3431 5.3431 2 7 2L17 2C18.6569 2 20 3.3431 20 5L20 20.9983C20 21.7895 19.1248 22.2673 18.4592 21.8395L12.8111 18.8514C12.317 18.5338 11.683 18.5338 11.1889 18.8514L5.5408 21.8395C4.8752 22.2673 4 21.7895 4 20.9983Z"/></symbol>
+  <symbol id="kl-files" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H8C5.79086 2 4 3.79086 4 6V18C4 20.2091 5.79086 22 8 22H16C18.2091 22 20 20.2091 20 18V8L14 2ZM14 2V5C14 6.65685 15.3431 8 17 8H20M8 13H12M8 17H16"/></symbol>
+  <symbol id="kl-mcp" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2L18 2C19.1046 2 20 2.8954 20 4L20 8C20 9.1046 19.1046 10 18 10L6 10C4.8954 10 4 9.1046 4 8L4 4C4 2.8954 4.8954 2 6 2ZM6 14L18 14C19.1046 14 20 14.8954 20 16L20 20C20 21.1046 19.1046 22 18 22L6 22C4.8954 22 4 21.1046 4 20L4 16C4 14.8954 4.8954 14 6 14Z" fill="none"/> <path d="M9 6C9 6.5523 8.5523 7 8 7C7.4477 7 7 6.5523 7 6C7 5.4477 7.4477 5 8 5C8.5523 5 9 5.4477 9 6ZM13 6C13 6.5523 12.5523 7 12 7C11.4477 7 11 6.5523 11 6C11 5.4477 11.4477 5 12 5C12.5523 5 13 5.4477 13 6ZM9 18C9 18.5523 8.5523 19 8 19C7.4477 19 7 18.5523 7 18C7 17.4477 7.4477 17 8 17C8.5523 17 9 17.4477 9 18ZM13 18C13 18.5523 12.5523 19 12 19C11.4477 19 11 18.5523 11 18C11 17.4477 11.4477 17 12 17C12.5523 17 13 17.4477 13 18Z" fill="currentColor" stroke="none"/></symbol>
+  <symbol id="kl-network" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM2 12H22M12 2C14.6667 5 16 8.5 16 12C16 15.5 14.6667 19 12 22C9.33333 19 8 15.5 8 12C8 8.5 9.33333 5 12 2Z"/></symbol>
+  <symbol id="kl-other" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12H5.01M12 12H12.01M19 12H19.01"/></symbol>
+  <symbol id="kl-prompt" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 3 C20.6569 3 22 4.3431 22 6 C22 7.6569 20.6569 9 19 9 C17.3431 9 16 7.6569 16 6 C16 4.3431 17.3431 3 19 3 ZM12.668 3.0179 C12.4456 3.006 12.2228 3 12 3 C6.4772 3 2 6.5817 2 11 C2 12.9769 2.915 14.8839 4.5686 16.353 L5 21 L9.5808 18.7624 C10.3721 18.9202 11.1845 19 12 19 C16.8496 19 21.0003 16.2162 21.8466 12.3961" fill="none"/></symbol>
+  <symbol id="kl-shell" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5L10.5571 10.6204C10.7899 10.8199 10.7899 11.1801 10.5571 11.3796L4 17M20 19H13"/></symbol>
+  <symbol id="kl-tools" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18.682 8.8536L20.2678 7.2678C20.4553 7.0802 20.7097 6.9749 20.9749 6.9749C21.4902 6.9749 21.9211 7.3664 21.9703 7.8794C21.9901 8.0857 22 8.2928 22 8.5C22 12.0899 19.0899 15 15.5 15C11.9101 15 9 12.0899 9 8.5C9 4.9101 11.9101 2 15.5 2C15.7072 2 15.9143 2.0099 16.1206 2.0297C16.6336 2.0789 17.0251 2.5098 17.0251 3.0251C17.0251 3.2903 16.9198 3.5447 16.7322 3.7322L15.1464 5.318C14.6776 5.7869 14.4142 6.4227 14.4142 7.0858C14.4142 8.4665 15.5335 9.5858 16.9142 9.5858C17.5773 9.5858 18.2131 9.3224 18.682 8.8536ZM15.3955 14.9992C15.3688 14.9987 15.342 14.9985 15.3152 14.9985C13.9891 14.9985 12.7173 15.5253 11.7797 16.463L7.1213 21.1213C6.5587 21.6839 5.7956 22 5 22C3.3431 22 2 20.6569 2 19C2 18.2044 2.3161 17.4413 2.8787 16.8787L7.537 12.2203C8.4747 11.2827 9.0015 10.0109 9.0015 8.6848C9.0015 8.658 9.0013 8.6312 9.0008 8.6045"/></symbol>
+</svg>
+
 
 <!-- ═══ ICON SPRITE (Lucide, inlined — no external requests) ══════ -->
 <svg xmlns="http://www.w3.org/2000/svg" style="display:none" aria-hidden="true">
@@ -3812,11 +3835,12 @@ function groupTrail(trail){
   turns.forEach(t=>{ if(!t.sub && t.lanes.size) t.sub = eventSummary([...t.lanes.values()][0][0].ev).slice(0,90); });
   return turns;
 }
-function treeRowEl({cls, caret, label, sub, count, onToggle}){
+function treeRowEl({cls, caret, label, sub, count, onToggle, lane}){
   const btn = document.createElement('button');
   btn.className = 'tree-row '+cls;
   btn.innerHTML =
     (caret ? '<svg class="tree-caret" viewBox="0 0 12 12"><path d="M3 4.5 L6 8 L9 4.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>' : '<span class="tree-caret"></span>')+
+    (lane ? '<svg class="tree-lane-icon" aria-hidden="true"><use href="#kl-'+lane+'"/></svg>' : '')+
     '<span class="'+(cls==='turn'?'tree-turn-label':'tree-lane-label')+'">'+safe(label)+'</span>'+
     (sub ? '<span class="tree-turn-sub">'+safe(sub)+'</span>' : '')+
     '<span class="tree-count">'+count+'</span>';
@@ -3851,7 +3875,7 @@ function renderSessionFlow(trail){
     LANE_ORDER.filter(l=>turn.lanes.has(l)).forEach(lane=>{
       const items = turn.lanes.get(lane);
       const laneKids = document.createElement('div'); laneKids.className='tree-children';
-      const laneHead = treeRowEl({cls:'lane', caret:true, label:LANE_LABEL[lane], sub:'', count:items.length,
+      const laneHead = treeRowEl({cls:'lane', caret:true, label:LANE_LABEL[lane], sub:'', count:items.length, lane,
         onToggle:(e)=>{ laneKids.classList.toggle('hidden'); e.currentTarget.classList.toggle('collapsed'); }});
       items.forEach(({ev,i})=>laneKids.appendChild(treeLeafEl(ev,i)));
       kids.appendChild(laneHead); kids.appendChild(laneKids);
@@ -3910,7 +3934,7 @@ function renderNodePanel(ev){
       '<div class="drawer-rule-row" style="align-items:flex-start;margin-bottom:0"><span class="drawer-rule-label">Action</span>'+
         '<div style="font-size:11px;color:var(--gray-600);line-height:1.5;word-break:break-word">'+safe(ev.action||'')+'</div></div>'+
       ((policy.ruleId||policy.title||policy.evidence||categoryLabel)?
-        '<div class="drawer-policy-card '+(v==='allow'?'allowed':'')+'">'+
+        '<div class="drawer-policy-card '+({allow:'allowed',warn:'warned',block:''})[v]+'">'+
           '<div class="drawer-rule-row"><span class="drawer-rule-label">Policy</span>'+
             '<div><div style="font-size:11px;font-weight:600;color:var(--gray-800)">'+safe(policy.ruleId||policy.id||'runtime-policy')+'</div>'+
             (categoryLabel?'<div style="font-size:10px;color:var(--gray-500);margin-top:2px">'+safe(categoryLabel)+'</div>':'')+'</div></div>'+

--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -7,7 +7,7 @@
 <link rel="icon" type="image/png" href="https://prismor.dev/Prismor_Logo.png" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script>
   (function () {
@@ -48,9 +48,11 @@
     --chart-palette-4: #A8D5F7;
     --chart-palette-5: #A7F3D0;
     --chart-palette-6: #FCA5A5;
-    /* Same faces as prismor.dev: Inter for UI, JetBrains Mono for code/ids */
+    /* Inter for UI. Code keeps a monospace stack, but the platform's own --
+       a downloaded display face for command text was a strong opinion the app
+       did not need, and one fewer webfont is one fewer render-blocking load. */
     --font-ui: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
   }
   html[data-theme="dark"] {
     --gray-50: #1a1a1d; --gray-100: #202024; --gray-200: #2c2c33;
@@ -954,7 +956,7 @@
   .drawer-toggle .icon { width: 12px; height: 12px; vertical-align: -1.5px; }
   .scoped-tag .icon { width: 11px; height: 11px; vertical-align: -1.5px; }
 
-  /* ── Monospace surfaces (code, ids, editors) — JetBrains Mono like the site ── */
+  /* ── Monospace surfaces (code, ids, editors) — the platform's own face ── */
   code, .yaml-editor, .sess-id, .sess-drawer-sessid, .event-sess-id,
   td.mono, .finding-cmd, .trigger-detail, .rule-id, .user-id, .adv-pill,
   .policy-meta .path { font-family: var(--font-mono); }
@@ -1081,29 +1083,38 @@
   .art-pre { font-family:var(--font-mono); font-size:10.5px; line-height:1.45; color:var(--gray-700);
     background:var(--gray-50); border:1px solid var(--gray-200); border-radius:7px;
     padding:7px 9px; margin:0; max-height:200px; overflow:auto; white-space:pre-wrap; word-break:break-word; }
-  .sess-tree { padding:10px 4px 16px; font-size:12px; }
-  .tree-turn { margin-bottom:2px; }
+  .sess-tree { padding:8px 6px 14px; font-size:12.5px; }
+  /* A turn is the unit people scan for, so it gets the separator and the
+     breathing room; lanes and rows inside it stay quiet. */
+  .tree-turn { margin-bottom:2px; padding-bottom:2px; }
+  .tree-turn + .tree-turn { border-top:1px solid var(--gray-100); padding-top:4px; }
   .tree-row { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
-    background:none; border:0; padding:5px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+    background:none; border:0; padding:6px 8px; border-radius:8px; cursor:pointer; color:inherit; }
   .tree-row:hover { background:var(--gray-50); }
+  .tree-row.turn { padding:7px 8px; }
+  .tree-row.lane .tree-lane-label { font-size:11px; text-transform:uppercase; letter-spacing:.05em;
+    color:var(--gray-500); }
   .tree-caret { width:12px; flex:none; color:var(--gray-400); transition:transform .12s ease; }
   .tree-row.collapsed .tree-caret { transform:rotate(-90deg); }
   .tree-turn-label { font-weight:700; color:var(--gray-800); }
-  .tree-turn-sub { color:var(--gray-500); font-weight:400; margin-left:6px;
+  .tree-turn-sub { color:var(--gray-500); font-weight:400; margin-left:8px; min-width:0;
     overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-  .tree-count { margin-left:auto; flex:none; font-size:10px; font-weight:600; color:var(--gray-600);
-    background:var(--gray-100); border-radius:10px; padding:1px 7px; }
+  .tree-count { margin-left:auto; flex:none; font-size:10px; font-weight:600; color:var(--gray-500);
+    background:var(--gray-100); border-radius:10px; padding:1px 7px; min-width:20px; text-align:center; }
+  .tree-row.turn .tree-count { color:var(--gray-700); }
   .tree-children { margin-left:14px; padding-left:10px; border-left:1px solid var(--gray-200); }
   .tree-children.hidden { display:none; }
   .tree-lane-label { font-weight:600; color:var(--gray-700); }
-  .tree-leaf { display:flex; align-items:center; gap:8px; width:100%; text-align:left;
-    background:none; border:0; padding:4px 8px; border-radius:7px; cursor:pointer; color:inherit; }
+  .tree-leaf { display:flex; align-items:center; gap:9px; width:100%; text-align:left;
+    background:none; border:0; padding:5px 8px; border-radius:8px; cursor:pointer; color:inherit; }
   .tree-leaf:hover { background:var(--gray-50); }
-  .tree-leaf.sel { background:var(--gray-100); box-shadow:inset 2px 0 0 var(--gray-800); }
+  .tree-leaf.sel { background:var(--gray-100); box-shadow:inset 2px 0 0 var(--accent); }
+  .tree-leaf.sel .tree-text { color:var(--gray-900); font-weight:500; }
   .tree-dot { width:8px; height:8px; border-radius:50%; flex:none; background:var(--green-500); }
   .tree-dot.warn { background:#f59e0b; }
   .tree-dot.block { background:#ef4444; }
-  .tree-id { flex:none; font-family:var(--font-mono); font-size:10px; color:var(--gray-400); }
+  .tree-id { flex:none; font-size:10px; font-weight:600; letter-spacing:.02em;
+    color:var(--gray-500); background:var(--gray-100); border-radius:5px; padding:1px 6px; }
   .tree-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gray-700); }
   .tree-leaf.blocked .tree-text { color:#b91c1c; font-weight:600; }
   .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); }
@@ -3781,10 +3792,17 @@ function groupTrail(trail){
   const turns = [];
   let cur = null;
   trail.forEach((ev,i)=>{
-    if (!cur || ev.type === 'prompt'){
-      cur = { label:'Turn '+(turns.length+1), sub:'', lanes:new Map(), count:0 };
+    // A new turn starts at a prompt the agent has not just been given. The
+    // same prompt arriving twice is one turn: a hook registered in two
+    // settings scopes runs twice per message, and three identical turns read
+    // as the person having said it three times.
+    const text = ev.type === 'prompt' ? eventSummary(ev) : '';
+    const repeat = cur && text && cur.promptText === text;
+    if (!cur || (ev.type === 'prompt' && !repeat)){
+      cur = { label:'Turn '+(turns.length+1), sub:'', promptText:text, lanes:new Map(), count:0 };
       turns.push(cur);
     }
+    if (repeat) return;  // already represented by the turn it opened
     if (ev.type === 'prompt' && !cur.sub) cur.sub = eventSummary(ev).slice(0,90);
     const lane = eventLane(ev);
     if (!cur.lanes.has(lane)) cur.lanes.set(lane, []);

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -3381,6 +3381,48 @@ def set_project_rule_states(workspace: Path, disabled_ids: List[str]) -> Dict[st
 _TRAIL_ROWS = 250
 
 
+#: Two hook processes firing for one action land within a second of each other;
+#: a legitimate repeat of the same command is slower than this.
+_DUPLICATE_WINDOW_S = 10.0
+
+
+def _drop_duplicate_events(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse the same event logged more than once.
+
+    A hook registered in two settings scopes -- the user's and the project's --
+    runs twice for one action, and Claude Code offers no way to tell the copies
+    apart at dispatch time. Left alone, one prompt became three turns in the
+    session view, each identical, which reads as the agent having said the same
+    thing three times.
+
+    Same type and same content within a few seconds is one action. A real
+    repeat (the agent running `ls` twice) is either slower than the window or
+    genuinely worth showing twice.
+    """
+    seen: Dict[Tuple[str, str], float] = {}
+    out: List[Dict[str, Any]] = []
+    for ev in events:
+        key = (str(ev.get("type") or ""), str(ev.get("action") or "")[:400])
+        stamp = _epoch_of(ev.get("_tsRaw"))
+        previous = seen.get(key)
+        if previous is not None and stamp is not None and abs(previous - stamp) <= _DUPLICATE_WINDOW_S:
+            continue
+        if stamp is not None:
+            seen[key] = stamp
+        out.append(ev)
+    return out
+
+
+def _epoch_of(value: Any) -> Optional[float]:
+    if not value:
+        return None
+    from datetime import datetime as _dt
+    try:
+        return _dt.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
 def _merge_tool_phases(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fold a tool call's PreToolUse and PostToolUse rows into one.
 
@@ -3509,6 +3551,7 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                 detail = (row["command_text"] or row["path_text"] or row["url_text"]
                           or artifacts.get("prompt") or artifacts.get("response") or "")
                 recent_events.append({
+                    "_tsRaw": row["ts"],
                     "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
                     "tsAbs": _absolute_time_store(row["ts"]),
                     "type": row["type"] or "",
@@ -3531,7 +3574,9 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                         "source": enrichment.get("source") or ("finding" if finding_id else ""),
                     },
                 })
-            recent_events = _merge_tool_phases(recent_events)
+            recent_events = _merge_tool_phases(_drop_duplicate_events(recent_events))
+            for item in recent_events:
+                item.pop("_tsRaw", None)
             block_keys = {
                 (item.get("title") or "", item.get("evidence") or "", item.get("ts") or "")
                 for item in recent_blocked

--- a/tests/test_session_artifacts.py
+++ b/tests/test_session_artifacts.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from prismor.runtime.store import (  # noqa: E402
     _ARTIFACT_CHARS,
+    _drop_duplicate_events,
     _merge_tool_phases,
     event_artifacts,
     event_lane,
@@ -95,6 +96,46 @@ class TestMergeToolPhases(unittest.TestCase):
         merged = _merge_tool_phases(events)
         self.assertEqual(len(merged), 1)
         self.assertNotIn("phases", merged[0])
+
+
+class TestDropDuplicateEvents(unittest.TestCase):
+    """One action logged twice is one row.
+
+    Claude Code runs a hook registered in both the user's settings and the
+    project's, once each, and offers no way to tell the copies apart at
+    dispatch. Left alone, one prompt became three identical turns in the
+    session view -- as if the person had said it three times.
+    """
+
+    def _ev(self, action, ts, type_="prompt"):
+        return {"type": type_, "action": action, "_tsRaw": ts}
+
+    def test_the_same_prompt_from_two_hooks_is_one_row(self):
+        events = [
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:01+00:00"),
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:01+00:00"),
+            self._ev("prompt: deploy the thing", "2026-01-01T00:00:02+00:00"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 1)
+
+    def test_the_same_command_run_again_later_is_kept(self):
+        """A repeat outside the window is something the agent really did twice."""
+        events = [
+            self._ev("shell: ls", "2026-01-01T00:05:00+00:00", "shell"),
+            self._ev("shell: ls", "2026-01-01T00:00:00+00:00", "shell"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
+
+    def test_different_actions_at_the_same_moment_both_survive(self):
+        events = [
+            self._ev("shell: ls", "2026-01-01T00:00:01+00:00", "shell"),
+            self._ev("shell: pwd", "2026-01-01T00:00:01+00:00", "shell"),
+        ]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
+
+    def test_an_unparseable_timestamp_never_drops_an_event(self):
+        events = [self._ev("prompt: x", "not-a-time"), self._ev("prompt: x", "not-a-time")]
+        self.assertEqual(len(_drop_duplicate_events(events)), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Overflow.** A flex item's `min-width` is `auto`, so an unbroken shell string refused to shrink and the policy card's reason text painted past its border into the page. Both halves of the row shrink now, and the value wraps on any character — a command line often has no spaces to break on. Verified: zero elements paint outside the panel.

**The code block** had a round `max-height` instead of a whole number of lines, so it cut its last row through the middle and read as broken rather than scrollable.

**Colour.** Severity ran across four unrelated hues — critical violet, high pink, medium yellow, low blue — so the most urgent badge looked the calmest. One ramp now (red → orange → amber → grey), and the policy card drops its pink fill for a neutral surface with a verdict-coloured edge.

**Icons** from [keyline-icons](https://github.com/keyline-icons/keyline-icons) (MIT, 24×24 stroke), inlined as a sprite — no request, no dependency. From [ui-skills](https://github.com/ibelick/ui-skills)' baseline, the rules that apply to plain CSS: tabular figures on timestamps, no invented letter-spacing, one accent per view.