### PR TITLE
Full session capture: ship every evaluated call under full_capture

### DIFF
--- a/prismor/runtime/enterprise/telemetry.py
+++ b/prismor/runtime/enterprise/telemetry.py
@@ -82,6 +82,8 @@ def _verdict(finding: Dict[str, Any]) -> str:
         return "blocked"
     if action in ("warn", "warned"):
         return "warned"
+    if action in ("allow", "allowed"):
+        return "allowed"
     return "observed"
 
 

--- a/prismor/runtime/runtime.py
+++ b/prismor/runtime/runtime.py
@@ -685,8 +685,27 @@ def _dispatch_telemetry(
 ) -> None:
     """Forward findings to configured sinks before the blocking decision so a
     SIEM sees every event, including blocked ones. Best-effort."""
-    if not (getattr(engine, "outputs", None) and findings):
+    if not getattr(engine, "outputs", None):
         return
+    if not findings:
+        # Full session capture: under the org's full_capture opt-in every
+        # evaluated call ships, not just the flagged ones, so the console's
+        # session trail is the whole trail. Redacted orgs keep the old
+        # findings-only behaviour (they already get per-session call counts
+        # from the heartbeat).
+        try:
+            from prismor.runtime.enterprise import remote_policy as _rp
+            if not _rp.current_full_capture():
+                return
+        except Exception:
+            return
+        findings = [{
+            "action": "allow",
+            "severity": "info",
+            "category": "audit",
+            "ruleId": "audit-allowed",
+            "title": f"{event.get('type') or 'call'} allowed",
+        }]
     try:
         from prismor.runtime.sinks import dispatch as sink_dispatch
         exm = getattr(engine, "active_exemption", None)

--- a/tests/test_full_session_capture.py
+++ b/tests/test_full_session_capture.py
@@ -1,0 +1,33 @@
+"""Under full_capture every evaluated call ships to the control-plane sink,
+not just the flagged ones; redacted orgs keep findings-only."""
+from unittest import mock
+
+from prismor.runtime import runtime as rt
+from prismor.runtime.enterprise import telemetry
+
+
+def _run(full_capture, findings, tmp_path):
+    engine = mock.Mock(outputs=[{"type": "prismor"}], workspace_managed=False, active_exemption=None)
+    sent = []
+    with mock.patch("prismor.runtime.enterprise.remote_policy.current_full_capture", return_value=full_capture), \
+         mock.patch("prismor.runtime.sinks.dispatch", side_effect=lambda f, *a, **k: sent.extend(f)):
+        rt._dispatch_telemetry(
+            engine=engine, findings=findings, event={"type": "shell", "command": "ls"},
+            workspace=tmp_path, agent="claude", mode="observe", session_id="s1",
+            subject=mock.Mock(as_dict=lambda: {}),
+        )
+    return sent
+
+
+def test_clean_call_ships_under_full_capture(tmp_path):
+    sent = _run(True, [], tmp_path)
+    assert len(sent) == 1 and telemetry._verdict(sent[0]) == "allowed"
+
+
+def test_clean_call_dropped_when_redacted(tmp_path):
+    assert _run(False, [], tmp_path) == []
+
+
+def test_findings_still_ship(tmp_path):
+    f = [{"action": "block", "title": "x"}]
+    assert _run(False, f, tmp_path) == f


### PR DESCRIPTION
Until now a cloud telemetry record was only built when a call produced a
finding, so the console's session trail was really the flagged-call trail:
clean tool calls and clean prompts never left the machine. Under the org's
full_capture opt-in the runtime now synthesizes an 'allowed' audit record
for a clean evaluation, carrying the scrubbed command/prompt/path in detail
like any other full-capture record. Redacted orgs are unchanged.
