### PR TITLE
Release 1.49.3 — the setup summary holds what it prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.49.3] — 2026-09-08
+
+### Fixed
+- **The setup summary printed through its own border.** The box was a fixed 48
+  columns and its row padding floors at zero, so any longer value — a ten-agent
+  list, comfortably — ran straight past the right edge and broke the frame. The
+  box now sizes to its contents within the terminal, and a value that still
+  does not fit wraps under itself on commas rather than escaping or being cut.
+
+### Changed
+- **The governance-mode list is readable.** Each option is a name, a sentence
+  and two bars, printed with no separation, so four options read as one
+  paragraph and the selected row was hard to find. Options are separated, and
+  the bars line up under the description they belong to instead of sitting
+  three columns to its left.
+- **Less prose in the wizard.** The self-edit step explained itself in four
+  lines for a two-option question; it takes two now. The cloaking step dropped
+  a path into Prismor's own source tree — not something the reader can act
+  on — for what the agent actually sees in place of a secret, and its options
+  are short enough to fit a narrow terminal.
+
+
 ## [1.49.2] — 2026-09-08
 
 ### Fixed

--- a/prismor/runtime/__init__.py
+++ b/prismor/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Prismor local session-security utility."""
 
-__version__ = "1.49.2"
+__version__ = "1.49.3"
 
 from prismor.runtime.semantic_guard import SemanticGuard, SemanticRisk
 from prismor.runtime.semantic_guard_v2 import SemanticGuardV2, HybridRisk

--- a/prismor/runtime/setup_wizard.py
+++ b/prismor/runtime/setup_wizard.py
@@ -425,6 +425,8 @@ def _step_governance_mode(current: str = "custom", step: int = 2, total: int = 6
             if mid == "custom":
                 nm = _pad(_w("custom", BOLD) if i == sel else _w("custom", DIM), 20)
                 lines.append(f"  {arrow}{dot}  {nm}{_w('Pick exactly which rules block, rule by rule', DIM)}")
+                if i != len(ids) - 1:
+                    lines.append("")
                 continue
             m = modes[mid]
             blocking, tot_rules = coverage({**m, "id": mid})
@@ -432,8 +434,12 @@ def _step_governance_mode(current: str = "custom", step: int = 2, total: int = 6
             friction = int(m.get("friction_index", 0))
             nm = _pad(_w(mid, BOLD) if i == sel else _w(mid, DIM), 20)
             lines.append(f"  {arrow}{dot}  {nm}{_w(m.get('intent', ''), DIM)}")
-            lines.append(f"  {'':22}{_w(f'coverage [{_mode_bar(pct)}] {pct:>3}%', DIM)}"
+            lines.append(f"  {'':25}{_w(f'coverage [{_mode_bar(pct)}] {pct:>3}%', DIM)}"
                          f"   {_w(f'friction [{_mode_bar(friction)}] {friction:>3}%', DIM)}")
+            # A name, a sentence and two bars per option: run together they read
+            # as one paragraph and the selected row is hard to place.
+            if i != len(ids) - 1:
+                lines.append("")
         lines.append("")
         lines.append(_control_line([
             ("↑↓", "select"), ("e", "explain"), ("←", "back"), ("enter", "next"),
@@ -717,15 +723,15 @@ def _step_agents(target: Path, step: int = 2, total: int = 4) -> list:
 
 def _step_cloak(current: bool = True, step: int = 3, total: int = 4) -> bool:
     opts = [
-        ("yes", "Install cloaking hooks  (recommended — prevents secret leaks to the LLM provider)"),
-        ("no",  "Skip — only runtime policy hooks will be installed"),
+        ("yes", "Install cloaking hooks   recommended"),
+        ("no",  "Skip — runtime policy hooks only"),
     ]
     sel = 0 if current else 1
 
     while True:
         lines = _header_lines(step, total, "SECRET CLOAKING")
-        lines.append(f"  {_w('Prevents real secrets from reaching model context, JSONL transcripts,', DIM)}")
-        lines.append(f"  {_w('or upstream API requests. See prismor/runtime/cloaking/README.md.', DIM)}")
+        lines.append(f"  {_w('Keeps real secrets out of model context, session logs and outbound', DIM)}")
+        lines.append(f"  {_w('API requests — the agent sees @@SECRET:name@@ instead.', DIM)}")
         lines.append("")
         for i, (name, desc) in enumerate(opts):
             arrow = _w("▸ ", CYAN) if i == sel else "  "
@@ -798,10 +804,8 @@ def _step_unlock(current: bool = False, step: int = 6, total: int = 6):
 
     while True:
         lines = _header_lines(step, total, "AGENT SELF-EDIT")
-        lines.append(f"  {_w('Prismor blocks the agent from editing its own policy.', DIM)}")
-        lines.append(f"  {_w('A password lets you hand it that ability for a few minutes:', DIM)}")
-        lines.append(f"  {_w('run `prismor unlock`, and the agent can fix a rule that is', DIM)}")
-        lines.append(f"  {_w('getting in the way. You can always set one up later.', DIM)}")
+        lines.append(f"  {_w('The agent cannot edit its own policy. A password lends it that for', DIM)}")
+        lines.append(f"  {_w('a few minutes via `prismor unlock`. You can set one up any time.', DIM)}")
         lines.append("")
         for i, (name, desc) in enumerate(opts):
             arrow = _w("▸ ", CYAN) if i == sel else "  "
@@ -852,6 +856,26 @@ def _prompt_unlock_password() -> bool:
     return False
 
 
+def _wrap_value(value: str, width: int) -> List[str]:
+    """Wrap a summary value to `width`, breaking on ", " then spaces."""
+    text = str(value or "")
+    if len(text) <= width:
+        return [text]
+    lines: List[str] = []
+    rest = text
+    while len(rest) > width:
+        window = rest[:width + 1]
+        cut = window.rfind(", ")
+        cut = cut + 1 if cut > 0 else window.rfind(" ")
+        if cut <= 0:
+            cut = width
+        lines.append(rest[:cut].rstrip())
+        rest = rest[cut:].lstrip()
+    if rest:
+        lines.append(rest)
+    return lines
+
+
 # ── Confirm ──────────────────────────────────────────────────────────────────
 
 def _step_confirm(target: Path, mode: str, rules: List[dict], agents: List[str], cloak: bool = False, scope: str = "project", unlock_pw: bool = False, mirror_agents: Optional[List[str]] = None, gov_mode: Optional[str] = None) -> bool:
@@ -862,7 +886,12 @@ def _step_confirm(target: Path, mode: str, rules: List[dict], agents: List[str],
     n_rec_on = sum(1 for r in rules if r.get("recommended") and r["on"])
     ags  = ", ".join(agents)
     mirror_agents = mirror_agents or []
-    W = 48
+    # Wide enough for the longest value we are about to print, and never wider
+    # than the terminal. A fixed 48 meant a ten-agent list ran straight through
+    # the right border, because the padding below floors at zero.
+    W = max(48, min(_term_width() - 6, max([len(ags), len(disp)], default=0) + 18))
+    KEY_W = 14
+    VAL_W = W - KEY_W - 2
 
     def bdr(l, fill, r):
         return _w(f"  {l}{fill * W}{r}", DIM)
@@ -873,14 +902,26 @@ def _step_confirm(target: Path, mode: str, rules: List[dict], agents: List[str],
         return _w("  │", DIM) + " " + content + p + " " + _w("│", DIM)
 
     def kv(k: str, v: str, vc: str = WHT) -> str:
-        return f"{_pad(_w(k, DIM), 14)}{_w(v, vc)}"
+        return f"{_pad(_w(k, DIM), KEY_W)}{_w(v, vc)}"
+
+    def kv_rows(k: str, v: str, vc: str = WHT) -> List[str]:
+        """A key and a value that may not fit on one line, as box rows.
+
+        Wraps on commas and spaces so a long agent list continues under itself
+        instead of escaping the box.
+        """
+        chunks = _wrap_value(v, VAL_W)
+        out = [row(kv(k, chunks[0] if chunks else "", vc))]
+        for extra in chunks[1:]:
+            out.append(row(f"{' ' * KEY_W}{_w(extra, vc)}"))
+        return out
 
     while True:
         lines = _header_lines()
         lines.append(bdr("╭", "─", "╮"))
         lines.append(row(_w("READY TO INSTALL", BOLD)))
         lines.append(row())
-        lines.append(row(kv("Project", disp[:30])))
+        lines.extend(kv_rows("Project", disp))
         lines.append(row(kv("Mode", mode, GRN if mode == "enforce" else YEL)))
         if mode == "enforce" and gov_mode not in (None, "custom"):
             try:
@@ -900,10 +941,10 @@ def _step_confirm(target: Path, mode: str, rules: List[dict], agents: List[str],
                 lines.append(row(_w("nothing blocks — Prismor will only watch", YEL)))
         else:
             lines.append(row(kv("Rules", f"{n_on}/{len(rules)} enabled")))
-        lines.append(row(kv("Agents", ags)))
+        lines.extend(kv_rows("Agents", ags))
         lines.append(row(kv("Surface", "PreToolUse / PostToolUse hooks")))
         if mirror_agents:
-            lines.append(row(kv("MCP mirror", ", ".join(mirror_agents), YEL)))
+            lines.extend(kv_rows("MCP mirror", ", ".join(mirror_agents), YEL))
             lines.append(row(_w("built-ins served by Prismor; next session", DIM)))
         lines.append(row(kv("Cloak", "yes  (secret prevention)" if cloak else "no",
                             GRN if cloak else DIM)))

--- a/tests/test_setup_wizard_layout.py
+++ b/tests/test_setup_wizard_layout.py
@@ -1,0 +1,76 @@
+"""The setup wizard's confirm box has to hold what it prints.
+
+The box was a fixed 48 columns and its row padding floors at zero, so a value
+wider than the box -- ten enrolled agents, comfortably -- printed straight
+through the right border.
+"""
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from prismor.runtime import setup_wizard as wizard  # noqa: E402
+
+AGENTS = ["claude", "cursor", "windsurf", "openclaw", "codex", "grok", "kiro",
+          "openhands", "qwen", "goose"]
+
+
+def _plain(line: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", line)
+
+
+def _confirm_lines(width: int):
+    captured = []
+    original = (wizard._render, wizard._read_key, wizard._term_width)
+    wizard._render = lambda lines: captured.append(list(lines))
+    wizard._read_key = lambda: "q"
+    wizard._term_width = lambda: width
+    try:
+        wizard._step_confirm(Path.home() / "workspace", "observe",
+                             [{"on": True, "recommended": True}], AGENTS,
+                             cloak=True, scope="project")
+    except SystemExit:
+        pass
+    finally:
+        wizard._render, wizard._read_key, wizard._term_width = original
+    return [_plain(l) for l in captured[0]]
+
+
+class TestConfirmBox(unittest.TestCase):
+    def test_every_box_line_is_the_same_width(self):
+        for width in (64, 80, 100, 140):
+            lines = [l for l in _confirm_lines(width)
+                     if l.lstrip().startswith(("│", "╭", "╰"))]
+            widths = {len(l) for l in lines}
+            self.assertEqual(len(widths), 1,
+                             f"ragged box at term width {width}: {sorted(widths)}")
+
+    def test_the_box_fits_the_terminal(self):
+        for width in (64, 80, 100):
+            for line in _confirm_lines(width):
+                self.assertLessEqual(len(line), width, f"line wider than {width}: {line!r}")
+
+    def test_a_long_agent_list_wraps_rather_than_truncates(self):
+        body = " ".join(_confirm_lines(64))
+        for agent in AGENTS:
+            self.assertIn(agent, body, f"{agent} vanished from the summary")
+
+
+class TestWrapValue(unittest.TestCase):
+    def test_breaks_on_commas_first(self):
+        self.assertEqual(wizard._wrap_value("alpha, beta, gamma", 12), ["alpha, beta,", "gamma"])
+
+    def test_short_value_is_left_alone(self):
+        self.assertEqual(wizard._wrap_value("observe", 20), ["observe"])
+
+    def test_an_unbreakable_value_is_still_cut_to_width(self):
+        out = wizard._wrap_value("x" * 30, 10)
+        self.assertTrue(all(len(chunk) <= 10 for chunk in out), out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Overflow.** The confirm box was a fixed 48 columns and its row padding floors at zero, so any longer value printed straight through the right border and broke the frame — a ten-agent list does it comfortably. The box now sizes to its contents within the terminal, and a value that still does not fit wraps under itself on commas.

```
before   │ Agents        claude, cursor, windsurf, openclaw, codex, grok, kiro, openhands, qwen, goose |
after    │ Agents        claude, cursor, windsurf, openclaw, codex, │
         │               grok, kiro, openhands, qwen, goose         │
```

**Mode list.** Each option is a name, a sentence and two bars, printed with nothing between them, so four options read as one paragraph. Options are separated now, and the bars align under the description instead of sitting three columns to its left.

**Less prose.** The self-edit step used four lines for a two-option question; two now. The cloaking step pointed at a README inside our own source tree — nothing the reader can act on — and instead says what the agent actually sees in place of a secret.

Tested: the box is the same width on every line at 64/80/100/140 columns, never wider than the terminal, and no agent silently vanishes from the summary.