### PR TITLE
perf(telemetry): batch control-plane uploads through the offline spool

### DIFF
--- a/prismor/runtime/enterprise/heartbeat.py
+++ b/prismor/runtime/enterprise/heartbeat.py
@@ -131,8 +131,7 @@ def maybe_flush(now: Optional[float] = None) -> bool:
             counters: Dict[str, Any] = data.get("counters", {}) or {}
             last = float(data.get("last_flush", 0))
             t = time.time() if now is None else now
-            total = sum(int(v.get("count", 0)) for v in counters.values())
-            if total <= 0 or (t - last) < FLUSH_INTERVAL:
+            if (t - last) < FLUSH_INTERVAL:
                 return False
             import uuid
             for key, slot in counters.items():
@@ -166,8 +165,9 @@ def maybe_flush(now: Optional[float] = None) -> bool:
     except (OSError, ValueError):
         return False
 
-    if not records:
-        return False
+    # Always call through, even with no counts of our own: upload_telemetry
+    # drains the telemetry spool, and findings now ride that spool instead of
+    # one POST each. This tick is what ships them.
     try:
         from prismor.runtime.sinks import upload_telemetry
         upload_telemetry(records)

--- a/prismor/runtime/sinks.py
+++ b/prismor/runtime/sinks.py
@@ -56,6 +56,10 @@ _FACILITIES = {
     "local0": 16, "local1": 17, "local2": 18, "local3": 19,
     "local4": 20, "local5": 21, "local6": 22, "local7": 23,
 }
+# Spool depth that forces a control-plane upload even between heartbeat
+# ticks, so a burst of findings is not held back by a quiet minute.
+FLUSH_BATCH = 50
+
 _SEVERITY_TO_SYSLOG = {
     "CRITICAL": 2,  # critical
     "HIGH": 3,      # error
@@ -435,10 +439,27 @@ def _dispatch_prismor(
             "[prismor] ignoring `url` on the prismor sink — telemetry is pinned to the "
             "enrolled control plane (a local url override cannot redirect the device key)\n"
         )
-    upload_telemetry(
-        records,
-        timeout=float(cfg.get("timeout_seconds", 6)),
-    )
+    # Batch by default. One POST per finding was affordable while findings were
+    # rare; under full_capture every evaluated call is a finding (runtime.py
+    # synthesizes `audit-allowed` for the unflagged ones), so that is now one
+    # request per tool call -- hundreds a minute from a busy agent, each one a
+    # serverless invocation and a connection against the pooler.
+    #
+    # The offline spool is already an outbox with at-least-once delivery, so
+    # observed/warned records ride it and ship on the next flush: the
+    # heartbeat's 60s tick, or right here once FLUSH_BATCH have piled up.
+    # Blocked verdicts still upload immediately -- an alert 60s late is not an
+    # alert. Row volume at the control plane is unchanged; this is about
+    # request amplification and keeping the hot path off the network.
+    from prismor.runtime.enterprise import telemetry_spool as _spool
+
+    timeout = float(cfg.get("timeout_seconds", 6))
+    if any(r.get("verdict") == "blocked" for r in records):
+        upload_telemetry(records, timeout=timeout)
+        return
+    _spool.append(records)
+    if _spool.pending_count() >= FLUSH_BATCH:
+        upload_telemetry([], timeout=timeout)
 
 
 def upload_telemetry(

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -64,8 +64,9 @@ def test_calls_accumulate_and_flush_debounces(monkeypatch):
     assert "agent_name" not in rec  # unnamed instance
     assert rec["redacted"] is True
 
-    # Counter reset — an immediate second flush has nothing to send.
-    assert heartbeat.maybe_flush(now=time.time() + 2 * heartbeat.FLUSH_INTERVAL + 2) is False
+    # Counter reset — the next tick still calls through (it is what drains the
+    # telemetry spool that findings now ride) but has no counts to send.
+    assert heartbeat.maybe_flush(now=time.time() + 2 * heartbeat.FLUSH_INTERVAL + 2) is True
     assert len(sent) == 1
 
 

--- a/tests/test_prismor_sink_batching.py
+++ b/tests/test_prismor_sink_batching.py
@@ -1,0 +1,93 @@
+"""The prismor control-plane sink batches through the offline spool.
+
+One POST per finding was affordable while findings were rare. Under the org's
+full_capture opt-in every evaluated call becomes a finding (runtime.py
+synthesizes `audit-allowed` for the unflagged ones), so that shape means one
+request per tool call. These tests pin the batching contract:
+
+  * observed/warned records are spooled, not posted;
+  * a blocked verdict still goes immediately;
+  * a full spool flushes without waiting for the heartbeat tick;
+  * the heartbeat tick drains the spool even with no counts of its own.
+"""
+import prismor.runtime.sinks as sinks
+import prismor.runtime.enterprise.identity as ident
+import prismor.runtime.enterprise.telemetry as telem
+import prismor.runtime.enterprise.telemetry_spool as spool
+
+
+def _setup(monkeypatch, tmp_path, verdict):
+    # A real identity file rather than a patched load_identity: tests/test_defer.py
+    # pops the identity module out of sys.modules, so modules that imported it by
+    # reference keep the old object and never observe an attribute patch.
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path))
+    ident.save_identity({
+        "device_id": "d", "org_id": "o", "user_id": "u",
+        "device_key": "prism_dev_x", "api_base": "http://127.0.0.1:1",
+    })
+    monkeypatch.setattr(telem, "build_record", lambda *a, **k: {"ts": None, "verdict": verdict})
+    monkeypatch.setattr(telem, "assert_redacted", lambda rec: None)
+    uploads = []
+    monkeypatch.setattr(sinks, "upload_telemetry", lambda recs, **kw: uploads.append(recs))
+    return uploads
+
+
+def _finding():
+    return {"severity": "HIGH", "category": "x", "ruleId": "r", "title": "t", "id": "s:f"}
+
+
+def test_observed_findings_spool_instead_of_posting(monkeypatch, tmp_path):
+    uploads = _setup(monkeypatch, tmp_path, "observed")
+
+    for _ in range(3):
+        sinks._dispatch_prismor({"type": "prismor"}, [_finding()], {"type": "shell"}, {})
+
+    assert uploads == [], "observed findings must not POST per event"
+    assert spool.pending_count() == 3
+
+
+def test_blocked_finding_uploads_immediately(monkeypatch, tmp_path):
+    """An alert 60s late is not an alert."""
+    uploads = _setup(monkeypatch, tmp_path, "blocked")
+
+    sinks._dispatch_prismor({"type": "prismor"}, [_finding()], {"type": "shell"}, {})
+
+    assert len(uploads) == 1 and len(uploads[0]) == 1
+    assert spool.pending_count() == 0
+
+
+def test_full_spool_forces_a_flush(monkeypatch, tmp_path):
+    uploads = _setup(monkeypatch, tmp_path, "observed")
+    monkeypatch.setattr(sinks, "FLUSH_BATCH", 5)
+
+    for _ in range(5):
+        sinks._dispatch_prismor({"type": "prismor"}, [_finding()], {"type": "shell"}, {})
+
+    # The last append crossed the threshold: one drain call carrying no new
+    # records of its own (upload_telemetry pulls the batch out of the spool).
+    assert uploads == [[]]
+
+
+def test_heartbeat_tick_drains_the_spool_with_no_counts(monkeypatch, tmp_path):
+    """The 60s tick is what ships spooled findings, so it must call through
+    even when the device recorded no tool calls in the window."""
+    import time
+    from prismor.runtime.enterprise import heartbeat
+
+    monkeypatch.setenv("PRISMOR_HOME", str(tmp_path))
+    ident.save_identity({
+        "device_id": "d", "org_id": "o", "user_id": "u",
+        "device_key": "prism_dev_x", "api_base": "http://127.0.0.1:1",
+    })
+    sent = []
+    monkeypatch.setattr("prismor.runtime.sinks.upload_telemetry",
+                        lambda recs, **kw: sent.append(recs))
+
+    heartbeat.record_call(agent="claude", session_id="s1")
+    # Drop the counter so the tick has nothing of its own to report.
+    import json
+    heartbeat._counter_path().write_text(
+        json.dumps({"v": 2, "last_flush": 0, "counters": {}}), encoding="utf-8")
+
+    assert heartbeat.maybe_flush(now=time.time() + heartbeat.FLUSH_INTERVAL + 1) is True
+    assert sent == [[]], "the tick must still call upload_telemetry to drain the spool"

