### PR TITLE
examples: Streamlit chat over the Gemini proxy demo

### DIFF
--- a/examples/gemini-proxy-demo/README.md
+++ b/examples/gemini-proxy-demo/README.md
@@ -1,0 +1,37 @@
+# Gemini through `prismor proxy`
+
+Two demos of the same thing: `prismor proxy` on Google Gen AI traffic, with the
+SDK's own `base_url` as the only integration point.
+
+## `demo.py` — offline, no key
+
+```
+python examples/gemini-proxy-demo/demo.py
+```
+
+Runs a stub Gemini upstream, the proxy in enforce mode, and a client, in one
+process. No API key, no network, no `google-genai` install. Shows a benign
+`functionCall` released verbatim and a destructive one replaced before the
+client sees it, buffered and streaming.
+
+## `streamlit_app.py` — real API, real UI
+
+```
+pip install streamlit google-genai
+prismor proxy --mode enforce --port 7099 --workspace .
+PRISMOR_PROXY=http://127.0.0.1:7099 GEMINI_API_KEY=... streamlit run examples/gemini-proxy-demo/streamlit_app.py
+```
+
+A chat UI whose only Prismor-aware line is the `base_url` on the client. The
+prompt is screened and cloak-masked on the way out: paste a live credential
+into the chat and the model answers about a `@@SECRET:...@@` placeholder.
+
+`PRISMOR_PROXY` defaults to `http://127.0.0.1:7080`.
+
+## Ports
+
+The proxy defaults to 7080, and `demo.py` hardcodes it. A machine already
+running a proxy there (a long-lived one under a LaunchAgent, say) will end up
+with two listeners bound at once — the OS permits it, and requests land on
+whichever, under the wrong workspace and policy. Check with
+`lsof -nP -iTCP:7080 -sTCP:LISTEN` and pass `--port` if it is taken.

--- a/examples/gemini-proxy-demo/streamlit_app.py
+++ b/examples/gemini-proxy-demo/streamlit_app.py
@@ -1,0 +1,22 @@
+import os, streamlit as st
+from google import genai
+from google.genai import types
+
+client = genai.Client(
+    api_key=os.environ["GEMINI_API_KEY"],
+    http_options=types.HttpOptions(base_url=os.getenv("PRISMOR_PROXY", "http://127.0.0.1:7080")),
+)
+
+st.title("Gemini chat")
+if "chat" not in st.session_state:
+    st.session_state.chat = client.chats.create(model="gemini-3.6-flash")
+
+for m in st.session_state.chat.get_history():
+    if text := "".join(p.text or "" for p in m.parts):
+        st.chat_message("user" if m.role == "user" else "assistant").write(text)
+
+if prompt := st.chat_input("Ask something"):
+    st.chat_message("user").write(prompt)
+    st.chat_message("assistant").write_stream(
+        c.text for c in st.session_state.chat.send_message_stream(prompt) if c.text
+    )


### PR DESCRIPTION
`examples/gemini-proxy-demo/demo.py` (#388) shows the proxy governing Google Gen AI against a stub upstream, offline and keyless. This adds the other half: a real chat UI on the real API, where the only Prismor-aware line is the `base_url` on the client.

```python
client = genai.Client(
    api_key=os.environ["GEMINI_API_KEY"],
    http_options=types.HttpOptions(base_url=os.getenv("PRISMOR_PROXY", "http://127.0.0.1:7080")),
)
```

22 lines total, including the chat loop.

## Verified against prismor 1.50.0

| check | result |
|---|---|
| streams through the proxy in enforce mode | `PONG` |
| prompt screening reaches the wire | credential pasted into chat reached Gemini as `@@SECRET:...@@` |
| overhead vs direct call | 2.0-2.5s direct, 2.6-4.5s proxied (n=4) |

## Two things worth knowing

**Port 7080 collides.** It is both the proxy default and `demo.py`'s hardcoded port. A second listener binds *alongside* an existing one rather than failing, and requests then land on whichever, under the wrong workspace and policy. This cost real debugging time on a box already running a long-lived proxy under a LaunchAgent. The README says to check `lsof` and pass `--port`; making `demo.py`'s port overridable is a reasonable follow-up, left out here to keep the diff to new files.

**`gemini-2.5-flash` is retired** — the API returns 404 pointing new users at `gemini-3.6-flash`, which is what this uses.