### PR TITLE
fix(transcripts): import on Python 3.8/3.9

### DIFF
--- a/prismor/runtime/transcripts/adapters/__init__.py
+++ b/prismor/runtime/transcripts/adapters/__init__.py
@@ -1,5 +1,7 @@
 """Per-agent transcript adapters."""
 
+from __future__ import annotations
+
 from typing import Dict, List
 
 from prismor.runtime.transcripts.adapters.claude import ClaudeAdapter

--- a/tests/test_python_floor.py
+++ b/tests/test_python_floor.py
@@ -1,0 +1,50 @@
+"""Guard `requires-python = ">=3.8"` against annotations that need 3.9/3.10.
+
+CI runs on 3.12, where `List[str] | None` in a signature evaluates fine — so an
+import smoke test here would prove nothing. The floor only breaks on the user's
+interpreter, which is how `transcripts/adapters/__init__.py` shipped a PEP 604
+union that made five modules unimportable on 3.8/3.9.
+
+An annotation is evaluated at def time unless the module opts into PEP 563, so
+the rule is: use `X | Y` or `list[str]` in annotations only with
+`from __future__ import annotations`.
+"""
+
+import ast
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parent.parent / "prismor"
+NEW_GENERICS = {"list", "dict", "set", "tuple", "frozenset", "type"}
+
+
+def _too_new(node):
+    """Annotation subtrees that 3.8 cannot evaluate."""
+    for n in ast.walk(node):
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.BitOr):
+            yield "PEP 604 union"
+        elif isinstance(n, ast.Subscript) and getattr(n.value, "id", None) in NEW_GENERICS:
+            yield f"builtin generic {n.value.id}[...]"
+
+
+def test_annotations_evaluate_on_the_declared_floor():
+    offenders = []
+    for path in sorted(PKG.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        if any(
+            isinstance(n, ast.ImportFrom)
+            and n.module == "__future__"
+            and any(a.name == "annotations" for a in n.names)
+            for n in tree.body
+        ):
+            continue
+        for node in ast.walk(tree):
+            annotations = []
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                annotations = [a.annotation for a in node.args.args + node.args.kwonlyargs]
+                annotations += [node.returns]
+            elif isinstance(node, ast.AnnAssign):
+                annotations = [node.annotation]
+            for ann in filter(None, annotations):
+                for why in _too_new(ann):
+                    offenders.append(f"{path.relative_to(PKG.parent)}:{ann.lineno}: {why}")
+    assert not offenders, "add `from __future__ import annotations` to:\n" + "\n".join(offenders)


### PR DESCRIPTION
Follow-up to the review on #361, which noted five modules under `prismor/runtime/transcripts/` failing to import on 3.8/3.9.

It is one line, not five files. `get_adapters(names: List[str] | None = None)` in `transcripts/adapters/__init__.py` is a PEP 604 union in a runtime-evaluated signature; `corpus`, `coverage`, `driver` and `report` already opt into PEP 563 and only fail because they all import through it.

Verified on real 3.8.20 and 3.9.23 interpreters — a full import sweep of all 102 modules under `prismor/` goes from 6 failures to 1, the remaining one being the `tomllib` import #361 fixes.

Also adds `tests/test_python_floor.py`: an AST walk that fails when a module uses a PEP 604 union or a builtin generic in an annotation without `from __future__ import annotations`. CI runs on 3.12 where those evaluate fine, so an import smoke test proves nothing about the floor; this catches it at the syntax level regardless of the running interpreter. Confirmed it fails when the fix is reverted.

`tests/test_transcripts.py` 39 passed, `tests/test_coverage_report.py` 7 passed.