### PR TITLE
Prismor Dashboard - Session trail: background tasks, block reasons, and a readable dark mode

### DIFF
--- a/prismor/runtime/dashboard.html
+++ b/prismor/runtime/dashboard.html
@@ -78,6 +78,7 @@
     --chart-palette-5: #34d399;
     --chart-palette-6: #fb7185;
   }
+  :root { --danger-ink: #b91c1c; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
     font-family: var(--font-ui);
@@ -698,14 +699,14 @@
   .sess-act-btn {
     font-family: inherit; font-size: 10px; padding: 4px 10px;
     border: 1px solid var(--gray-200); border-radius: 4px;
-    background: #fff; color: var(--gray-700); cursor: pointer; white-space: nowrap;
+    background: var(--surface); color: var(--gray-700); cursor: pointer; white-space: nowrap;
   }
   .sess-act-btn:hover { background: var(--gray-50); }
   .sess-act-btn.pause { color: #b45309; border-color: #fde68a; }
   .sess-act-btn.pause:hover { background: #fffbeb; }
   .sess-act-btn.resume { color: #15803d; border-color: #bbf7d0; }
   .sess-act-btn.resume:hover { background: #f0fdf4; }
-  .sess-act-btn.clear { color: #b91c1c; border-color: #fecaca; }
+  .sess-act-btn.clear { color: var(--danger-ink); border-color: #fecaca; }
   .sess-act-btn.clear:hover { background: #fef2f2; }
   .sess-act-btn.expand { color: var(--gray-500); }
 
@@ -981,7 +982,7 @@
     color:var(--gray-500); background:var(--gray-50); border:1px solid var(--gray-200);
     border-radius:8px; padding:7px 12px; cursor:pointer; transition:all .12s;
   }
-  .view-back:hover { background:#fff; color:var(--gray-800); border-color:var(--gray-300); }
+  .view-back:hover { background:var(--surface); color:var(--gray-800); border-color:var(--gray-300); }
   .view-back .icon { width:13px; height:13px; }
   .crumbs { font-size:11px; color:var(--gray-400); display:flex; align-items:center; gap:6px; }
   .crumbs a { color:var(--gray-500); cursor:pointer; text-decoration:none; }
@@ -1057,7 +1058,7 @@
   .session-hero {
     display:flex; align-items:center; gap:14px; flex-wrap:wrap;
     padding:16px 20px; margin-bottom:16px;
-    border:1px solid var(--gray-200); border-radius:14px; background:#fff;
+    border:1px solid var(--gray-200); border-radius:14px; background:var(--surface);
   }
   .session-hero-main { flex:1; min-width:200px; }
   .session-hero-title { font-size:11px; text-transform:uppercase; letter-spacing:.6px; color:var(--gray-400); font-weight:700; }
@@ -1131,7 +1132,7 @@
   .tree-id { flex:none; font-size:10px; font-weight:600;
     color:var(--gray-500); background:var(--gray-100); border-radius:5px; padding:1px 6px; }
   .tree-text { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gray-700); }
-  .tree-leaf.blocked .tree-text { color:#b91c1c; font-weight:600; }
+  .tree-leaf.blocked .tree-text { color:var(--danger-ink); font-weight:600; }
   .tree-ts { margin-left:auto; flex:none; font-size:10px; color:var(--gray-400); font-variant-numeric:tabular-nums; }
   .flow-legend { display:flex; gap:12px; font-size:10px; color:var(--gray-500); }
   .flow-legend span { display:inline-flex; align-items:center; gap:4px; }
@@ -1303,6 +1304,15 @@
     background: rgba(59, 130, 246, 0.14);
     color: #93c5fd;
   }
+  /* The pale pink/amber hairlines these pills carry are drawn for a white
+     card; on the dark hero they glowed brighter than their own labels. */
+  html[data-theme="dark"] .sess-act-btn.clear { border-color: rgba(242,161,161,.32); }
+  html[data-theme="dark"] .sess-act-btn.pause { color:#fbbf24; border-color: rgba(251,191,36,.32); }
+  html[data-theme="dark"] .sess-act-btn.resume { color:#6ee7b7; border-color: rgba(110,231,183,.32); }
+  html[data-theme="dark"] .sess-act-btn.pause:hover,
+  html[data-theme="dark"] .sess-act-btn.clear:hover,
+  html[data-theme="dark"] .sess-act-btn.resume:hover { background: var(--surface-strong); }
+
   html[data-theme="dark"] .drawer-policy-card {
     background: rgba(244, 63, 94, 0.08);
     border-color: rgba(244, 63, 94, 0.3);
@@ -1440,6 +1450,7 @@
      ═══════════════════════════════════════════════════════════════════ */
   :root {
     --sidebar-w: 212px;
+    --topbar-h: 44px;
     --md-primary: #f2542d; --md-primary-d: #d6431f; --md-primary-soft: rgba(242,84,45,.12);
     --accent: #f2542d;
   }
@@ -1470,8 +1481,12 @@
   .tab-nav .tab-lock { margin-left: auto; }
 
   .topbar, .page, .prismor-cta { margin-left: var(--sidebar-w); }
+  /* The shell is the frame, so a page fills the width left of it rather than
+     centring a 1280px column against a fixed sidebar -- which read as a page
+     shoved off to one side on anything wider than a laptop. */
+  .page { max-width: none; }
   .topbar {
-    height: 44px; padding: 0 20px; background: var(--surface);
+    height: var(--topbar-h); padding: 0 20px; background: var(--surface);
     border-bottom: 1px solid var(--gray-200); box-shadow: none;
   }
   .topbar-left { gap: 8px; }
@@ -1510,6 +1525,20 @@
     color: var(--gray-400); border-left: 1px dashed var(--gray-300);
     height: 14px; padding-left: 7px; display: flex; align-items: center;
   }
+
+  /* The session page is a frame, not a document: the hero, the column heads
+     and the detail panel stay put and only the trail scrolls. A 600-event
+     session used to push its own controls -- and the panel showing the row you
+     just clicked -- off the top of the screen. */
+  #page-session.page {
+    display: flex; flex-direction: column; gap: 0;
+    height: calc(100vh - var(--topbar-h)); overflow: hidden;
+  }
+  #page-session .session-layout { flex: 1; min-height: 0; align-items: stretch; }
+  #page-session .session-layout > div { display: flex; flex-direction: column; min-height: 0; }
+  #page-session .flow-card { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  #page-session #sessFlowCanvas { flex: 1; min-height: 0; overflow-y: auto; }
+  #page-session .node-panel { position: static; min-height: 0; overflow-y: auto; }
 
   @media (max-width: 900px) {
     .tab-nav { width: 60px; }
@@ -1563,6 +1592,10 @@
 
     --app-bg: #0b0b0c; --surface: #151517; --surface-muted: #100f11; --surface-strong: #1e1e21;
     --overlay: rgba(0,0,0,0.72);
+
+    /* A blocked row is read, not just spotted: #b91c1c on near-black is the
+       colour of a link nobody can make out. Lighten the ink, keep the hue. */
+    --danger-ink: #f2a1a1;
 
     --accent: #f5f5f6;
     --md-primary: #f5f5f6; --md-primary-d: #ffffff; --md-primary-soft: rgba(255,255,255,0.10);
@@ -1670,6 +1703,12 @@
     background: var(--surface); border-color: var(--gray-200); color: var(--gray-700);
   }
 
+  .match-hit{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;line-height:1.5;
+    color:var(--gray-800);background:rgba(220,38,38,.09);border:1px solid rgba(220,38,38,.22);
+    border-radius:4px;padding:4px 6px;word-break:break-all;max-height:120px;overflow:auto}
+  .match-pattern{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;line-height:1.5;
+    color:var(--gray-600);background:var(--gray-100);border-radius:4px;padding:4px 6px;word-break:break-all}
+  mark.match-mark{background:rgba(220,38,38,.22);color:inherit;border-radius:2px;padding:0 1px}
 </style>
 </head>
 <body>
@@ -1682,6 +1721,7 @@
   <symbol id="kl-other" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12H5.01M12 12H12.01M19 12H19.01"/></symbol>
   <symbol id="kl-prompt" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 3 C20.6569 3 22 4.3431 22 6 C22 7.6569 20.6569 9 19 9 C17.3431 9 16 7.6569 16 6 C16 4.3431 17.3431 3 19 3 ZM12.668 3.0179 C12.4456 3.006 12.2228 3 12 3 C6.4772 3 2 6.5817 2 11 C2 12.9769 2.915 14.8839 4.5686 16.353 L5 21 L9.5808 18.7624 C10.3721 18.9202 11.1845 19 12 19 C16.8496 19 21.0003 16.2162 21.8466 12.3961" fill="none"/></symbol>
   <symbol id="kl-shell" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5L10.5571 10.6204C10.7899 10.8199 10.7899 11.1801 10.5571 11.3796L4 17M20 19H13"/></symbol>
+  <symbol id="kl-task" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 6v6l4 2M22 12c0 5.5228-4.4772 10-10 10S2 17.5228 2 12 6.4772 2 12 2s10 4.4772 10 10Z"/></symbol>
   <symbol id="kl-tools" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18.682 8.8536L20.2678 7.2678C20.4553 7.0802 20.7097 6.9749 20.9749 6.9749C21.4902 6.9749 21.9211 7.3664 21.9703 7.8794C21.9901 8.0857 22 8.2928 22 8.5C22 12.0899 19.0899 15 15.5 15C11.9101 15 9 12.0899 9 8.5C9 4.9101 11.9101 2 15.5 2C15.7072 2 15.9143 2.0099 16.1206 2.0297C16.6336 2.0789 17.0251 2.5098 17.0251 3.0251C17.0251 3.2903 16.9198 3.5447 16.7322 3.7322L15.1464 5.318C14.6776 5.7869 14.4142 6.4227 14.4142 7.0858C14.4142 8.4665 15.5335 9.5858 16.9142 9.5858C17.5773 9.5858 18.2131 9.3224 18.682 8.8536ZM15.3955 14.9992C15.3688 14.9987 15.342 14.9985 15.3152 14.9985C13.9891 14.9985 12.7173 15.5253 11.7797 16.463L7.1213 21.1213C6.5587 21.6839 5.7956 22 5 22C3.3431 22 2 20.6569 2 19C2 18.2044 2.3161 17.4413 2.8787 16.8787L7.537 12.2203C8.4747 11.2827 9.0015 10.0109 9.0015 8.6848C9.0015 8.658 9.0013 8.6312 9.0008 8.6045"/></symbol>
 </svg>
 
@@ -3864,15 +3904,29 @@ async function sessViewAction(action){
 // index, so clicking one still selects it in the detail panel.
 const LANE_LABEL = {
   prompt:'Prompts', tools:'Tool calls', files:'Files', shell:'Shell',
-  network:'Network', context:'Context', mcp:'MCP', other:'Other',
+  network:'Network', context:'Context', mcp:'MCP', task:'Background tasks', other:'Other',
 };
-const LANE_ORDER = ['prompt','context','tools','shell','files','network','mcp','other'];
+const LANE_ORDER = ['prompt','context','task','tools','shell','files','network','mcp','other'];
 
+// A task notification is the harness handing the same turn back to the agent
+// when out-of-band work finishes -- a backgrounded command, a Monitor, a
+// subagent. It arrives on the same hook a person's message does, so without
+// this it reads as the user having typed ten times mid-task.
+function taskNote(ev){
+  const t = (ev.artifacts||{}).user_message || (ev.artifacts||{}).prompt || '';
+  if (ev.type !== 'prompt' || t.indexOf('<task-notification>') === -1) return null;
+  const g = k => (t.match(new RegExp('<'+k+'>([\\s\\S]*?)</'+k+'>'))||[])[1] || '';
+  return { id: g('task-id'), summary: (g('summary') || g('output-file') || 'finished').trim(),
+           took: (ev.artifacts||{}).task_took || '' };
+}
 function eventLane(ev){
+  if (taskNote(ev)) return 'task';
   const lane = ev.lane || 'other';
   return LANE_LABEL[lane] ? lane : 'other';
 }
 function eventSummary(ev){
+  const note = taskNote(ev);
+  if (note) return note.id+(note.took ? ' ('+note.took+')' : '')+' - '+note.summary.replace(/\s+/g,' ').slice(0,200);
   const a = ev.artifacts || {};
   // For a prompt, the person's own message beats the flattened blob: a chat
   // API resends the whole conversation every round trip, so the blob grows by
@@ -3897,7 +3951,8 @@ function groupTrail(trail){
     // same prompt arriving twice is one turn: a hook registered in two
     // settings scopes runs twice per message, and three identical turns read
     // as the person having said it three times.
-    const text = ev.type === 'prompt' ? turnKeyOf(ev) : '';
+    const isTurnStart = ev.type === 'prompt' && !taskNote(ev);
+    const text = isTurnStart ? turnKeyOf(ev) : '';
     // Same message, or the same conversation one round trip later. Sessions
     // recorded before the prompt was stored in parts have only the flattened
     // blob, and a later round trip of one question is that blob with the
@@ -3905,7 +3960,7 @@ function groupTrail(trail){
     // catches on newer data, instead of leaving old sessions split.
     const repeat = !!(cur && text && (cur.promptText === text ||
       (cur.promptText.length > 40 && text.startsWith(cur.promptText))));
-    if (!cur || (ev.type === 'prompt' && !repeat)){
+    if (!cur || (isTurnStart && !repeat)){
       cur = { label:'Turn '+(turns.length+1), sub:'', promptText:text, lanes:new Map(), count:0 };
       turns.push(cur);
     }
@@ -3914,7 +3969,7 @@ function groupTrail(trail){
       if (text.length > cur.promptText.length) cur.promptText = text;
       return;  // already represented by the turn it opened
     }
-    if (ev.type === 'prompt' && !cur.sub) cur.sub = eventSummary(ev).slice(0,90);
+    if (isTurnStart && !cur.sub) cur.sub = eventSummary(ev).slice(0,90);
     const lane = eventLane(ev);
     if (!cur.lanes.has(lane)) cur.lanes.set(lane, []);
     cur.lanes.get(lane).push({ev, i});
@@ -3944,7 +3999,7 @@ function treeLeafEl(ev, idx){
   const text = eventSummary(ev);
   btn.innerHTML =
     '<span class="tree-dot '+(v==='block'?'block':(v==='warn'?'warn':''))+'"></span>'+
-    '<span class="tree-id">'+safe((ev.toolTag||ev.type||'ev').toString().slice(0,14))+'</span>'+
+    '<span class="tree-id">'+safe((taskNote(ev) ? 'task' : (ev.toolTag||ev.type||'ev')).toString().slice(0,14))+'</span>'+
     '<span class="tree-text" title="'+safeAttr(text)+'">'+safe(text)+'</span>'+
     '<span class="tree-ts">'+safe(ev.ts||'')+'</span>';
   return btn;
@@ -4027,7 +4082,9 @@ function renderNodePanel(ev){
             '<div><div style="font-size:11px;font-weight:600;color:var(--gray-800)">'+safe(policy.ruleId||policy.id||'runtime-policy')+'</div>'+
             (categoryLabel?'<div style="font-size:10px;color:var(--gray-500);margin-top:2px">'+safe(categoryLabel)+'</div>':'')+'</div></div>'+
           (policy.title?'<div class="drawer-rule-row"><span class="drawer-rule-label">Rule</span><div style="font-size:11px;color:var(--gray-700);line-height:1.4">'+safe(policy.title)+'</div></div>':'')+
-          (policy.evidence?'<div class="drawer-rule-row"><span class="drawer-rule-label">Reason</span><div style="font-size:11px;color:var(--gray-700);line-height:1.4">'+safe(policy.evidence)+'</div></div>':'')+
+          (policy.matched?'<div class="drawer-rule-row"><span class="drawer-rule-label">Matched</span><div class="match-hit">'+safe(policy.matched)+'</div></div>':'')+
+          (policy.pattern?'<div class="drawer-rule-row"><span class="drawer-rule-label">Pattern</span><div class="match-pattern">'+safe(policy.pattern)+'</div></div>':'')+
+          (policy.evidence?'<div class="drawer-rule-row"><span class="drawer-rule-label">Reason</span><div style="font-size:11px;color:var(--gray-700);line-height:1.4;word-break:break-word">'+highlightHit(policy.evidence, policy.matched)+'</div></div>':'')+
           '<div class="drawer-rule-row" style="margin-bottom:0"><span class="drawer-rule-label">Mode</span>'+
             '<span class="scoped-tag '+(policy.mode==='enforce'?'tag-deny':'tag-net')+'">'+safe(policy.mode||(v==='block'?'enforce':'observe'))+'</span>'+
             (policy.action?'<span class="scoped-tag '+(policy.action==='block'?'tag-deny':'tag-allow')+'">'+safe(policy.action)+'</span>':'')+
@@ -4050,8 +4107,19 @@ const ARTIFACT_FIELDS = [
   ['content','Content'], ['mcp_server','MCP server'], ['mcp_tool','MCP tool'],
   ['system','System prompt'], ['prompt','Full prompt evaluated'],
   ['model','Model'], ['provider','Provider'], ['surface','Surface'],
+  ['task_took','Took'], ['task_launched_by','Launched by'],
   ['subagent_type','Subagent'], ['cwd','Working dir'],
 ];
+// Which characters tripped the rule. The evidence is the whole command, so
+// without marking the hit a reader is left diffing a 400-character line
+// against a regex by eye.
+function highlightHit(text, hit){
+  const body = String(text||'');
+  if (!hit) return safe(body);
+  const at = body.indexOf(hit);
+  if (at < 0) return safe(body);
+  return safe(body.slice(0, at))+'<mark class="match-mark">'+safe(hit)+'</mark>'+safe(body.slice(at+hit.length));
+}
 function artifactsHtml(ev){
   const a = ev.artifacts || {};
   const rows = ARTIFACT_FIELDS.filter(([k])=>a[k]).map(([k,label])=>{

--- a/prismor/runtime/policy_engine.py
+++ b/prismor/runtime/policy_engine.py
@@ -1573,6 +1573,11 @@ class PolicyEngine:
                     "category": "secret_access",
                     "title": "Access to Prismor plaintext secret vault",
                     "evidence": _truncate(_hit_vault),
+                    # This guard is code, not a regex, so the "pattern" is the
+                    # vault path it looked for -- without it the dashboard can
+                    # only say some rule objected to a 400-character command.
+                    "pattern": (".prismor/secrets"
+                                if ".prismor/secrets" in _hit_vault else _vault),
                     "eventIndex": index,
                     "ruleId": "prismor-vault-access",
                     "action": "block",

--- a/prismor/runtime/store.py
+++ b/prismor/runtime/store.py
@@ -914,6 +914,10 @@ def persist_runtime_findings(
                     "action": finding.get("action"),
                     "mode": finding.get("mode"),
                     "remediation": finding.get("remediation"),
+                    # Which line of the rule fired. The engine works it out on
+                    # the match path already; dropping it here left every
+                    # blocked row saying only that some rule said no.
+                    "pattern": finding.get("pattern"),
                     "source": "runtime",
                 }),
             ))
@@ -3457,6 +3461,116 @@ def _merge_tool_phases(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return merged[:_TRAIL_ROWS]
 
 
+def _attach_matched_patterns(events: List[Dict[str, Any]], workspace: Optional[Path]) -> None:
+    """Quote the pattern that fired and the text it hit.
+
+    A finding names its rule but not the line inside it that matched, which
+    leaves a blocked row saying "policy said no" over a 400-character command.
+    Findings written from now on carry the pattern; older rows are re-derived
+    by re-running the rule over the event's own text -- the stored evidence is
+    truncated, so the full command is what the pattern is matched against.
+    Guards that are code rather than policy rules (the vault, egress and
+    semantic guards) have no pattern to quote and keep none.
+    """
+    blocked = [
+        item for item in events
+        if item.get("verdict") == "blocked" and not (item.get("policy") or {}).get("pattern")
+    ]
+    if not blocked:
+        return
+    try:
+        from prismor.runtime.policy_engine import PolicyEngine
+
+        engine = PolicyEngine(workspace=workspace) if workspace else PolicyEngine()
+        rules = {rule.id: rule for rule in engine.rules}
+    except Exception:
+        return
+    # A finding id carries its rule id with a session prefix and an event index
+    # around it ("<session>:dos-resource-exhaustion-136"), so a row whose
+    # enrichment lost the rule id is still attributable.
+    by_length = sorted(rules, key=len, reverse=True)
+
+    for item in blocked:
+        policy = item.get("policy") or {}
+        raw_id = policy.get("ruleId") or ""
+        rule = rules.get(raw_id) or next(
+            (rules[rid] for rid in by_length if rid and rid in raw_id), None
+        )
+        if not rule:
+            continue
+        artifacts = item.get("artifacts") or {}
+        text = (artifacts.get("command") or artifacts.get("path") or artifacts.get("url")
+                or artifacts.get("prompt") or policy.get("evidence") or "")
+        pattern = rule.matched_pattern(text) if text else None
+        if not pattern:
+            continue
+        policy["pattern"] = pattern
+        try:
+            hit = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+        except re.error:
+            hit = None
+        if hit:
+            policy["matched"] = hit.group(0)[:300]
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.1f}s" if seconds < 10 else f"{round(seconds)}s"
+    minutes = int(seconds // 60)
+    if minutes < 60:
+        return f"{minutes}m {round(seconds % 60)}s"
+    return f"{minutes // 60}h {minutes % 60}m"
+
+
+def _attach_task_durations(
+    events: List[Dict[str, Any]], tool_calls: Dict[str, Dict[str, str]]
+) -> None:
+    """Tie a background task's notification back to the call that started it.
+
+    The notification only says the work ended, and names its launch by an
+    opaque tool_use_id.  The call itself is already in the trail, so the join
+    gives both the duration and the command a reader can recognise.  A Monitor
+    arms without a PreToolUse hook -- Prismor never sees it start -- so it is
+    timed from its own first event and marked with a leading "+" rather than
+    being timed from someone else's start.
+    """
+    from datetime import datetime
+
+    def _parse(ts: Any) -> Any:
+        try:
+            return datetime.fromisoformat(str(ts))
+        except Exception:
+            return None
+
+    first_seen: Dict[str, Any] = {}
+    for item in reversed(events):  # oldest first, so a task's own first event lands first
+        artifacts = item.get("artifacts") or {}
+        text = artifacts.get("prompt") or artifacts.get("user_message") or ""
+        if "<task-notification>" not in text:
+            continue
+        ended = _parse(item.get("_tsRaw"))
+        task_id = (re.search(r"<task-id>(.*?)</task-id>", text) or [None, ""])[1].strip()
+        use_id = (re.search(r"<tool-use-id>(.*?)</tool-use-id>", text) or [None, ""])[1].strip()
+        call = tool_calls.get(use_id) if use_id else None
+        if call:
+            artifacts["task_launched_by"] = " - ".join(
+                part for part in (call.get("tool"), call.get("detail")) if part
+            )
+            started = _parse(call.get("ts"))
+            if started and ended and ended >= started:
+                artifacts["task_took"] = _format_duration((ended - started).total_seconds())
+        else:
+            artifacts["task_launched_by"] = (
+                "not recorded - a Monitor arms without a tool hook"
+                if not use_id else f"tool call {use_id} is outside this trail"
+            )
+            armed = first_seen.get(task_id)
+            if armed and ended and ended >= armed:
+                artifacts["task_took"] = "+" + _format_duration((ended - armed).total_seconds())
+        if task_id and ended and task_id not in first_seen:
+            first_seen[task_id] = ended
+
+
 def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any]:
     """Return scoped rules + recent blocked findings for a session."""
     from prismor.runtime.scoped_agent import load_scoped_rules, check_scoped_rules
@@ -3464,6 +3578,10 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
 
     recent_blocked: List[Dict[str, Any]] = []
     recent_events: List[Dict[str, Any]] = []
+    # The tool call behind each tool_use_id, so a background task's
+    # notification can say how long the work took and what actually launched
+    # it, instead of quoting an opaque id.
+    tool_calls: Dict[str, Dict[str, str]] = {}
     db = prismor_home() / "prismor.db"
     if db.exists():
         try:
@@ -3517,6 +3635,16 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                     raw = {}
                 meta = raw.get("metadata", {}) if isinstance(raw, dict) else {}
                 tool_tag = meta.get("tool_name") if isinstance(meta, dict) else ""
+                hook_payload = meta.get("raw") if isinstance(meta, dict) else None
+                if isinstance(hook_payload, dict) and hook_payload.get("tool_use_id"):
+                    # Rows arrive newest first, so the last write is the call itself.
+                    tool_calls[str(hook_payload["tool_use_id"])] = {
+                        "ts": row["ts"],
+                        "tool": tool_tag or hook_payload.get("tool_name") or "",
+                        "detail": " ".join(
+                            str(row["command_text"] or row["path_text"] or row["url_text"] or "").split()
+                        )[:300],
+                    }
                 finding_id = row["finding_id"]
                 severity = row["severity"]
                 category = row["category"]
@@ -3572,9 +3700,12 @@ def get_session_scoped_detail(workspace: Path, session_id: str) -> Dict[str, Any
                         "action": enrichment.get("action") or ("block" if verdict == "blocked" else ""),
                         "mode": enrichment.get("mode") or "",
                         "source": enrichment.get("source") or ("finding" if finding_id else ""),
+                        "pattern": enrichment.get("pattern") or "",
                     },
                 })
             recent_events = _merge_tool_phases(_drop_duplicate_events(recent_events))
+            _attach_task_durations(recent_events, tool_calls)
+            _attach_matched_patterns(recent_events, workspace)
             for item in recent_events:
                 item.pop("_tsRaw", None)
             block_keys = {

--- a/tests/test_task_durations.py
+++ b/tests/test_task_durations.py
@@ -1,0 +1,62 @@
+from prismor.runtime.store import _attach_task_durations
+
+
+def _note(task_id, tool_use_id, ts):
+    prompt = f"<task-notification>\n<task-id>{task_id}</task-id>\n"
+    if tool_use_id:
+        prompt += f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
+    prompt += "<summary>done</summary>\n</task-notification>"
+    return {"_tsRaw": ts, "artifacts": {"prompt": prompt}}
+
+
+CALLS = {"toolu_1": {"ts": "2026-09-10T16:18:03+00:00", "tool": "Bash", "detail": "aws s3 sync a b"}}
+
+
+def test_duration_and_launching_call_come_from_the_tool_use_id():
+    events = [_note("b1", "toolu_1", "2026-09-10T16:33:11+00:00")]
+    _attach_task_durations(events, CALLS)
+    artifacts = events[0]["artifacts"]
+    assert artifacts["task_took"] == "15m 8s"
+    assert artifacts["task_launched_by"] == "Bash - aws s3 sync a b"
+
+
+def test_a_monitor_is_timed_from_its_own_first_event():
+    # Newest first, the order the trail arrives in.
+    events = [_note("b2", "", "2026-09-10T16:40:00+00:00"),
+              _note("b2", "", "2026-09-10T16:33:00+00:00")]
+    _attach_task_durations(events, CALLS)
+    assert events[1]["artifacts"].get("task_took") is None  # nothing to measure from yet
+    assert events[0]["artifacts"]["task_took"] == "+7m 0s"
+    assert "Monitor" in events[0]["artifacts"]["task_launched_by"]
+
+
+def test_an_unseen_launch_is_named_not_guessed():
+    events = [_note("b3", "toolu_gone", "2026-09-10T16:33:11+00:00")]
+    _attach_task_durations(events, CALLS)
+    assert "task_took" not in events[0]["artifacts"]
+    assert "toolu_gone" in events[0]["artifacts"]["task_launched_by"]
+
+
+class _FakeRule:
+    id = "dos-resource-exhaustion"
+    raw_patterns = [r"yes\s*\|"]
+
+    def matched_pattern(self, value):
+        import re
+        return self.raw_patterns[0] if re.search(self.raw_patterns[0], value) else None
+
+
+def test_blocked_row_quotes_the_pattern_that_fired(monkeypatch):
+    from prismor.runtime import policy_engine, store
+
+    monkeypatch.setattr(policy_engine, "PolicyEngine",
+                        lambda **kw: type("E", (), {"rules": [_FakeRule()]})())
+    events = [{
+        "verdict": "blocked",
+        # The stored rule id keeps the session prefix and event index around it.
+        "policy": {"ruleId": "abc:dos-resource-exhaustion-136", "evidence": "truncated..."},
+        "artifacts": {"command": "aws ec2 describe-images | yes | head"},
+    }]
+    store._attach_matched_patterns(events, None)
+    assert events[0]["policy"]["pattern"] == r"yes\s*\|"
+    assert events[0]["policy"]["matched"] == "yes |"


### PR DESCRIPTION
The session flow page could not answer three questions a reader brings to it: what did this turn actually do, why was that row blocked, and — in dark mode — what does it say.

## Background tasks are not new turns

A `<task-notification>` arrives on the same hook a person's message does, so the trail opened a fresh **Turn** for each one. A single question that spawned nine background commands read as ten prompts. They now collapse into a **Background tasks** lane inside the turn that started them: a real session went from ~15 turns to 5.

Each row is timed. The notification says only that the work ended and names its launch by an opaque `tool_use_id`; the launching call is already in the trail, so joining the two gives the duration and a command a reader recognises:

```
BACKGROUND TASKS                                                12
  task  b71wj79zm (2.9s)    — "Run the S3 cross-account copy" completed (exit 0)
  task  buw85c7md (30m 36s) — "Copy all ECR images to target account" completed (exit 0)
  task  bekb5y5qc (+17m 37s)— Monitor event: "S3 bucket copy progress"
```

Clicking one shows `Took` and `Launched by: Bash - export AWS_PROFILE=… aws rds wait …`.

A Monitor arms without a `PreToolUse` hook — Prismor never sees it start — so it is timed from its own first event and marked with a leading `+` rather than borrowing another task's start. Where the launch is genuinely unavailable the panel says which case it is (`not recorded - a Monitor arms without a tool hook`, or `tool call toolu_… is outside this trail`) instead of guessing.

## A blocked row says which pattern fired

`PolicyEngine` already computes `matched_pattern` on every match; `store` dropped it when writing the finding, leaving the panel to say "policy said no" over a 400-character command. It is persisted now, and rows already in the database re-derive it by re-running the rule over the event's **full** text (stored evidence is truncated to 220 chars, which is usually why the pattern is not in it). The panel gains:

```
Matched   yes |            ← the text that tripped it
Pattern   yes\s*\|         ← the rule line that fired
Reason    …describe-images | «yes |» head…   ← hit marked inline
```

The vault guard is code rather than a regex, so it now reports the path it looked for (`.prismor/secrets`) as its pattern. The other code guards (egress, semantic, staged-execution, scoped-agent) have nothing to quote and keep nothing.

This immediately surfaced a false positive: two `dos-resource-exhaustion` blocks in the test session fired on `yes\s*\|` matching `| yes |` in an AWS polling loop, not a fork bomb.

## Layout and dark mode

- The session page is a frame, not a document: hero, card header and detail panel stay put; only the trail scrolls (`height: calc(100vh - var(--topbar-h))`).
- `.page` fills the width beside the sidebar instead of centring a 1280px column against it.
- `.session-hero`, `.sess-act-btn` and `.view-back:hover` were pinned to `#fff`, so the session card stayed white in dark mode and its near-white id text vanished. Blocked ink is a `--danger-ink` token that lightens to `#f2a1a1` on dark instead of `#b91c1c` on near-black.

## Testing

- `tests/test_task_durations.py` — duration + launching call from the `tool_use_id`, Monitor timed from its own first event, unseen launch named rather than guessed, and a blocked row quoting the pattern that fired.
- `tests/test_store_dashboard_queries.py tests/test_egress_dashboard_api.py tests/test_telemetry_chain.py tests/test_policy_engine.py tests/test_task_durations.py` → 200 passed, 11 subtests passed.
- Verified in the running dashboard against a real 96-event session in both themes.