### PR TITLE
fix(policy): stop treating --force-with-lease as a force push

### DIFF
--- a/prismor/runtime/default_policy.yaml
+++ b/prismor/runtime/default_policy.yaml
@@ -1525,7 +1525,7 @@ rules:
     fields: [command]
     patterns:
       - '\bgit\s+remote\s+(set-url|add|rename)\b(?![^\n]*(?:github\.com|gitlab\.com|bitbucket\.org|dev\.azure\.com|git\.sr\.ht|codeberg\.org))'
-      - '\bgit\s+push\b[^\n]*--force'
+      - '\bgit\s+push\b[^\n]*--force(?!-with-lease|-if-includes)\b'
     action: warn
 
   # ── HIGH: Package manager registry poisoning ─────────────────────

--- a/tests/test_false_positive_fixes.py
+++ b/tests/test_false_positive_fixes.py
@@ -132,3 +132,26 @@ class TestScrubbableSecretHeuristic(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestForceWithLeaseIsNotForcePush(unittest.TestCase):
+    """--force-with-lease / --force-if-includes are the safe forms git itself
+    recommends; matching them as a force push blocked every rebase-and-push
+    on enforce installs."""
+
+    def setUp(self):
+        self.engine = PolicyEngine()
+
+    def _hijack(self, command):
+        event = {**PRE, "command": command}
+        findings = self.engine.evaluate(event, index=0, session_id="t")
+        return any(f.get("ruleId") == "git-remote-hijack" for f in findings)
+
+    def test_force_with_lease_is_not_flagged(self):
+        self.assertFalse(self._hijack(
+            "git reset --hard origin/main && git push --force-with-lease fork docs/x"))
+        self.assertFalse(self._hijack("git push --force-if-includes origin feature"))
+
+    def test_bare_force_still_flagged(self):
+        self.assertTrue(self._hijack("git push --force origin main"))
+        self.assertTrue(self._hijack("git push origin main --force"))


### PR DESCRIPTION
## Why
\`git-remote-hijack\` matched \`git push ... --force\` as a substring, so \`--force-with-lease\` and \`--force-if-includes\` (the safe forms) were flagged too. On an enrolled enforce install this blocked every rebase-and-push:

\`\`\`
Prismor blocked this action: [HIGH] Detects git remote URL changes to unknown hosts and force pushes (rule: git-remote-hijack)
git reset --hard origin/main && git push --force-with-lease fork docs/governance-modes-skill-refresh
\`\`\`

## Change
Pattern becomes \`\\bgit\\s+push\\b[^\\n]*--force(?!-with-lease|-if-includes)\\b\`. Bare \`--force\` (anywhere on the line) still matches.

## Tests
New \`TestForceWithLeaseIsNotForcePush\` in \`tests/test_false_positive_fixes.py\`; related suites (75 tests) green.

## Follow-up
prismor-web \`lib/default-policy-rules.ts\` is generated from this file; regenerate from origin/main after merge or the rules-sync CI guard goes red.