--- a/tests/test_prismor_sink_url_pin.py
+++ b/tests/test_prismor_sink_url_pin.py
@@ -21,7 +21,9 @@ def test_prismor_sink_ignores_local_url(monkeypatch, capsys):
     })
     monkeypatch.setattr(ident, "revoked_backoff_active", lambda: False)
     # Keep record-building trivial and deterministic.
-    monkeypatch.setattr(telem, "build_record", lambda *a, **k: {"ok": True})
+    # verdict "blocked" keeps this on the immediate-upload path; observed
+    # findings are spooled and shipped by the heartbeat flush instead.
+    monkeypatch.setattr(telem, "build_record", lambda *a, **k: {"ok": True, "verdict": "blocked"})
     monkeypatch.setattr(telem, "assert_redacted", lambda rec: None)
 
     # Capture exactly how upload_telemetry is invoked.


### PR DESCRIPTION
## Problem

Under the org's `full_capture` opt-in, `_dispatch_telemetry` synthesizes an `audit-allowed` finding for every *unflagged* tool call so the console's session trail is the whole trail. `_dispatch_prismor` then calls `upload_telemetry` once per dispatch.

Those two together mean **one synchronous HTTPS POST per tool call**. A busy agent produces hundreds a minute — each one a serverless invocation and a connection against the pooler — and it sits on the hot path: the developer's tool call blocks on it, up to the 6s timeout, against a control plane that may be a cold Neon/RDS.

Before full session capture this was fine, because a finding was a rare event. It is no longer rare; it is every call.

## Prior art — what already exists

