### PR TITLE
fix(mcp): screen tool arguments as egress destinations (#307)

### DIFF
--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -1776,6 +1776,11 @@ rules:
   # Precision comes from requiring a destination-shaped argument *whose
   # value starts with* the metadata host: descriptive prose that merely
   # mentions 169.254.169.254 does not match.
+  #
+  # One pattern per host, like cloud-metadata-ssrf above, rather than one
+  # alternation over all of them — `disable_patterns` drops a whole pattern
+  # string, so folding the hosts together would leave an AWS-only shop no
+  # way to switch off the GCP host from the console.
   - id: mcp-arg-metadata-endpoint
     severity: CRITICAL
     category: reconnaissance
@@ -1783,7 +1788,14 @@ rules:
     event_types: [mcp]
     fields: [mcp_args]
     patterns:
-      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?(?:169\.254\.169\.254|metadata\.google\.internal|169\.254\.170\.2|2852039166|0xa9fe[:\-]?a9fe|0251\.0376\.0251\.0376|::ffff:a9fe:a9fe|::ffff:169\.254\.169\.254)(?:[/:?#\]"\\]|$)'
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?169\.254\.169\.254(?:[/:?#\]"\\]|$)'
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?metadata\.google\.internal(?:[/:?#\]"\\]|$)'
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?169\.254\.170\.2(?:[/:?#\]"\\]|$)'  # ECS/EKS task credential relay
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?2852039166(?:[/:?#\]"\\]|$)'  # decimal encoding
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?0xa9fe[:\-]?a9fe(?:[/:?#\]"\\]|$)'  # hex encoding
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?0251\.0376\.0251\.0376(?:[/:?#\]"\\]|$)'  # octal octet encoding
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?::ffff:a9fe:a9fe(?:[/:?#\]"\\]|$)'  # IPv6-mapped (short hex)
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?::ffff:169\.254\.169\.254(?:[/:?#\]"\\]|$)'  # IPv6-mapped (dotted decimal)
     action: block
 
   # ── HIGH: PII in agent context ────────────────────────────────────

--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -1757,26 +1757,33 @@ rules:
       - '169\.254\.169\.254'
       - 'metadata\.google\.internal'
       - '169\.254\.170\.2'
-      - '2130706433'                       # 169.254.169.254 as decimal integer
+      - '2130706433'                       # 127.0.0.1 as decimal integer
+      - '2852039166'                       # 169.254.169.254 as decimal integer
       - '0xa9fe[:\-]?a9fe'                 # hex encoding
       - '0251\.0376\.0251\.0376'           # octal octet encoding
       - '::ffff:a9fe:a9fe'                 # IPv6-mapped (short hex)
       - '::ffff:169\.254\.169\.254'        # IPv6-mapped (dotted decimal)
     action: block
 
-  # ── CRITICAL: Cloud metadata endpoint in remote MCP call arguments ───
-  # Remote MCP calls use `url` for the server endpoint and serialize their
-  # tool arguments in `outbound_payload`. Restrict this to a URL-valued
-  # argument so descriptive text that happens to mention an IMDS address is
-  # not treated as an egress destination.
+  # ── CRITICAL: Cloud metadata endpoint in MCP call arguments ─────────
+  # cloud-metadata-ssrf screens `url`, which on an MCP call is the *server*
+  # endpoint — an allowed server can still be asked to fetch IMDS for you.
+  # The destination lives in the call arguments, so match those instead:
+  # `mcp_args` is the serialized pre-call arguments whatever the transport
+  # (remote servers put them in outbound_payload, local stdio in response),
+  # and is empty post-call, so this never scans tool output.
+  #
+  # Precision comes from requiring a destination-shaped argument *whose
+  # value starts with* the metadata host: descriptive prose that merely
+  # mentions 169.254.169.254 does not match.
   - id: mcp-arg-metadata-endpoint
     severity: CRITICAL
     category: reconnaissance
     title: Blocks MCP tool arguments targeting cloud instance metadata endpoints
     event_types: [mcp]
-    fields: [outbound_payload]
+    fields: [mcp_args]
     patterns:
-      - '"(?:url|uri|endpoint)"\s*:\s*"https?://(?:169\.254\.169\.254|metadata\.google\.internal|169\.254\.170\.2|2130706433|0xa9fe[:\-]?a9fe|0251\.0376\.0251\.0376|::ffff:a9fe:a9fe|::ffff:169\.254\.169\.254)(?:[/:?\\]|$)'
+      - '"[a-z_]*(?:url|uri|endpoint|target|host|hostname|address|addr|link|href|server|origin|domain)"\s*:\s*"(?:[a-z][a-z0-9+.\-]*://)?(?:[^"@/]*@)?\[?(?:169\.254\.169\.254|metadata\.google\.internal|169\.254\.170\.2|2852039166|0xa9fe[:\-]?a9fe|0251\.0376\.0251\.0376|::ffff:a9fe:a9fe|::ffff:169\.254\.169\.254)(?:[/:?#\]"\\]|$)'
     action: block
 
   # ── HIGH: PII in agent context ────────────────────────────────────

--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -1764,6 +1764,21 @@ rules:
       - '::ffff:169\.254\.169\.254'        # IPv6-mapped (dotted decimal)
     action: block
 
+  # ── CRITICAL: Cloud metadata endpoint in remote MCP call arguments ───
+  # Remote MCP calls use `url` for the server endpoint and serialize their
+  # tool arguments in `outbound_payload`. Restrict this to a URL-valued
+  # argument so descriptive text that happens to mention an IMDS address is
+  # not treated as an egress destination.
+  - id: mcp-arg-metadata-endpoint
+    severity: CRITICAL
+    category: reconnaissance
+    title: Blocks MCP tool arguments targeting cloud instance metadata endpoints
+    event_types: [mcp]
+    fields: [outbound_payload]
+    patterns:
+      - '"(?:url|uri|endpoint)"\s*:\s*"https?://(?:169\.254\.169\.254|metadata\.google\.internal|169\.254\.170\.2|2130706433|0xa9fe[:\-]?a9fe|0251\.0376\.0251\.0376|::ffff:a9fe:a9fe|::ffff:169\.254\.169\.254)(?:[/:?\\]|$)'
+    action: block
+
   # ── HIGH: PII in agent context ────────────────────────────────────
   # Detects SSNs, formatted credit card numbers, and US phone numbers
   # appearing in tool outputs, user prompts, or shell commands. Agents

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -305,6 +305,26 @@ def test_remote_upstream_builds_network_event(tmp_path, monkeypatch):
     assert json.loads(pre["outbound_payload"]) == {"q": "hi"}
 
 
+def test_remote_metadata_argument_is_blocked_before_forwarding(tmp_path, monkeypatch):
+    """The MCP server may be allowed while its fetch destination is denied."""
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path / "home"))
+    remote = FakeUpstream(UpstreamSpec(name="db", url="https://db.example.com/mcp"))
+    gateway, sent = make_gateway(tmp_path, monkeypatch, [remote])
+    list_tools(gateway, sent)
+
+    gateway._handle_tools_call_safe("C-metadata", {
+        "name": "db__echo",
+        "arguments": {
+            "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        },
+    })
+
+    result = sent[-1]["result"]
+    assert result["isError"] is True
+    assert "mcp-arg-metadata-endpoint" in result["content"][0]["text"]
+    assert not any(method == "tools/call" for method, _ in remote.requests)
+
+
 def test_list_changed_invalidates_routes_and_reemits(tmp_path, monkeypatch):
     a = stub("a")
     gateway, sent = make_gateway(tmp_path, monkeypatch, [a])

--- a/tests/test_mcp_guardrails.py
+++ b/tests/test_mcp_guardrails.py
@@ -210,16 +210,49 @@ class McpArgsField(unittest.TestCase):
 
 # ── Default policy: MCP argument egress destinations ───────────────────────
 
+# (label, arguments) pairs that all name the same forbidden destination in a
+# destination-shaped argument. Every one must block on both transports.
+_METADATA_ARGS = [
+    ("aws imds path", {"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}),
+    ("no trailing slash", {"url": "http://169.254.169.254"}),
+    ("no scheme", {"url": "169.254.169.254/latest/meta-data/"}),
+    ("google metadata", {"url": "http://metadata.google.internal/computeMetadata/v1/"}),
+    ("google bare host", {"url": "http://metadata.google.internal"}),
+    ("ecs credential relay", {"url": "http://169.254.170.2/v2/credentials/"}),
+    ("userinfo prefix", {"url": "http://example.com@169.254.169.254/latest/"}),
+    ("ipv6-mapped in brackets", {"url": "http://[::ffff:169.254.169.254]/latest/"}),
+    ("hex-encoded host", {"url": "http://0xa9fea9fe/latest/"}),
+    ("decimal-encoded host", {"url": "http://2852039166/latest/"}),
+    ("uppercase scheme", {"url": "HTTP://169.254.169.254/latest/"}),
+    ("argument named base_url", {"base_url": "http://169.254.169.254/latest/"}),
+    ("argument named target", {"target": "http://169.254.169.254/latest/"}),
+    ("host and path split apart", {"host": "169.254.169.254", "path": "/latest/meta-data/"}),
+    ("nested request object", {"request": {"url": "http://169.254.169.254/latest/"}}),
+]
+
+_BENIGN_ARGS = [
+    ("plain https destination", {"url": "https://example.com"}),
+    ("api destination", {"url": "https://api.github.com/repos/o/r"}),
+    ("prose mentioning imds", {"message": "The server returned 169.254.169.254"}),
+    ("question about imds", {"query": "what is 169.254.169.254 used for"}),
+    ("imds inside a longer url path", {"url": "https://docs.example.com/169.254.169.254"}),
+]
+
+
 class McpArgumentEgress(unittest.TestCase):
-    """Remote MCP destinations are screened in arguments, not server URL."""
+    """An allowed MCP server can still be asked to fetch a denied destination.
+
+    The destination lives in the call arguments, not in the server `url`, and
+    it has to be screened on both transports: a remote server serializes its
+    arguments into ``outbound_payload``, a local stdio server into ``response``.
+    """
 
     def setUp(self):
         self.ws = Path(tempfile.mkdtemp(prefix="prismor-mcp-egress-ws-"))
 
-    def _decide(self, arguments: dict):
+    def _decide(self, event: dict):
         return evaluate_tool_call(
-            event=_remote_mcp_event(
-                "mcp__db__fetch", "https://db.example.com/mcp", arguments),
+            event=event,
             workspace=self.ws,
             agent="claude",
             mode="enforce",
@@ -228,23 +261,43 @@ class McpArgumentEgress(unittest.TestCase):
             register_agent=False,
         )
 
-    def test_metadata_url_argument_blocks_with_mcp_rule(self):
-        decision = self._decide({
-            "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
-        })
-        self.assertFalse(decision.allow)
-        self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
+    def _remote(self, args: dict):
+        return self._decide(_remote_mcp_event(
+            "mcp__db__fetch", "https://db.example.com/mcp", args))
 
-    def test_google_metadata_url_argument_blocks_with_mcp_rule(self):
-        decision = self._decide({"url": "http://metadata.google.internal/computeMetadata/v1/"})
-        self.assertFalse(decision.allow)
-        self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
+    def _stdio(self, args: dict):
+        return self._decide(_stdio_mcp_event("mcp__db__fetch", args))
 
-    def test_benign_url_argument_is_allowed(self):
-        self.assertTrue(self._decide({"url": "https://example.com"}).allow)
+    def test_metadata_destination_blocks_over_remote_transport(self):
+        for label, args in _METADATA_ARGS:
+            with self.subTest(label):
+                decision = self._remote(args)
+                self.assertFalse(decision.allow)
+                self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
 
-    def test_descriptive_metadata_text_is_not_treated_as_destination(self):
-        self.assertTrue(self._decide({"message": "The server returned 169.254.169.254"}).allow)
+    def test_metadata_destination_blocks_over_stdio_transport(self):
+        # A local stdio MCP server with a fetch tool reaches IMDS just as well
+        # as a remote one; the rule must not depend on the transport.
+        for label, args in _METADATA_ARGS:
+            with self.subTest(label):
+                decision = self._stdio(args)
+                self.assertFalse(decision.allow)
+                self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
+
+    def test_benign_arguments_are_allowed_on_both_transports(self):
+        for label, args in _BENIGN_ARGS:
+            with self.subTest(label):
+                self.assertTrue(self._remote(args).allow)
+                self.assertTrue(self._stdio(args).allow)
+
+    def test_does_not_fire_on_stdio_tool_output(self):
+        # Post-call `response` is the tool's OUTPUT. An argument guardrail that
+        # matched it would silently start screening tool results too.
+        event = _stdio_mcp_event(
+            "mcp__db__fetch",
+            {"url": "http://169.254.169.254/latest/meta-data/"},
+            agent_event="PostToolUse")
+        self.assertTrue(self._decide(event).allow)
 
 
 # ── End-to-end: Claude hook dispatcher ─────────────────────────────────────

--- a/tests/test_mcp_guardrails.py
+++ b/tests/test_mcp_guardrails.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(_REPO))
 
 from prismor.runtime.policy_engine import PolicyEngine  # noqa: E402
 from prismor.runtime.hooks import should_block  # noqa: E402
+from prismor.runtime.runtime import evaluate_tool_call  # noqa: E402
 
 
 def _engine(policy_yaml: str) -> PolicyEngine:
@@ -205,6 +206,45 @@ class McpArgsField(unittest.TestCase):
                               agent_event="PostToolUse")
         f = self.eng.evaluate(ev, index=0, session_id="s1")
         self.assertEqual([x for x in f if x["ruleId"] == "mcp-args-guard"], [])
+
+
+# ── Default policy: MCP argument egress destinations ───────────────────────
+
+class McpArgumentEgress(unittest.TestCase):
+    """Remote MCP destinations are screened in arguments, not server URL."""
+
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp(prefix="prismor-mcp-egress-ws-"))
+
+    def _decide(self, arguments: dict):
+        return evaluate_tool_call(
+            event=_remote_mcp_event(
+                "mcp__db__fetch", "https://db.example.com/mcp", arguments),
+            workspace=self.ws,
+            agent="claude",
+            mode="enforce",
+            session_id="mcp-argument-egress",
+            persist=False,
+            register_agent=False,
+        )
+
+    def test_metadata_url_argument_blocks_with_mcp_rule(self):
+        decision = self._decide({
+            "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+        })
+        self.assertFalse(decision.allow)
+        self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
+
+    def test_google_metadata_url_argument_blocks_with_mcp_rule(self):
+        decision = self._decide({"url": "http://metadata.google.internal/computeMetadata/v1/"})
+        self.assertFalse(decision.allow)
+        self.assertEqual(decision.rule_id, "mcp-arg-metadata-endpoint")
+
+    def test_benign_url_argument_is_allowed(self):
+        self.assertTrue(self._decide({"url": "https://example.com"}).allow)
+
+    def test_descriptive_metadata_text_is_not_treated_as_destination(self):
+        self.assertTrue(self._decide({"message": "The server returned 169.254.169.254"}).allow)
 
 
 # ── End-to-end: Claude hook dispatcher ─────────────────────────────────────

--- a/tests/test_mcp_guardrails.py
+++ b/tests/test_mcp_guardrails.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import yaml
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parent.parent
@@ -29,6 +30,7 @@ sys.path.insert(0, str(_REPO))
 from prismor.runtime.policy_engine import PolicyEngine  # noqa: E402
 from prismor.runtime.hooks import should_block  # noqa: E402
 from prismor.runtime.runtime import evaluate_tool_call  # noqa: E402
+from prismor.runtime import policy_engine  # noqa: E402
 
 
 def _engine(policy_yaml: str) -> PolicyEngine:
@@ -289,6 +291,42 @@ class McpArgumentEgress(unittest.TestCase):
             with self.subTest(label):
                 self.assertTrue(self._remote(args).allow)
                 self.assertTrue(self._stdio(args).allow)
+
+    def test_console_overlay_can_retune_the_rule(self):
+        # Everything about this rule has to be reachable from the console: it
+        # ships as YAML with no Python behind it, so an admin can observe it,
+        # switch it off, add their own metadata host, or drop one host they
+        # do not run. One pattern per host is what makes that last one work --
+        # `disable_patterns` drops a whole pattern string, so a single
+        # alternation over all the hosts would be all-or-nothing.
+        rules = {r["id"]: r for r in yaml.safe_load(
+            (Path(policy_engine.__file__).parent / "default_policy.yaml").read_text()
+        )["rules"]}
+        gcp_pattern = next(p for p in rules["mcp-arg-metadata-endpoint"]["patterns"]
+                           if "google" in p)
+        aws = {"url": "http://169.254.169.254/latest/meta-data/"}
+        gcp = {"url": "http://metadata.google.internal/computeMetadata/v1/"}
+
+        def under(overlay: str, args: dict):
+            ws = Path(tempfile.mkdtemp(prefix="prismor-mcp-egress-ov-"))
+            (ws / ".prismor").mkdir()
+            (ws / ".prismor" / "policy.yaml").write_text(
+                'version: "1.0"\nsettings:\n  default_mode: enforce\n' + overlay)
+            return evaluate_tool_call(
+                event=_stdio_mcp_event("mcp__db__fetch", args), workspace=ws,
+                agent="claude", mode="enforce", session_id="mcp-egress-overlay",
+                persist=False, register_agent=False)
+
+        rule = "rules:\n  - id: mcp-arg-metadata-endpoint\n"
+        self.assertTrue(under(rule + "    mode: observe\n", aws).allow)
+        self.assertTrue(under(rule + "    enabled: false\n", aws).allow)
+        self.assertFalse(under(
+            rule + "    add_patterns:\n      - 'imds\\.corp\\.internal'\n",
+            {"url": "https://imds.corp.internal/creds"}).allow)
+
+        drop_gcp = rule + "    disable_patterns:\n      - " + json.dumps(gcp_pattern) + "\n"
+        self.assertTrue(under(drop_gcp, gcp).allow)
+        self.assertFalse(under(drop_gcp, aws).allow)   # the other hosts survive
 
     def test_does_not_fire_on_stdio_tool_output(self):
         # Post-call `response` is the tool's OUTPUT. An argument guardrail that


### PR DESCRIPTION
## Problem

Remote MCP calls are represented as `network` events where `url` identifies the MCP server, while MCP tool arguments are serialized in `outbound_payload`.

Existing egress rules evaluate the MCP server URL but do not screen destinations contained inside MCP tool arguments. As a result, a malicious MCP tool call targeting a cloud metadata endpoint such as `169.254.169.254` can be allowed even though the MCP server itself is an allowed destination.

Closes #307

## Prior art — what already exists

- [x] **I reused an existing mechanism.** Which one, and how:

Added the detection rule to `prismor/runtime/default_policy.yaml` and reused the existing policy field/pattern matching mechanism. No new Python detection logic or separate MCP policy engine was introduced.

The existing egress rules already contain cloud-metadata detection patterns for the normal `url` field. This change extends that protection to MCP tool argument destinations through `outbound_payload`.

**Tangential updates:** none.

## Solution — high level

- Added `mcp-arg-metadata-endpoint` to `prismor/runtime/default_policy.yaml`.
- The rule evaluates MCP tool arguments in `outbound_payload` for cloud metadata destinations.
- Matching is restricted to URL-valued `url`, `uri`, and `endpoint` arguments to avoid matching metadata IPs appearing only in descriptive text.
- Added regression coverage for malicious metadata destinations, benign URLs, false-positive cases, and gateway refusal before forwarding.

## Deep dive — how it works

Remote MCP requests contain two relevant destinations:

1. `url` — the MCP server endpoint.
2. `outbound_payload` — the serialized MCP tool arguments, which may contain a second destination.

Previously, existing egress rules evaluated the MCP server's `url` but did not screen a destination embedded in the MCP tool arguments.

The new `mcp-arg-metadata-endpoint` rule evaluates `outbound_payload` and only treats destination-like MCP arguments (`url`, `uri`, and `endpoint`) as egress destinations.

The rule covers the existing cloud-metadata encodings used by the policy, including AWS and Google metadata endpoints.

A key false-positive case is metadata text that is not actually a destination. The implementation therefore avoids broadly matching arbitrary serialized MCP text and limits matching to URL-valued destination arguments.

The change does not introduce separate gateway and ext-authz policy logic. Both continue to use the shared runtime policy evaluation path, keeping their verdicts consistent.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/default_policy.yaml` | Added the `mcp-arg-metadata-endpoint` blocking rule to screen cloud metadata destinations contained in MCP tool arguments. |
| `tests/test_mcp_guardrails.py` | Added regression coverage for AWS metadata, Google metadata, benign URLs, and metadata values appearing in non-destination text. |
| `tests/test_mcp_gateway.py` | Added gateway coverage verifying that a blocked MCP argument is refused before forwarding. |

## Testing

`python -m prismor.runtime.cli policy validate prismor/runtime/default_policy.yaml`

`python -m pytest tests/test_mcp_gateway.py tests/test_mcp_guardrails.py tests/test_egress.py -q`

**Results:**

- Policy validation: passed
- 125 passed, 2 skipped

- [ ] `bash scripts/run_security_tests.sh` passes
- [x] Added or updated tests covering the new behavior
- [x] If a policy rule changed: `prismor policy validate prismor/runtime/default_policy.yaml`
- [ ] If an integration changed: `bash scripts/verify_registry.sh`

The full `pytest -q` suite was also attempted but is currently blocked during collection by a pre-existing Windows cloaking-hook failure in `test_cloak_secret_guard.py`, where empty hook output results in a `JSONDecodeError`.

## Security checklist

- [x] No detection patterns hardcoded in Python — all rules live in YAML
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No guardrail weakened; if one was, it is called out and justified above

## Diff size

Lines changed: +75 / -0

Justification if large: The change is limited to one policy rule and focused regression coverage for the new MCP egress behavior. No unrelated runtime or policy changes are included.