- [x] **I reused an existing mechanism.** `prismor/runtime/enterprise/telemetry_spool.py` is already a bounded, lock-guarded, privacy-bounded outbox with at-least-once delivery, written for offline periods. `upload_telemetry` already drains it into every batch. Batching needed the spool to be used on the success path too, not only on failure — no new queue, no daemon, no new file.

Also reused: `heartbeat.maybe_flush`, which already runs on every hook dispatch in a managed workspace and is already debounced to 60s. That is the flush timer; it did not need one of its own.

**Tangential updates:** `heartbeat.maybe_flush` no longer returns early when its counter is zero, because that tick is now what drains the spool. Two existing tests encode the old behaviour and are updated (below).

## Solution — high level

- Observed/warned records are **spooled instead of posted**, and ship on the next flush.
- Flush is the heartbeat's existing 60s tick, or immediately once `FLUSH_BATCH` (50) records have piled up, so a burst is not held back by a quiet minute.
- **Blocked verdicts still upload immediately** — an alert 60s late is not an alert.
- `maybe_flush` calls through to `upload_telemetry` even with no counts of its own, since that call is what drains the spool.

## Deep dive — how it works

`_dispatch_prismor` builds records exactly as before (redaction boundary, chain link, receipt signature all unchanged) and then branches on verdict:

- any `blocked` in the batch → `upload_telemetry(records)` as before, synchronously;
- otherwise → `_spool.append(records)`, then `upload_telemetry([])` only if `pending_count() >= FLUSH_BATCH`. Passing an empty list is deliberate: `upload_telemetry` drains the spool itself, so there is one code path that builds a batch.

The failure mode I had to handle is the **stranded spool**: if the only flush trigger were `FLUSH_BATCH`, a device that goes quiet at 49 records would hold them until its next burst. The heartbeat tick covers that, which is why the zero-counter early return had to go — otherwise a quiet minute produced no drain either.

Deliberately NOT done:

- **No aggregation.** Row count at the control plane is unchanged; ingest already does one `createMany` per request. This PR is about request amplification, not table growth. Rolling up `audit-allowed` volume is a separate change with a separate trade-off.
- **No background thread or daemon.** The device is a laptop that sleeps; poll-shaped flushing on a hook that is already running is the correct shape and adds no lifecycle to get wrong.
- **No change to the redaction boundary.** `assert_redacted` still runs before anything is spooled, and the spool has always held post-redaction records.

## Files changed

| File | Why it changed |
|------|----------------|
| `prismor/runtime/sinks.py` | `FLUSH_BATCH` constant; `_dispatch_prismor` spools observed/warned records and flushes on depth, uploading blocked verdicts immediately. |
| `prismor/runtime/enterprise/heartbeat.py` | `maybe_flush` drops the zero-counter early return and always calls `upload_telemetry`, because that tick is now the spool's drain trigger. |
| `tests/test_prismor_sink_batching.py` | New — pins the batching contract. |
| `tests/test_heartbeat.py` | An empty tick now calls through and returns True; assertion updated. |
| `tests/test_prismor_sink_url_pin.py` | Uses a `blocked` verdict to stay on the immediate-upload path. The url-pinning assertion itself is unchanged. |

## Testing

```
python -m pytest tests/test_prismor_sink_batching.py tests/test_heartbeat.py \
                 tests/test_prismor_sink_url_pin.py -q -p no:randomly
# 11 passed

# full suite, this branch vs a pristine origin/main worktree:
python -m pytest tests/ -q -p no:randomly --continue-on-collection-errors
# main:   20 failed, 2559 passed
# branch: 20 failed, 2563 passed   -> identical failure set, +4 new tests
```

The 20 failures are pre-existing on `main` (plus 4 modules that fail to collect without an installed adapter wheel). Failure sets were diffed, not counted.

New coverage in `tests/test_prismor_sink_batching.py`:

- observed findings spool rather than POST;
- a blocked finding uploads immediately and leaves the spool empty;
- crossing `FLUSH_BATCH` triggers exactly one drain call;
- a heartbeat tick with no counts still calls `upload_telemetry` to drain the spool.

- [x] Added or updated tests covering the new behavior
- [ ] `bash scripts/run_security_tests.sh` — not run; no detection rule changed
- [ ] Policy rule validation — n/a, no YAML changed
- [ ] `scripts/verify_registry.sh` — n/a, no integration changed

## Security checklist

- [x] No detection patterns hardcoded in Python — no rules changed
- [x] No real secrets, keys, or credentials in code, tests, fixtures, or docs
- [x] No real secret values printed, logged, or serialized
- [x] No guardrail weakened — records still pass `assert_redacted` before spooling, the spool has always held post-redaction data, and the device-key destination stays pinned to the enrolled `api_base`
- [x] Docs still accurate — no documented behaviour changed

One reviewer-visible trade-off, called out rather than buried: **observed/warned findings now reach the console up to ~60s later** (or on the next tool call if the agent goes quiet). Blocked verdicts are unaffected. Delivery is still at-least-once; the spool is bounded and age-capped as before.

## Diff size

Lines changed: +29 / −8 in runtime code, plus one new test file.
